### PR TITLE
Add AppKit recipes for Lakebase, Genie, and SQL Analytics

### DIFF
--- a/plugins/llms-txt.ts
+++ b/plugins/llms-txt.ts
@@ -185,7 +185,10 @@ export default function llmsTxtPlugin(): Plugin {
         "",
         `- [All Resources](${baseUrl}/resources): Browse all templates`,
         `- [Base App Template](${baseUrl}/resources/base-app-template): Databricks local bootstrap template for CLI, auth, app scaffolding, and agent skill setup`,
-        `- [AI Chat App Template](${baseUrl}/resources/ai-chat-app-template): Databricks local bootstrap plus a simple AI chat implementation using AI SDK and AI Elements`,
+        `- [AI Chat App Template](${baseUrl}/resources/ai-chat-app-template): Streaming AI chat powered by Databricks Model Serving (AI Gateway) with AI SDK and AI Elements`,
+        `- [Data App Template](${baseUrl}/resources/data-app-template): Bootstrap a Databricks app with Lakebase for persistent data storage, schema setup, and CRUD API routes`,
+        `- [Analytics Dashboard App Template](${baseUrl}/resources/analytics-dashboard-app-template): Interactive analytics dashboard backed by Lakebase with parameterized SQL queries and chart components`,
+        `- [AI Data Explorer Template](${baseUrl}/resources/ai-data-explorer-template): Full-stack data app with Lakebase persistence, AI chat via Model Serving, and Genie natural-language data exploration`,
         "",
       ];
 

--- a/src/components/resources/template-detail.tsx
+++ b/src/components/resources/template-detail.tsx
@@ -3,17 +3,16 @@ import Layout from "@theme/Layout";
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import type { Template } from "@/lib/recipes/recipes";
-import { recipes } from "@/lib/recipes/recipes";
 
 type TemplateDetailProps = {
   template: Template;
+  children: ReactNode;
 };
 
-export function TemplateDetail({ template }: TemplateDetailProps): ReactNode {
-  const templateRecipes = template.recipeIds
-    .map((id) => recipes.find((r) => r.id === id))
-    .filter((r): r is (typeof recipes)[number] => r !== undefined);
-
+export function TemplateDetail({
+  template,
+  children,
+}: TemplateDetailProps): ReactNode {
   return (
     <Layout title={template.name} description={template.description}>
       <main className="container px-4 py-16">
@@ -44,61 +43,7 @@ export function TemplateDetail({ template }: TemplateDetailProps): ReactNode {
             ))}
           </div>
 
-          <h2 className="mb-6 text-xl font-semibold text-black dark:text-white">
-            Steps
-          </h2>
-          <ol className="mb-12 list-none space-y-4 pl-0">
-            {template.steps.map((step, idx) => (
-              <li
-                key={step.id}
-                className="rounded-lg border border-black/10 bg-[#f7f6f4] p-4 dark:border-white/10 dark:bg-[#182a32]"
-              >
-                <div className="mb-1 flex items-baseline gap-3">
-                  <span className="shrink-0 text-sm font-semibold text-black/40 dark:text-white/40">
-                    {idx + 1}
-                  </span>
-                  <span className="font-medium text-black dark:text-white">
-                    {step.title}
-                  </span>
-                </div>
-                {step.details ? (
-                  <p className="m-0 mt-1 pl-7 text-sm text-black/60 dark:text-white/60">
-                    {step.details}
-                  </p>
-                ) : null}
-                {step.command ? (
-                  <pre className="mt-2 ml-7 overflow-x-auto rounded-md bg-black/5 px-3 py-2 text-sm dark:bg-white/5">
-                    <code>{step.command}</code>
-                  </pre>
-                ) : null}
-              </li>
-            ))}
-          </ol>
-
-          {templateRecipes.some((r) => r.references?.length) ? (
-            <>
-              <h2 className="mb-4 text-xl font-semibold text-black dark:text-white">
-                References
-              </h2>
-              <ul className="list-disc space-y-1 pl-5">
-                {templateRecipes.flatMap(
-                  (recipe) =>
-                    recipe.references?.map((ref) => (
-                      <li key={ref.href}>
-                        <a
-                          href={ref.href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-sm"
-                        >
-                          {ref.label}
-                        </a>
-                      </li>
-                    )) ?? [],
-                )}
-              </ul>
-            </>
-          ) : null}
+          <div className="prose-solution">{children}</div>
         </div>
       </main>
     </Layout>

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -102,16 +102,24 @@ export const recipes: Recipe[] = [
   },
   {
     id: "vercel-ai-chat-app",
-    name: "Vercel AI SDK + AI Elements Chat",
+    name: "AI Chat with Databricks Model Serving",
     description:
-      "Build a minimal streaming chat app using Vercel AI SDK and AI Elements patterns.",
-    tags: ["AI SDK", "AI Elements", "Chat"],
+      "Build a streaming chat app powered by Databricks AI Gateway (model serving). Uses Vercel AI SDK with an OpenAI-compatible provider pointed at your Databricks serving endpoint, plus AI Elements for the chat UI.",
+    tags: ["AI SDK", "AI Gateway", "Model Serving", "Chat"],
     prerequisites: ["databricks-local-bootstrap"],
     steps: [
       {
+        id: "list-serving-endpoints",
+        title: "Identify your model serving endpoint",
+        command:
+          "databricks serving-endpoints list --profile <PROFILE> -o json",
+        details:
+          "List available serving endpoints in your workspace. Pick the endpoint name you want to use for chat (e.g. a foundation model endpoint or a custom model endpoint). You can also check a specific endpoint with:\n\ndatabricks serving-endpoints get <endpoint-name> --profile <PROFILE>",
+      },
+      {
         id: "install-ai-sdk",
-        title: "Install AI SDK",
-        command: "bun add ai @ai-sdk/react",
+        title: "Install AI SDK and the OpenAI-compatible provider",
+        command: "bun add ai @ai-sdk/react @ai-sdk/openai-compatible",
       },
       {
         id: "install-ai-elements",
@@ -120,40 +128,54 @@ export const recipes: Recipe[] = [
       },
       {
         id: "set-provider-env",
-        title: "Configure AI provider environment variables",
+        title: "Configure Databricks environment variables",
+        command:
+          "echo 'DATABRICKS_HOST=https://<workspace>.cloud.databricks.com\\nDATABRICKS_TOKEN=<your-token>\\nDATABRICKS_SERVING_ENDPOINT=<endpoint-name>' >> .env",
         details:
-          "Set either VERCEL_OIDC_TOKEN or AI_GATEWAY_API_KEY (or provider-specific keys such as OPENAI_API_KEY).",
+          "DATABRICKS_HOST is your workspace URL. DATABRICKS_TOKEN is a personal access token or service principal token. DATABRICKS_SERVING_ENDPOINT is the name of the model serving endpoint you identified in step 1.",
+      },
+      {
+        id: "create-provider",
+        title: "Create the Databricks AI provider",
+        details:
+          'Create a provider module that connects AI SDK to your Databricks model serving endpoint using the OpenAI-compatible interface:\n\nimport { createOpenAICompatible } from "@ai-sdk/openai-compatible";\n\nconst databricks = createOpenAICompatible({\n  name: "databricks",\n  baseURL: `${process.env.DATABRICKS_HOST}/serving-endpoints`,\n  headers: {\n    Authorization: `Bearer ${process.env.DATABRICKS_TOKEN}`,\n  },\n});\n\nexport const chatModel = databricks.chatModel(\n  process.env.DATABRICKS_SERVING_ENDPOINT!\n);',
       },
       {
         id: "create-chat-route",
         title: "Create a streaming chat API route",
         details:
-          "Implement /api/chat with streamText and return toUIMessageStreamResponse().",
+          'Implement a /api/chat route that streams responses from your Databricks model serving endpoint:\n\nimport { streamText } from "ai";\nimport { chatModel } from "./provider";\n\napp.post("/api/chat", async (req, res) => {\n  const { messages } = req.body;\n  const result = streamText({\n    model: chatModel,\n    messages,\n  });\n  result.pipeDataStreamToResponse(res);\n});',
       },
       {
         id: "create-chat-ui",
-        title: "Create a client chat UI with useChat",
+        title: "Create the chat UI with useChat and AI Elements",
         details:
-          "Use useChat + DefaultChatTransport and render text parts with a submit form.",
+          'Use the useChat hook for streaming and AI Elements components for the chat interface:\n\nimport { useChat } from "@ai-sdk/react";\n\nexport function ChatPage() {\n  const { messages, input, handleInputChange, handleSubmit } = useChat();\n\n  return (\n    <div className="flex flex-col h-[600px]">\n      <div className="flex-1 overflow-y-auto space-y-4 p-4">\n        {messages.map((m) => (\n          <div key={m.id} className={m.role === "user" ? "text-right" : ""}>\n            <span className="text-sm font-medium">\n              {m.role === "user" ? "You" : "Assistant"}\n            </span>\n            <p>{m.content}</p>\n          </div>\n        ))}\n      </div>\n      <form onSubmit={handleSubmit} className="border-t p-4 flex gap-2">\n        <input\n          value={input}\n          onChange={handleInputChange}\n          placeholder="Ask a question..."\n          className="flex-1 border rounded px-3 py-2"\n        />\n        <button type="submit">Send</button>\n      </form>\n    </div>\n  );\n}',
       },
       {
         id: "run-and-test",
         title: "Run and test locally",
         command: "bun run dev",
+        details:
+          "Open the chat page in your browser and send a message. Responses stream from your Databricks model serving endpoint through the AI SDK.",
       },
     ],
     references: [
       {
-        label: "AI SDK docs",
-        href: "https://ai-sdk.dev/docs/introduction",
+        label: "AI Gateway docs",
+        href: "https://docs.databricks.com/en/ai-gateway/",
+      },
+      {
+        label: "Model Serving endpoints",
+        href: "https://docs.databricks.com/en/machine-learning/model-serving/create-manage-serving-endpoints.html",
+      },
+      {
+        label: "AI SDK OpenAI-compatible providers",
+        href: "https://ai-sdk.dev/providers/openai-compatible-providers",
       },
       {
         label: "AI Elements docs",
         href: "https://ui.shadcn.com/docs/registry/ai-elements",
-      },
-      {
-        label: "Fullstackrecipes AI SDK setup",
-        href: "recipe://fullstackrecipes.com/ai-sdk-setup",
       },
     ],
   },
@@ -366,7 +388,7 @@ export const templates: Template[] = [
     id: "ai-chat-app-template",
     name: "AI Chat App Template",
     description:
-      "Databricks local bootstrap plus a simple AI chat implementation using AI SDK and AI Elements.",
+      "Databricks local bootstrap plus a streaming AI chat powered by Databricks Model Serving (AI Gateway) with AI SDK and AI Elements.",
     recipeIds: ["databricks-local-bootstrap", "vercel-ai-chat-app"],
   }),
   createTemplate({
@@ -391,7 +413,7 @@ export const templates: Template[] = [
     id: "ai-data-explorer-template",
     name: "AI Data Explorer Template",
     description:
-      "A full-stack data application with Lakebase persistence, AI chat, and Genie natural-language data exploration.",
+      "A full-stack data application with Lakebase persistence, AI chat powered by Databricks Model Serving, and Genie natural-language data exploration.",
     recipeIds: [
       "databricks-local-bootstrap",
       "lakebase-data-persistence",

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -1,21 +1,9 @@
-type RecipeStep = {
-  id: string;
-  title: string;
-  details?: string;
-  command?: string;
-};
-
-type Recipe = {
+export type Recipe = {
   id: string;
   name: string;
   description: string;
   tags: string[];
   prerequisites?: string[];
-  steps: RecipeStep[];
-  references?: Array<{
-    label: string;
-    href: string;
-  }>;
 };
 
 export type Template = {
@@ -24,7 +12,6 @@ export type Template = {
   description: string;
   recipeIds: string[];
   tags: string[];
-  steps: RecipeStep[];
 };
 
 type TemplatePreviewItem = {
@@ -42,63 +29,6 @@ export const recipes: Recipe[] = [
     description:
       "Prepare a local Databricks app workspace: install CLI, authenticate, scaffold, and install Databricks agent skills.",
     tags: ["Databricks CLI", "Setup", "Agent Skills"],
-    steps: [
-      {
-        id: "check-cli",
-        title: "Verify Databricks CLI version",
-        command: "databricks --version",
-        details:
-          "Use Databricks CLI 0.292+ before running setup and app scaffolding commands.",
-      },
-      {
-        id: "install-cli",
-        title: "Install or upgrade Databricks CLI (if needed)",
-        command: "brew tap databricks/tap && brew install databricks",
-        details:
-          "On Linux/Windows use the official installer alternatives from Databricks docs.",
-      },
-      {
-        id: "auth-login",
-        title: "Authenticate to your Databricks workspace",
-        command: "databricks auth login --host <workspace-url>",
-      },
-      {
-        id: "select-profile",
-        title: "List and select profile",
-        command: "databricks auth profiles",
-        details: "Always run workspace commands with --profile <PROFILE>.",
-      },
-      {
-        id: "scaffold-app",
-        title: "Scaffold a new Databricks app folder",
-        command:
-          'databricks apps init --name <app-name> --description "<desc>" --run none --profile <PROFILE>',
-        details:
-          "This creates a new workspace folder for app development and skips auto-run so code can be reviewed first.",
-      },
-      {
-        id: "install-skills",
-        title: "Install Databricks agent skills",
-        command: "npx skills add databricks/databricks-agent-skills --all",
-        details:
-          "--all installs all skills to all detected agents with confirmation skipped.",
-      },
-      {
-        id: "verify-skills",
-        title: "Verify installed skills",
-        command: "npx skills list",
-      },
-    ],
-    references: [
-      {
-        label: "Databricks CLI install",
-        href: "https://docs.databricks.com/en/dev-tools/cli/install",
-      },
-      {
-        label: "Databricks CLI authentication",
-        href: "https://docs.databricks.com/en/dev-tools/cli/authentication.html",
-      },
-    ],
   },
   {
     id: "vercel-ai-chat-app",
@@ -107,77 +37,6 @@ export const recipes: Recipe[] = [
       "Build a streaming chat app powered by Databricks AI Gateway (model serving). Uses Vercel AI SDK with an OpenAI-compatible provider pointed at your Databricks serving endpoint, plus AI Elements for the chat UI.",
     tags: ["AI SDK", "AI Gateway", "Model Serving", "Chat"],
     prerequisites: ["databricks-local-bootstrap"],
-    steps: [
-      {
-        id: "list-serving-endpoints",
-        title: "Identify your model serving endpoint",
-        command:
-          "databricks serving-endpoints list --profile <PROFILE> -o json",
-        details:
-          "List available serving endpoints in your workspace. Pick the endpoint name you want to use for chat (e.g. a foundation model endpoint or a custom model endpoint). You can also check a specific endpoint with:\n\ndatabricks serving-endpoints get <endpoint-name> --profile <PROFILE>",
-      },
-      {
-        id: "install-ai-sdk",
-        title: "Install AI SDK and the OpenAI-compatible provider",
-        command: "bun add ai @ai-sdk/react @ai-sdk/openai-compatible",
-      },
-      {
-        id: "install-ai-elements",
-        title: "Install AI Elements UI components",
-        command: "bunx shadcn@latest add @ai-elements/all",
-      },
-      {
-        id: "set-provider-env",
-        title: "Configure Databricks environment variables",
-        command:
-          "echo 'DATABRICKS_HOST=https://<workspace>.cloud.databricks.com\\nDATABRICKS_TOKEN=<your-token>\\nDATABRICKS_SERVING_ENDPOINT=<endpoint-name>' >> .env",
-        details:
-          "DATABRICKS_HOST is your workspace URL. DATABRICKS_TOKEN is a personal access token or service principal token. DATABRICKS_SERVING_ENDPOINT is the name of the model serving endpoint you identified in step 1.",
-      },
-      {
-        id: "create-provider",
-        title: "Create the Databricks AI provider",
-        details:
-          'Create a provider module that connects AI SDK to your Databricks model serving endpoint using the OpenAI-compatible interface:\n\nimport { createOpenAICompatible } from "@ai-sdk/openai-compatible";\n\nconst databricks = createOpenAICompatible({\n  name: "databricks",\n  baseURL: `${process.env.DATABRICKS_HOST}/serving-endpoints`,\n  headers: {\n    Authorization: `Bearer ${process.env.DATABRICKS_TOKEN}`,\n  },\n});\n\nexport const chatModel = databricks.chatModel(\n  process.env.DATABRICKS_SERVING_ENDPOINT!\n);',
-      },
-      {
-        id: "create-chat-route",
-        title: "Create a streaming chat API route",
-        details:
-          'Implement a /api/chat route that streams responses from your Databricks model serving endpoint:\n\nimport { streamText } from "ai";\nimport { chatModel } from "./provider";\n\napp.post("/api/chat", async (req, res) => {\n  const { messages } = req.body;\n  const result = streamText({\n    model: chatModel,\n    messages,\n  });\n  result.pipeDataStreamToResponse(res);\n});',
-      },
-      {
-        id: "create-chat-ui",
-        title: "Create the chat UI with useChat and AI Elements",
-        details:
-          'Use the useChat hook for streaming and AI Elements components for the chat interface:\n\nimport { useChat } from "@ai-sdk/react";\n\nexport function ChatPage() {\n  const { messages, input, handleInputChange, handleSubmit } = useChat();\n\n  return (\n    <div className="flex flex-col h-[600px]">\n      <div className="flex-1 overflow-y-auto space-y-4 p-4">\n        {messages.map((m) => (\n          <div key={m.id} className={m.role === "user" ? "text-right" : ""}>\n            <span className="text-sm font-medium">\n              {m.role === "user" ? "You" : "Assistant"}\n            </span>\n            <p>{m.content}</p>\n          </div>\n        ))}\n      </div>\n      <form onSubmit={handleSubmit} className="border-t p-4 flex gap-2">\n        <input\n          value={input}\n          onChange={handleInputChange}\n          placeholder="Ask a question..."\n          className="flex-1 border rounded px-3 py-2"\n        />\n        <button type="submit">Send</button>\n      </form>\n    </div>\n  );\n}',
-      },
-      {
-        id: "run-and-test",
-        title: "Run and test locally",
-        command: "bun run dev",
-        details:
-          "Open the chat page in your browser and send a message. Responses stream from your Databricks model serving endpoint through the AI SDK.",
-      },
-    ],
-    references: [
-      {
-        label: "AI Gateway docs",
-        href: "https://docs.databricks.com/en/ai-gateway/",
-      },
-      {
-        label: "Model Serving endpoints",
-        href: "https://docs.databricks.com/en/machine-learning/model-serving/create-manage-serving-endpoints.html",
-      },
-      {
-        label: "AI SDK OpenAI-compatible providers",
-        href: "https://ai-sdk.dev/providers/openai-compatible-providers",
-      },
-      {
-        label: "AI Elements docs",
-        href: "https://ui.shadcn.com/docs/registry/ai-elements",
-      },
-    ],
   },
   {
     id: "lakebase-data-persistence",
@@ -186,53 +45,6 @@ export const recipes: Recipe[] = [
       "Add a managed Postgres database to your Databricks app using the Lakebase plugin. Covers schema setup, table creation, and full CRUD REST API routes.",
     tags: ["Lakebase", "Postgres", "CRUD", "Data"],
     prerequisites: ["databricks-local-bootstrap"],
-    steps: [
-      {
-        id: "enable-lakebase-plugin",
-        title: "Enable the Lakebase plugin",
-        details:
-          'Add the lakebase plugin to your server entry point. Use autoStart: false on the server plugin so you can run database setup before accepting requests:\n\nimport { createApp, server, lakebase } from "@databricks/appkit";\n\ncreateApp({ plugins: [server({ autoStart: false }), lakebase()] })\n  .then(async (appkit) => {\n    // setup routes then start\n    await appkit.server.start();\n  })\n  .catch(console.error);',
-      },
-      {
-        id: "define-schema",
-        title: "Define your database schema",
-        details:
-          "Create a schema and table using raw SQL. Lakebase provides a Postgres-compatible interface through appkit.lakebase.query():\n\nconst SETUP_SCHEMA = `CREATE SCHEMA IF NOT EXISTS app`;\n\nconst CREATE_TABLE = `\n  CREATE TABLE IF NOT EXISTS app.items (\n    id SERIAL PRIMARY KEY,\n    title TEXT NOT NULL,\n    completed BOOLEAN NOT NULL DEFAULT false,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n  )\n`;\n\nawait appkit.lakebase.query(SETUP_SCHEMA);\nawait appkit.lakebase.query(CREATE_TABLE);",
-      },
-      {
-        id: "create-crud-routes",
-        title: "Create CRUD API routes",
-        details:
-          'Use appkit.server.extend() to register Express routes that call appkit.lakebase.query() with parameterized SQL:\n\nappkit.server.extend((app) => {\n  app.get("/api/items", async (_req, res) => {\n    const { rows } = await appkit.lakebase.query(\n      "SELECT * FROM app.items ORDER BY created_at DESC"\n    );\n    res.json(rows);\n  });\n\n  app.post("/api/items", async (req, res) => {\n    const { rows } = await appkit.lakebase.query(\n      "INSERT INTO app.items (title) VALUES ($1) RETURNING *",\n      [req.body.title]\n    );\n    res.status(201).json(rows[0]);\n  });\n\n  app.patch("/api/items/:id", async (req, res) => {\n    const { rows } = await appkit.lakebase.query(\n      "UPDATE app.items SET completed = NOT completed WHERE id = $1 RETURNING *",\n      [req.params.id]\n    );\n    res.json(rows[0]);\n  });\n\n  app.delete("/api/items/:id", async (req, res) => {\n    await appkit.lakebase.query("DELETE FROM app.items WHERE id = $1", [req.params.id]);\n    res.status(204).send();\n  });\n});',
-      },
-      {
-        id: "wire-up-server",
-        title: "Wire up schema setup and start the server",
-        details:
-          "Run the schema setup before registering routes and starting the server:\n\ncreateApp({ plugins: [server({ autoStart: false }), lakebase()] })\n  .then(async (appkit) => {\n    await appkit.lakebase.query(SETUP_SCHEMA);\n    await appkit.lakebase.query(CREATE_TABLE);\n    registerRoutes(appkit);\n    await appkit.server.start();\n  })\n  .catch(console.error);",
-      },
-      {
-        id: "test-lakebase",
-        title: "Run and test locally",
-        command: "bun run dev",
-        details:
-          "Verify the endpoints with curl:\n\ncurl -X POST http://localhost:3000/api/items -H 'Content-Type: application/json' -d '{\"title\":\"My first item\"}'\ncurl http://localhost:3000/api/items",
-      },
-    ],
-    references: [
-      {
-        label: "Lakebase plugin docs",
-        href: "https://databricks.github.io/appkit/docs/plugins/lakebase",
-      },
-      {
-        label: "Lakebase database permissions",
-        href: "https://databricks.github.io/appkit/docs/plugins/lakebase#database-permissions",
-      },
-      {
-        label: "What is a Lakebase?",
-        href: "/solutions/what-is-a-lakebase",
-      },
-    ],
   },
   {
     id: "genie-conversational-analytics",
@@ -241,50 +53,6 @@ export const recipes: Recipe[] = [
       "Embed a Databricks AI/BI Genie chat interface so users can explore data through natural language. Configure a Genie space, wire up the plugin, and render the chat component.",
     tags: ["Genie", "AI/BI", "Natural Language", "Data"],
     prerequisites: ["databricks-local-bootstrap"],
-    steps: [
-      {
-        id: "create-genie-space",
-        title: "Create a Genie space in your Databricks workspace",
-        details:
-          "Open your Databricks workspace, navigate to AI/BI Genie, and create a new Genie space connected to your data tables. Copy the space ID from the URL — you will need it for configuration.",
-      },
-      {
-        id: "set-genie-env",
-        title: "Set the Genie space environment variable",
-        command: "echo 'DATABRICKS_GENIE_SPACE_ID=<your-space-id>' >> .env",
-        details:
-          "Add your Genie space ID to the environment. The Genie plugin reads this value to connect to the right space.",
-      },
-      {
-        id: "enable-genie-plugin",
-        title: "Enable the Genie plugin",
-        details:
-          'Add the genie plugin to your server entry point:\n\nimport { createApp, server, genie } from "@databricks/appkit";\n\ncreateApp({\n  plugins: [\n    server(),\n    genie({ spaces: { default: process.env.DATABRICKS_GENIE_SPACE_ID } }),\n  ],\n}).catch(console.error);',
-      },
-      {
-        id: "add-genie-chat-ui",
-        title: "Add the GenieChat component to a page",
-        details:
-          'Import GenieChat from @databricks/appkit-ui and render it in a container:\n\nimport { GenieChat } from "@databricks/appkit-ui/react";\n\nexport function GeniePage() {\n  return (\n    <div className="h-[600px] border rounded-lg overflow-hidden">\n      <GenieChat alias="default" />\n    </div>\n  );\n}',
-      },
-      {
-        id: "test-genie",
-        title: "Run and test locally",
-        command: "bun run dev",
-        details:
-          "Open the Genie page in your browser and ask a natural-language question about your data to verify the integration.",
-      },
-    ],
-    references: [
-      {
-        label: "Genie plugin docs",
-        href: "https://databricks.github.io/appkit/docs/plugins/genie",
-      },
-      {
-        label: "AI/BI Genie documentation",
-        href: "https://docs.databricks.com/en/genie/index.html",
-      },
-    ],
   },
   {
     id: "sql-analytics-dashboard",
@@ -293,53 +61,6 @@ export const recipes: Recipe[] = [
       "Build interactive dashboards with parameterized SQL queries and chart components. Uses the Analytics plugin for SQL Warehouse queries and AppKit UI for visualizations.",
     tags: ["Analytics", "SQL", "Charts", "Dashboard"],
     prerequisites: ["databricks-local-bootstrap"],
-    steps: [
-      {
-        id: "enable-analytics-plugin",
-        title: "Enable the Analytics plugin",
-        details:
-          'Add the analytics plugin to your server entry point:\n\nimport { createApp, server, analytics } from "@databricks/appkit";\n\ncreateApp({\n  plugins: [server(), analytics()],\n}).catch(console.error);',
-      },
-      {
-        id: "create-sql-queries",
-        title: "Create parameterized SQL query files",
-        details:
-          "Add .sql files under config/queries/. Use :param_name for parameters and @param annotations for type safety:\n\nconfig/queries/monthly_metrics.sql:\n-- @param max_month_num number\nSELECT month, revenue, users\nFROM app.monthly_metrics\nWHERE month_num <= :max_month_num\nORDER BY month_num;",
-      },
-      {
-        id: "build-dashboard-ui",
-        title: "Build the dashboard UI with charts",
-        details:
-          'Import useAnalyticsQuery for data fetching and chart components for visualization:\n\nimport {\n  useAnalyticsQuery, AreaChart, LineChart, BarChart,\n  Card, CardContent, CardHeader, CardTitle,\n} from "@databricks/appkit-ui/react";\nimport { sql } from "@databricks/appkit-ui/js";\nimport { useState } from "react";\n\nexport function DashboardPage() {\n  const [maxMonth, setMaxMonth] = useState(12);\n  const params = { max_month_num: sql.number(maxMonth) };\n\n  return (\n    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">\n      <Card>\n        <CardHeader><CardTitle>Revenue Trend</CardTitle></CardHeader>\n        <CardContent>\n          <AreaChart queryKey="monthly_metrics" parameters={params} />\n        </CardContent>\n      </Card>\n      <Card>\n        <CardHeader><CardTitle>User Growth</CardTitle></CardHeader>\n        <CardContent>\n          <LineChart queryKey="monthly_metrics" parameters={params} />\n        </CardContent>\n      </Card>\n    </div>\n  );\n}',
-      },
-      {
-        id: "add-filters",
-        title: "Add interactive filters with typed parameters",
-        details:
-          'Use sql.string() and sql.number() helpers for type-safe query parameters. Bind them to UI controls like Select or Input to let users filter the dashboard interactively:\n\nconst params = {\n  region: sql.string(selectedRegion),\n  max_month_num: sql.number(maxMonth),\n};',
-      },
-      {
-        id: "test-analytics",
-        title: "Run and test locally",
-        command: "bun run dev",
-        details:
-          "Open the dashboard page and verify that charts render with data from your SQL Warehouse. Adjust filters to see the queries update.",
-      },
-    ],
-    references: [
-      {
-        label: "Analytics plugin docs",
-        href: "https://databricks.github.io/appkit/docs/plugins/analytics",
-      },
-      {
-        label: "AppKit chart components",
-        href: "https://databricks.github.io/appkit/docs/category/charts",
-      },
-      {
-        label: "SQL Warehouses",
-        href: "https://docs.databricks.com/en/compute/sql-warehouse/index.html",
-      },
-    ],
   },
 ];
 
@@ -364,7 +85,6 @@ function createTemplate(config: TemplateConfig): Template {
   });
 
   const tags = [...new Set(selectedRecipes.flatMap((recipe) => recipe.tags))];
-  const steps = selectedRecipes.flatMap((recipe) => recipe.steps);
 
   return {
     id: config.id,
@@ -372,7 +92,6 @@ function createTemplate(config: TemplateConfig): Template {
     description: config.description,
     recipeIds: config.recipeIds,
     tags,
-    steps,
   };
 }
 

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -157,6 +157,168 @@ export const recipes: Recipe[] = [
       },
     ],
   },
+  {
+    id: "lakebase-data-persistence",
+    name: "Lakebase Data Persistence",
+    description:
+      "Add a managed Postgres database to your Databricks app using the Lakebase plugin. Covers schema setup, table creation, and full CRUD REST API routes.",
+    tags: ["Lakebase", "Postgres", "CRUD", "Data"],
+    prerequisites: ["databricks-local-bootstrap"],
+    steps: [
+      {
+        id: "enable-lakebase-plugin",
+        title: "Enable the Lakebase plugin",
+        details:
+          'Add the lakebase plugin to your server entry point. Use autoStart: false on the server plugin so you can run database setup before accepting requests:\n\nimport { createApp, server, lakebase } from "@databricks/appkit";\n\ncreateApp({ plugins: [server({ autoStart: false }), lakebase()] })\n  .then(async (appkit) => {\n    // setup routes then start\n    await appkit.server.start();\n  })\n  .catch(console.error);',
+      },
+      {
+        id: "define-schema",
+        title: "Define your database schema",
+        details:
+          "Create a schema and table using raw SQL. Lakebase provides a Postgres-compatible interface through appkit.lakebase.query():\n\nconst SETUP_SCHEMA = `CREATE SCHEMA IF NOT EXISTS app`;\n\nconst CREATE_TABLE = `\n  CREATE TABLE IF NOT EXISTS app.items (\n    id SERIAL PRIMARY KEY,\n    title TEXT NOT NULL,\n    completed BOOLEAN NOT NULL DEFAULT false,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n  )\n`;\n\nawait appkit.lakebase.query(SETUP_SCHEMA);\nawait appkit.lakebase.query(CREATE_TABLE);",
+      },
+      {
+        id: "create-crud-routes",
+        title: "Create CRUD API routes",
+        details:
+          'Use appkit.server.extend() to register Express routes that call appkit.lakebase.query() with parameterized SQL:\n\nappkit.server.extend((app) => {\n  app.get("/api/items", async (_req, res) => {\n    const { rows } = await appkit.lakebase.query(\n      "SELECT * FROM app.items ORDER BY created_at DESC"\n    );\n    res.json(rows);\n  });\n\n  app.post("/api/items", async (req, res) => {\n    const { rows } = await appkit.lakebase.query(\n      "INSERT INTO app.items (title) VALUES ($1) RETURNING *",\n      [req.body.title]\n    );\n    res.status(201).json(rows[0]);\n  });\n\n  app.patch("/api/items/:id", async (req, res) => {\n    const { rows } = await appkit.lakebase.query(\n      "UPDATE app.items SET completed = NOT completed WHERE id = $1 RETURNING *",\n      [req.params.id]\n    );\n    res.json(rows[0]);\n  });\n\n  app.delete("/api/items/:id", async (req, res) => {\n    await appkit.lakebase.query("DELETE FROM app.items WHERE id = $1", [req.params.id]);\n    res.status(204).send();\n  });\n});',
+      },
+      {
+        id: "wire-up-server",
+        title: "Wire up schema setup and start the server",
+        details:
+          "Run the schema setup before registering routes and starting the server:\n\ncreateApp({ plugins: [server({ autoStart: false }), lakebase()] })\n  .then(async (appkit) => {\n    await appkit.lakebase.query(SETUP_SCHEMA);\n    await appkit.lakebase.query(CREATE_TABLE);\n    registerRoutes(appkit);\n    await appkit.server.start();\n  })\n  .catch(console.error);",
+      },
+      {
+        id: "test-lakebase",
+        title: "Run and test locally",
+        command: "bun run dev",
+        details:
+          "Verify the endpoints with curl:\n\ncurl -X POST http://localhost:3000/api/items -H 'Content-Type: application/json' -d '{\"title\":\"My first item\"}'\ncurl http://localhost:3000/api/items",
+      },
+    ],
+    references: [
+      {
+        label: "Lakebase plugin docs",
+        href: "https://databricks.github.io/appkit/docs/plugins/lakebase",
+      },
+      {
+        label: "Lakebase database permissions",
+        href: "https://databricks.github.io/appkit/docs/plugins/lakebase#database-permissions",
+      },
+      {
+        label: "What is a Lakebase?",
+        href: "/solutions/what-is-a-lakebase",
+      },
+    ],
+  },
+  {
+    id: "genie-conversational-analytics",
+    name: "Genie Conversational Analytics",
+    description:
+      "Embed a Databricks AI/BI Genie chat interface so users can explore data through natural language. Configure a Genie space, wire up the plugin, and render the chat component.",
+    tags: ["Genie", "AI/BI", "Natural Language", "Data"],
+    prerequisites: ["databricks-local-bootstrap"],
+    steps: [
+      {
+        id: "create-genie-space",
+        title: "Create a Genie space in your Databricks workspace",
+        details:
+          "Open your Databricks workspace, navigate to AI/BI Genie, and create a new Genie space connected to your data tables. Copy the space ID from the URL — you will need it for configuration.",
+      },
+      {
+        id: "set-genie-env",
+        title: "Set the Genie space environment variable",
+        command: "echo 'DATABRICKS_GENIE_SPACE_ID=<your-space-id>' >> .env",
+        details:
+          "Add your Genie space ID to the environment. The Genie plugin reads this value to connect to the right space.",
+      },
+      {
+        id: "enable-genie-plugin",
+        title: "Enable the Genie plugin",
+        details:
+          'Add the genie plugin to your server entry point:\n\nimport { createApp, server, genie } from "@databricks/appkit";\n\ncreateApp({\n  plugins: [\n    server(),\n    genie({ spaces: { default: process.env.DATABRICKS_GENIE_SPACE_ID } }),\n  ],\n}).catch(console.error);',
+      },
+      {
+        id: "add-genie-chat-ui",
+        title: "Add the GenieChat component to a page",
+        details:
+          'Import GenieChat from @databricks/appkit-ui and render it in a container:\n\nimport { GenieChat } from "@databricks/appkit-ui/react";\n\nexport function GeniePage() {\n  return (\n    <div className="h-[600px] border rounded-lg overflow-hidden">\n      <GenieChat alias="default" />\n    </div>\n  );\n}',
+      },
+      {
+        id: "test-genie",
+        title: "Run and test locally",
+        command: "bun run dev",
+        details:
+          "Open the Genie page in your browser and ask a natural-language question about your data to verify the integration.",
+      },
+    ],
+    references: [
+      {
+        label: "Genie plugin docs",
+        href: "https://databricks.github.io/appkit/docs/plugins/genie",
+      },
+      {
+        label: "AI/BI Genie documentation",
+        href: "https://docs.databricks.com/en/genie/index.html",
+      },
+    ],
+  },
+  {
+    id: "sql-analytics-dashboard",
+    name: "SQL Analytics Dashboard",
+    description:
+      "Build interactive dashboards with parameterized SQL queries and chart components. Uses the Analytics plugin for SQL Warehouse queries and AppKit UI for visualizations.",
+    tags: ["Analytics", "SQL", "Charts", "Dashboard"],
+    prerequisites: ["databricks-local-bootstrap"],
+    steps: [
+      {
+        id: "enable-analytics-plugin",
+        title: "Enable the Analytics plugin",
+        details:
+          'Add the analytics plugin to your server entry point:\n\nimport { createApp, server, analytics } from "@databricks/appkit";\n\ncreateApp({\n  plugins: [server(), analytics()],\n}).catch(console.error);',
+      },
+      {
+        id: "create-sql-queries",
+        title: "Create parameterized SQL query files",
+        details:
+          "Add .sql files under config/queries/. Use :param_name for parameters and @param annotations for type safety:\n\nconfig/queries/monthly_metrics.sql:\n-- @param max_month_num number\nSELECT month, revenue, users\nFROM app.monthly_metrics\nWHERE month_num <= :max_month_num\nORDER BY month_num;",
+      },
+      {
+        id: "build-dashboard-ui",
+        title: "Build the dashboard UI with charts",
+        details:
+          'Import useAnalyticsQuery for data fetching and chart components for visualization:\n\nimport {\n  useAnalyticsQuery, AreaChart, LineChart, BarChart,\n  Card, CardContent, CardHeader, CardTitle,\n} from "@databricks/appkit-ui/react";\nimport { sql } from "@databricks/appkit-ui/js";\nimport { useState } from "react";\n\nexport function DashboardPage() {\n  const [maxMonth, setMaxMonth] = useState(12);\n  const params = { max_month_num: sql.number(maxMonth) };\n\n  return (\n    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">\n      <Card>\n        <CardHeader><CardTitle>Revenue Trend</CardTitle></CardHeader>\n        <CardContent>\n          <AreaChart queryKey="monthly_metrics" parameters={params} />\n        </CardContent>\n      </Card>\n      <Card>\n        <CardHeader><CardTitle>User Growth</CardTitle></CardHeader>\n        <CardContent>\n          <LineChart queryKey="monthly_metrics" parameters={params} />\n        </CardContent>\n      </Card>\n    </div>\n  );\n}',
+      },
+      {
+        id: "add-filters",
+        title: "Add interactive filters with typed parameters",
+        details:
+          'Use sql.string() and sql.number() helpers for type-safe query parameters. Bind them to UI controls like Select or Input to let users filter the dashboard interactively:\n\nconst params = {\n  region: sql.string(selectedRegion),\n  max_month_num: sql.number(maxMonth),\n};',
+      },
+      {
+        id: "test-analytics",
+        title: "Run and test locally",
+        command: "bun run dev",
+        details:
+          "Open the dashboard page and verify that charts render with data from your SQL Warehouse. Adjust filters to see the queries update.",
+      },
+    ],
+    references: [
+      {
+        label: "Analytics plugin docs",
+        href: "https://databricks.github.io/appkit/docs/plugins/analytics",
+      },
+      {
+        label: "AppKit chart components",
+        href: "https://databricks.github.io/appkit/docs/category/charts",
+      },
+      {
+        label: "SQL Warehouses",
+        href: "https://docs.databricks.com/en/compute/sql-warehouse/index.html",
+      },
+    ],
+  },
 ];
 
 const recipeIndex: Record<string, Recipe> = Object.fromEntries(
@@ -206,6 +368,36 @@ export const templates: Template[] = [
     description:
       "Databricks local bootstrap plus a simple AI chat implementation using AI SDK and AI Elements.",
     recipeIds: ["databricks-local-bootstrap", "vercel-ai-chat-app"],
+  }),
+  createTemplate({
+    id: "data-app-template",
+    name: "Data App Template",
+    description:
+      "Bootstrap a Databricks app with Lakebase for persistent data storage. Includes schema setup and full CRUD API routes.",
+    recipeIds: ["databricks-local-bootstrap", "lakebase-data-persistence"],
+  }),
+  createTemplate({
+    id: "analytics-dashboard-app-template",
+    name: "Analytics Dashboard App Template",
+    description:
+      "Build an interactive analytics dashboard backed by Lakebase and powered by parameterized SQL queries and chart components.",
+    recipeIds: [
+      "databricks-local-bootstrap",
+      "lakebase-data-persistence",
+      "sql-analytics-dashboard",
+    ],
+  }),
+  createTemplate({
+    id: "ai-data-explorer-template",
+    name: "AI Data Explorer Template",
+    description:
+      "A full-stack data application with Lakebase persistence, AI chat, and Genie natural-language data exploration.",
+    recipeIds: [
+      "databricks-local-bootstrap",
+      "lakebase-data-persistence",
+      "vercel-ai-chat-app",
+      "genie-conversational-analytics",
+    ],
   }),
 ];
 

--- a/src/pages/resources/_recipes/ai-chat-model-serving.mdx
+++ b/src/pages/resources/_recipes/ai-chat-model-serving.mdx
@@ -1,0 +1,128 @@
+## AI Chat with Databricks Model Serving
+
+Build a streaming chat app powered by Databricks AI Gateway (model serving). Uses Vercel AI SDK with an OpenAI-compatible provider pointed at your Databricks serving endpoint, plus AI Elements for the chat UI.
+
+### 1. Identify your model serving endpoint
+
+List available serving endpoints in your workspace. Pick the endpoint name you want to use for chat (e.g. a foundation model endpoint or a custom model endpoint).
+
+```bash
+databricks serving-endpoints list --profile <PROFILE> -o json
+```
+
+You can also inspect a specific endpoint:
+
+```bash
+databricks serving-endpoints get <endpoint-name> --profile <PROFILE>
+```
+
+### 2. Install AI SDK and the OpenAI-compatible provider
+
+```bash
+bun add ai @ai-sdk/react @ai-sdk/openai-compatible
+```
+
+### 3. Install AI Elements UI components
+
+```bash
+bunx shadcn@latest add @ai-elements/all
+```
+
+### 4. Configure Databricks environment variables
+
+`DATABRICKS_HOST` is your workspace URL. `DATABRICKS_TOKEN` is a personal access token or service principal token. `DATABRICKS_SERVING_ENDPOINT` is the name of the model serving endpoint you identified in step 1.
+
+```bash
+echo 'DATABRICKS_HOST=https://<workspace>.cloud.databricks.com
+DATABRICKS_TOKEN=<your-token>
+DATABRICKS_SERVING_ENDPOINT=<endpoint-name>' >> .env
+```
+
+### 5. Create the Databricks AI provider
+
+Create a provider module that connects AI SDK to your Databricks model serving endpoint using the OpenAI-compatible interface:
+
+```typescript
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+const databricks = createOpenAICompatible({
+  name: "databricks",
+  baseURL: `${process.env.DATABRICKS_HOST}/serving-endpoints`,
+  headers: {
+    Authorization: `Bearer ${process.env.DATABRICKS_TOKEN}`,
+  },
+});
+
+export const chatModel = databricks.chatModel(
+  process.env.DATABRICKS_SERVING_ENDPOINT!
+);
+```
+
+### 6. Create a streaming chat API route
+
+Implement a `/api/chat` route that streams responses from your Databricks model serving endpoint:
+
+```typescript
+import { streamText } from "ai";
+import { chatModel } from "./provider";
+
+app.post("/api/chat", async (req, res) => {
+  const { messages } = req.body;
+  const result = streamText({
+    model: chatModel,
+    messages,
+  });
+  result.pipeDataStreamToResponse(res);
+});
+```
+
+### 7. Create the chat UI with useChat and AI Elements
+
+Use the `useChat` hook for streaming and AI Elements components for the chat interface:
+
+```tsx
+import { useChat } from "@ai-sdk/react";
+
+export function ChatPage() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat();
+
+  return (
+    <div className="flex flex-col h-[600px]">
+      <div className="flex-1 overflow-y-auto space-y-4 p-4">
+        {messages.map((m) => (
+          <div key={m.id} className={m.role === "user" ? "text-right" : ""}>
+            <span className="text-sm font-medium">
+              {m.role === "user" ? "You" : "Assistant"}
+            </span>
+            <p>{m.content}</p>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="border-t p-4 flex gap-2">
+        <input
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Ask a question..."
+          className="flex-1 border rounded px-3 py-2"
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+```
+
+### 8. Run and test locally
+
+Open the chat page in your browser and send a message. Responses stream from your Databricks model serving endpoint through the AI SDK.
+
+```bash
+bun run dev
+```
+
+#### References
+
+- [AI Gateway docs](https://docs.databricks.com/en/ai-gateway/)
+- [Model Serving endpoints](https://docs.databricks.com/en/machine-learning/model-serving/create-manage-serving-endpoints.html)
+- [AI SDK OpenAI-compatible providers](https://ai-sdk.dev/providers/openai-compatible-providers)
+- [AI Elements docs](https://ui.shadcn.com/docs/registry/ai-elements)

--- a/src/pages/resources/_recipes/ai-chat-model-serving.mdx
+++ b/src/pages/resources/_recipes/ai-chat-model-serving.mdx
@@ -54,7 +54,7 @@ const databricks = createOpenAICompatible({
 });
 
 export const chatModel = databricks.chatModel(
-  process.env.DATABRICKS_SERVING_ENDPOINT!
+  process.env.DATABRICKS_SERVING_ENDPOINT!,
 );
 ```
 

--- a/src/pages/resources/_recipes/databricks-local-bootstrap.mdx
+++ b/src/pages/resources/_recipes/databricks-local-bootstrap.mdx
@@ -1,0 +1,60 @@
+## Databricks Local Bootstrap
+
+Prepare a local Databricks app workspace: install CLI, authenticate, scaffold, and install Databricks agent skills.
+
+### 1. Verify Databricks CLI version
+
+Use Databricks CLI 0.292+ before running setup and app scaffolding commands.
+
+```bash
+databricks --version
+```
+
+### 2. Install or upgrade Databricks CLI (if needed)
+
+On Linux/Windows use the official installer alternatives from Databricks docs.
+
+```bash
+brew tap databricks/tap && brew install databricks
+```
+
+### 3. Authenticate to your Databricks workspace
+
+```bash
+databricks auth login --host <workspace-url>
+```
+
+### 4. List and select profile
+
+Always run workspace commands with `--profile <PROFILE>`.
+
+```bash
+databricks auth profiles
+```
+
+### 5. Scaffold a new Databricks app folder
+
+This creates a new workspace folder for app development and skips auto-run so code can be reviewed first.
+
+```bash
+databricks apps init --name <app-name> --description "<desc>" --run none --profile <PROFILE>
+```
+
+### 6. Install Databricks agent skills
+
+`--all` installs all skills to all detected agents with confirmation skipped.
+
+```bash
+npx skills add databricks/databricks-agent-skills --all
+```
+
+### 7. Verify installed skills
+
+```bash
+npx skills list
+```
+
+#### References
+
+- [Databricks CLI install](https://docs.databricks.com/en/dev-tools/cli/install)
+- [Databricks CLI authentication](https://docs.databricks.com/en/dev-tools/cli/authentication.html)

--- a/src/pages/resources/_recipes/genie-conversational-analytics.mdx
+++ b/src/pages/resources/_recipes/genie-conversational-analytics.mdx
@@ -1,0 +1,59 @@
+## Genie Conversational Analytics
+
+Embed a Databricks AI/BI Genie chat interface so users can explore data through natural language. Configure a Genie space, wire up the plugin, and render the chat component.
+
+### 1. Create a Genie space in your Databricks workspace
+
+Open your Databricks workspace, navigate to AI/BI Genie, and create a new Genie space connected to your data tables. Copy the space ID from the URL — you will need it for configuration.
+
+### 2. Set the Genie space environment variable
+
+Add your Genie space ID to the environment. The Genie plugin reads this value to connect to the right space.
+
+```bash
+echo 'DATABRICKS_GENIE_SPACE_ID=<your-space-id>' >> .env
+```
+
+### 3. Enable the Genie plugin
+
+Add the genie plugin to your server entry point:
+
+```typescript
+import { createApp, server, genie } from "@databricks/appkit";
+
+createApp({
+  plugins: [
+    server(),
+    genie({ spaces: { default: process.env.DATABRICKS_GENIE_SPACE_ID } }),
+  ],
+}).catch(console.error);
+```
+
+### 4. Add the GenieChat component to a page
+
+Import `GenieChat` from `@databricks/appkit-ui` and render it in a container:
+
+```tsx
+import { GenieChat } from "@databricks/appkit-ui/react";
+
+export function GeniePage() {
+  return (
+    <div className="h-[600px] border rounded-lg overflow-hidden">
+      <GenieChat alias="default" />
+    </div>
+  );
+}
+```
+
+### 5. Run and test locally
+
+Open the Genie page in your browser and ask a natural-language question about your data to verify the integration.
+
+```bash
+bun run dev
+```
+
+#### References
+
+- [Genie plugin docs](https://databricks.github.io/appkit/docs/plugins/genie)
+- [AI/BI Genie documentation](https://docs.databricks.com/en/genie/index.html)

--- a/src/pages/resources/_recipes/lakebase-data-persistence.mdx
+++ b/src/pages/resources/_recipes/lakebase-data-persistence.mdx
@@ -1,0 +1,114 @@
+## Lakebase Data Persistence
+
+Add a managed Postgres database to your Databricks app using the Lakebase plugin. Covers schema setup, table creation, and full CRUD REST API routes.
+
+### 1. Enable the Lakebase plugin
+
+Add the lakebase plugin to your server entry point. Use `autoStart: false` on the server plugin so you can run database setup before accepting requests:
+
+```typescript
+import { createApp, server, lakebase } from "@databricks/appkit";
+
+createApp({ plugins: [server({ autoStart: false }), lakebase()] })
+  .then(async (appkit) => {
+    // setup routes then start
+    await appkit.server.start();
+  })
+  .catch(console.error);
+```
+
+### 2. Define your database schema
+
+Create a schema and table using raw SQL. Lakebase provides a Postgres-compatible interface through `appkit.lakebase.query()`:
+
+```typescript
+const SETUP_SCHEMA = `CREATE SCHEMA IF NOT EXISTS app`;
+
+const CREATE_TABLE = `
+  CREATE TABLE IF NOT EXISTS app.items (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    completed BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )
+`;
+
+await appkit.lakebase.query(SETUP_SCHEMA);
+await appkit.lakebase.query(CREATE_TABLE);
+```
+
+### 3. Create CRUD API routes
+
+Use `appkit.server.extend()` to register Express routes that call `appkit.lakebase.query()` with parameterized SQL:
+
+```typescript
+appkit.server.extend((app) => {
+  app.get("/api/items", async (_req, res) => {
+    const { rows } = await appkit.lakebase.query(
+      "SELECT * FROM app.items ORDER BY created_at DESC"
+    );
+    res.json(rows);
+  });
+
+  app.post("/api/items", async (req, res) => {
+    const { rows } = await appkit.lakebase.query(
+      "INSERT INTO app.items (title) VALUES ($1) RETURNING *",
+      [req.body.title]
+    );
+    res.status(201).json(rows[0]);
+  });
+
+  app.patch("/api/items/:id", async (req, res) => {
+    const { rows } = await appkit.lakebase.query(
+      "UPDATE app.items SET completed = NOT completed WHERE id = $1 RETURNING *",
+      [req.params.id]
+    );
+    res.json(rows[0]);
+  });
+
+  app.delete("/api/items/:id", async (req, res) => {
+    await appkit.lakebase.query(
+      "DELETE FROM app.items WHERE id = $1",
+      [req.params.id]
+    );
+    res.status(204).send();
+  });
+});
+```
+
+### 4. Wire up schema setup and start the server
+
+Run the schema setup before registering routes and starting the server:
+
+```typescript
+createApp({ plugins: [server({ autoStart: false }), lakebase()] })
+  .then(async (appkit) => {
+    await appkit.lakebase.query(SETUP_SCHEMA);
+    await appkit.lakebase.query(CREATE_TABLE);
+    registerRoutes(appkit);
+    await appkit.server.start();
+  })
+  .catch(console.error);
+```
+
+### 5. Run and test locally
+
+Verify the endpoints with curl:
+
+```bash
+bun run dev
+```
+
+```bash
+curl -X POST http://localhost:3000/api/items \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"My first item"}'
+
+curl http://localhost:3000/api/items
+```
+
+#### References
+
+- [Lakebase plugin docs](https://databricks.github.io/appkit/docs/plugins/lakebase)
+- [Lakebase database permissions](https://databricks.github.io/appkit/docs/plugins/lakebase#database-permissions)
+- [What is a Lakebase?](/solutions/what-is-a-lakebase)

--- a/src/pages/resources/_recipes/lakebase-data-persistence.mdx
+++ b/src/pages/resources/_recipes/lakebase-data-persistence.mdx
@@ -45,7 +45,7 @@ Use `appkit.server.extend()` to register Express routes that call `appkit.lakeba
 appkit.server.extend((app) => {
   app.get("/api/items", async (_req, res) => {
     const { rows } = await appkit.lakebase.query(
-      "SELECT * FROM app.items ORDER BY created_at DESC"
+      "SELECT * FROM app.items ORDER BY created_at DESC",
     );
     res.json(rows);
   });
@@ -53,7 +53,7 @@ appkit.server.extend((app) => {
   app.post("/api/items", async (req, res) => {
     const { rows } = await appkit.lakebase.query(
       "INSERT INTO app.items (title) VALUES ($1) RETURNING *",
-      [req.body.title]
+      [req.body.title],
     );
     res.status(201).json(rows[0]);
   });
@@ -61,16 +61,15 @@ appkit.server.extend((app) => {
   app.patch("/api/items/:id", async (req, res) => {
     const { rows } = await appkit.lakebase.query(
       "UPDATE app.items SET completed = NOT completed WHERE id = $1 RETURNING *",
-      [req.params.id]
+      [req.params.id],
     );
     res.json(rows[0]);
   });
 
   app.delete("/api/items/:id", async (req, res) => {
-    await appkit.lakebase.query(
-      "DELETE FROM app.items WHERE id = $1",
-      [req.params.id]
-    );
+    await appkit.lakebase.query("DELETE FROM app.items WHERE id = $1", [
+      req.params.id,
+    ]);
     res.status(204).send();
   });
 });

--- a/src/pages/resources/_recipes/sql-analytics-dashboard.mdx
+++ b/src/pages/resources/_recipes/sql-analytics-dashboard.mdx
@@ -1,0 +1,88 @@
+## SQL Analytics Dashboard
+
+Build interactive dashboards with parameterized SQL queries and chart components. Uses the Analytics plugin for SQL Warehouse queries and AppKit UI for visualizations.
+
+### 1. Enable the Analytics plugin
+
+Add the analytics plugin to your server entry point:
+
+```typescript
+import { createApp, server, analytics } from "@databricks/appkit";
+
+createApp({
+  plugins: [server(), analytics()],
+}).catch(console.error);
+```
+
+### 2. Create parameterized SQL query files
+
+Add `.sql` files under `config/queries/`. Use `:param_name` for parameters and `@param` annotations for type safety:
+
+```sql
+-- config/queries/monthly_metrics.sql
+-- @param max_month_num number
+SELECT month, revenue, users
+FROM app.monthly_metrics
+WHERE month_num <= :max_month_num
+ORDER BY month_num;
+```
+
+### 3. Build the dashboard UI with charts
+
+Import `useAnalyticsQuery` for data fetching and chart components for visualization:
+
+```tsx
+import {
+  useAnalyticsQuery, AreaChart, LineChart, BarChart,
+  Card, CardContent, CardHeader, CardTitle,
+} from "@databricks/appkit-ui/react";
+import { sql } from "@databricks/appkit-ui/js";
+import { useState } from "react";
+
+export function DashboardPage() {
+  const [maxMonth, setMaxMonth] = useState(12);
+  const params = { max_month_num: sql.number(maxMonth) };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <Card>
+        <CardHeader><CardTitle>Revenue Trend</CardTitle></CardHeader>
+        <CardContent>
+          <AreaChart queryKey="monthly_metrics" parameters={params} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle>User Growth</CardTitle></CardHeader>
+        <CardContent>
+          <LineChart queryKey="monthly_metrics" parameters={params} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+### 4. Add interactive filters with typed parameters
+
+Use `sql.string()` and `sql.number()` helpers for type-safe query parameters. Bind them to UI controls like `Select` or `Input` to let users filter the dashboard interactively:
+
+```typescript
+const params = {
+  region: sql.string(selectedRegion),
+  max_month_num: sql.number(maxMonth),
+};
+```
+
+### 5. Run and test locally
+
+Open the dashboard page and verify that charts render with data from your SQL Warehouse. Adjust filters to see the queries update.
+
+```bash
+bun run dev
+```
+
+#### References
+
+- [Analytics plugin docs](https://databricks.github.io/appkit/docs/plugins/analytics)
+- [AppKit chart components](https://databricks.github.io/appkit/docs/category/charts)
+- [SQL Warehouses](https://docs.databricks.com/en/compute/sql-warehouse/index.html)

--- a/src/pages/resources/_recipes/sql-analytics-dashboard.mdx
+++ b/src/pages/resources/_recipes/sql-analytics-dashboard.mdx
@@ -33,8 +33,14 @@ Import `useAnalyticsQuery` for data fetching and chart components for visualizat
 
 ```tsx
 import {
-  useAnalyticsQuery, AreaChart, LineChart, BarChart,
-  Card, CardContent, CardHeader, CardTitle,
+  useAnalyticsQuery,
+  AreaChart,
+  LineChart,
+  BarChart,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
 } from "@databricks/appkit-ui/react";
 import { sql } from "@databricks/appkit-ui/js";
 import { useState } from "react";
@@ -46,13 +52,17 @@ export function DashboardPage() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <Card>
-        <CardHeader><CardTitle>Revenue Trend</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle>Revenue Trend</CardTitle>
+        </CardHeader>
         <CardContent>
           <AreaChart queryKey="monthly_metrics" parameters={params} />
         </CardContent>
       </Card>
       <Card>
-        <CardHeader><CardTitle>User Growth</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle>User Growth</CardTitle>
+        </CardHeader>
         <CardContent>
           <LineChart queryKey="monthly_metrics" parameters={params} />
         </CardContent>

--- a/src/pages/resources/ai-chat-app-template.tsx
+++ b/src/pages/resources/ai-chat-app-template.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { TemplateDetail } from "@/components/resources/template-detail";
 import { templates } from "@/lib/recipes/recipes";
+import DatabricksLocalBootstrap from "./_recipes/databricks-local-bootstrap.mdx";
+import AiChatModelServing from "./_recipes/ai-chat-model-serving.mdx";
 
 const template = templates.find((t) => t.id === "ai-chat-app-template");
 
@@ -8,5 +10,11 @@ export default function AiChatAppTemplatePage(): ReactNode {
   if (!template) {
     throw new Error("Template ai-chat-app-template not found");
   }
-  return <TemplateDetail template={template} />;
+  return (
+    <TemplateDetail template={template}>
+      <DatabricksLocalBootstrap />
+      <hr />
+      <AiChatModelServing />
+    </TemplateDetail>
+  );
 }

--- a/src/pages/resources/ai-data-explorer-template.tsx
+++ b/src/pages/resources/ai-data-explorer-template.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { TemplateDetail } from "@/components/resources/template-detail";
+import { templates } from "@/lib/recipes/recipes";
+
+const template = templates.find((t) => t.id === "ai-data-explorer-template");
+
+export default function AiDataExplorerTemplatePage(): ReactNode {
+  if (!template) {
+    throw new Error("Template ai-data-explorer-template not found");
+  }
+  return <TemplateDetail template={template} />;
+}

--- a/src/pages/resources/ai-data-explorer-template.tsx
+++ b/src/pages/resources/ai-data-explorer-template.tsx
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react";
 import { TemplateDetail } from "@/components/resources/template-detail";
 import { templates } from "@/lib/recipes/recipes";
+import DatabricksLocalBootstrap from "./_recipes/databricks-local-bootstrap.mdx";
+import LakebaseDataPersistence from "./_recipes/lakebase-data-persistence.mdx";
+import AiChatModelServing from "./_recipes/ai-chat-model-serving.mdx";
+import GenieConversationalAnalytics from "./_recipes/genie-conversational-analytics.mdx";
 
 const template = templates.find((t) => t.id === "ai-data-explorer-template");
 
@@ -8,5 +12,15 @@ export default function AiDataExplorerTemplatePage(): ReactNode {
   if (!template) {
     throw new Error("Template ai-data-explorer-template not found");
   }
-  return <TemplateDetail template={template} />;
+  return (
+    <TemplateDetail template={template}>
+      <DatabricksLocalBootstrap />
+      <hr />
+      <LakebaseDataPersistence />
+      <hr />
+      <AiChatModelServing />
+      <hr />
+      <GenieConversationalAnalytics />
+    </TemplateDetail>
+  );
 }

--- a/src/pages/resources/analytics-dashboard-app-template.tsx
+++ b/src/pages/resources/analytics-dashboard-app-template.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { TemplateDetail } from "@/components/resources/template-detail";
+import { templates } from "@/lib/recipes/recipes";
+
+const template = templates.find(
+  (t) => t.id === "analytics-dashboard-app-template",
+);
+
+export default function AnalyticsDashboardAppTemplatePage(): ReactNode {
+  if (!template) {
+    throw new Error("Template analytics-dashboard-app-template not found");
+  }
+  return <TemplateDetail template={template} />;
+}

--- a/src/pages/resources/analytics-dashboard-app-template.tsx
+++ b/src/pages/resources/analytics-dashboard-app-template.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
 import { TemplateDetail } from "@/components/resources/template-detail";
 import { templates } from "@/lib/recipes/recipes";
+import DatabricksLocalBootstrap from "./_recipes/databricks-local-bootstrap.mdx";
+import LakebaseDataPersistence from "./_recipes/lakebase-data-persistence.mdx";
+import SqlAnalyticsDashboard from "./_recipes/sql-analytics-dashboard.mdx";
 
 const template = templates.find(
   (t) => t.id === "analytics-dashboard-app-template",
@@ -10,5 +13,13 @@ export default function AnalyticsDashboardAppTemplatePage(): ReactNode {
   if (!template) {
     throw new Error("Template analytics-dashboard-app-template not found");
   }
-  return <TemplateDetail template={template} />;
+  return (
+    <TemplateDetail template={template}>
+      <DatabricksLocalBootstrap />
+      <hr />
+      <LakebaseDataPersistence />
+      <hr />
+      <SqlAnalyticsDashboard />
+    </TemplateDetail>
+  );
 }

--- a/src/pages/resources/base-app-template.tsx
+++ b/src/pages/resources/base-app-template.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { TemplateDetail } from "@/components/resources/template-detail";
 import { templates } from "@/lib/recipes/recipes";
+import DatabricksLocalBootstrap from "./_recipes/databricks-local-bootstrap.mdx";
 
 const template = templates.find((t) => t.id === "base-app-template");
 
@@ -8,5 +9,9 @@ export default function BaseAppTemplatePage(): ReactNode {
   if (!template) {
     throw new Error("Template base-app-template not found");
   }
-  return <TemplateDetail template={template} />;
+  return (
+    <TemplateDetail template={template}>
+      <DatabricksLocalBootstrap />
+    </TemplateDetail>
+  );
 }

--- a/src/pages/resources/data-app-template.tsx
+++ b/src/pages/resources/data-app-template.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { TemplateDetail } from "@/components/resources/template-detail";
 import { templates } from "@/lib/recipes/recipes";
+import DatabricksLocalBootstrap from "./_recipes/databricks-local-bootstrap.mdx";
+import LakebaseDataPersistence from "./_recipes/lakebase-data-persistence.mdx";
 
 const template = templates.find((t) => t.id === "data-app-template");
 
@@ -8,5 +10,11 @@ export default function DataAppTemplatePage(): ReactNode {
   if (!template) {
     throw new Error("Template data-app-template not found");
   }
-  return <TemplateDetail template={template} />;
+  return (
+    <TemplateDetail template={template}>
+      <DatabricksLocalBootstrap />
+      <hr />
+      <LakebaseDataPersistence />
+    </TemplateDetail>
+  );
 }

--- a/src/pages/resources/data-app-template.tsx
+++ b/src/pages/resources/data-app-template.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { TemplateDetail } from "@/components/resources/template-detail";
+import { templates } from "@/lib/recipes/recipes";
+
+const template = templates.find((t) => t.id === "data-app-template");
+
+export default function DataAppTemplatePage(): ReactNode {
+  if (!template) {
+    throw new Error("Template data-app-template not found");
+  }
+  return <TemplateDetail template={template} />;
+}

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -37,12 +37,14 @@ const CARD_VISUALS: Array<{
     ),
   },
   {
-    gradient: "bg-gradient-to-br from-[#11141a] via-[#1b2028] to-[#0d0f14]",
+    gradient: "bg-gradient-to-br from-[#0f1923] via-[#162333] to-[#0a1219]",
     shapes: (
       <div className="absolute inset-0">
-        <div className="absolute inset-0 opacity-80 [background-image:radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.25)_1px,transparent_0)] [background-size:8px_8px]" />
-        <div className="absolute left-6 top-8 h-24 w-24 rounded-full border border-white/25" />
-        <div className="absolute right-8 bottom-7 h-14 w-20 rounded-md bg-[#0f141b] shadow-lg" />
+        <div className="absolute left-7 top-8 h-14 w-20 rounded-sm bg-[#1a3a52]/90 shadow-lg" />
+        <div className="absolute left-7 top-26 h-14 w-20 rounded-sm bg-[#1a3a52]/90 shadow-lg" />
+        <div className="absolute left-32 top-14 h-20 w-24 rounded-md border border-[#2a8af6]/30 bg-[#0e1a26]/95" />
+        <div className="absolute right-8 top-8 h-6 w-6 rounded-full bg-[#2a8af6]/50" />
+        <div className="absolute right-10 bottom-8 h-4 w-12 rounded bg-[#2a8af6]/25" />
       </div>
     ),
   },
@@ -50,9 +52,26 @@ const CARD_VISUALS: Array<{
     gradient: "bg-gradient-to-br from-[#e9ecef] via-[#f9fafb] to-[#e2e7eb]",
     shapes: (
       <div className="absolute inset-0">
-        <div className="absolute left-6 top-6 h-32 w-20 border-r border-black/10 bg-white/72" />
-        <div className="absolute right-7 top-6 h-12 w-14 rounded bg-[#78a8ff]/55" />
-        <div className="absolute right-7 top-22 h-16 w-14 rounded bg-[#7dc8ff]/45" />
+        <div className="absolute left-6 bottom-6 h-28 w-10 rounded-t bg-[#4a9ff5]/40" />
+        <div className="absolute left-20 bottom-6 h-20 w-10 rounded-t bg-[#4a9ff5]/55" />
+        <div className="absolute left-34 bottom-6 h-32 w-10 rounded-t bg-[#4a9ff5]/35" />
+        <div className="absolute right-10 top-8 h-2 w-20 rounded bg-black/12" />
+        <div className="absolute right-10 top-14 h-2 w-14 rounded bg-black/10" />
+        <div className="absolute right-10 top-20 h-2 w-18 rounded bg-black/8" />
+      </div>
+    ),
+  },
+  {
+    gradient: "bg-gradient-to-br from-[#11141a] via-[#1b2028] to-[#0d0f14]",
+    shapes: (
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 opacity-80 [background-image:radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.25)_1px,transparent_0)] [background-size:8px_8px]" />
+        <div className="absolute left-8 top-8 h-12 w-28 rounded-md bg-[#1a1f28]/95 shadow-lg" />
+        <div className="absolute left-8 top-24 h-12 w-28 rounded-md bg-[#1a1f28]/95 shadow-lg" />
+        <div className="absolute right-6 top-6 h-32 w-24 rounded-lg border border-db-lava/30 bg-[#0e1116]/90" />
+        <div className="absolute right-10 top-12 h-2 w-16 rounded bg-db-lava/40" />
+        <div className="absolute right-10 top-18 h-2 w-12 rounded bg-white/15" />
+        <div className="absolute right-10 top-24 h-2 w-14 rounded bg-white/10" />
       </div>
     ),
   },

--- a/tests/e2e/pages.spec.ts
+++ b/tests/e2e/pages.spec.ts
@@ -15,6 +15,15 @@ const PAGES = [
   { path: "/resources", title: "Resources" },
   { path: "/resources/base-app-template", title: "Base App Template" },
   { path: "/resources/ai-chat-app-template", title: "AI Chat App Template" },
+  { path: "/resources/data-app-template", title: "Data App Template" },
+  {
+    path: "/resources/analytics-dashboard-app-template",
+    title: "Analytics Dashboard App Template",
+  },
+  {
+    path: "/resources/ai-data-explorer-template",
+    title: "AI Data Explorer Template",
+  },
   {
     path: "/docs/get-started/getting-started",
     title: "Getting Started",

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -34,6 +34,9 @@ describe("production build smoke tests", () => {
       "/resources",
       "/resources/base-app-template",
       "/resources/ai-chat-app-template",
+      "/resources/data-app-template",
+      "/resources/analytics-dashboard-app-template",
+      "/resources/ai-data-explorer-template",
     ];
 
     for (const path of expectedTemplates) {


### PR DESCRIPTION
## Summary

- **3 new recipes** extracted from `databricks/appkit` example apps:
  - **Lakebase Data Persistence** — managed Postgres CRUD with schema setup, table creation, and full REST API routes via `appkit.lakebase.query()`
  - **Genie Conversational Analytics** — embed a Databricks AI/BI Genie chat interface for natural-language data exploration via `GenieChat`
  - **SQL Analytics Dashboard** — build parameterized dashboards using file-based SQL queries, `useAnalyticsQuery`, and chart components (`AreaChart`, `LineChart`, `BarChart`)

- **3 new templates (cookbooks)** that compose recipes into end-to-end setups:
  - **Data App Template** = Bootstrap + Lakebase (simplest data-persistent app)
  - **Analytics Dashboard App Template** = Bootstrap + Lakebase + SQL Analytics (data app with interactive dashboards)
  - **AI Data Explorer Template** = Bootstrap + Lakebase + AI Chat + Genie (full-stack data app with conversational analytics)

- **New card visuals** for the resources page — database-themed and chart-themed CSS shapes for the new template cards

- **E2e tests** added for all 3 new template pages

## Test plan

- [x] `bun run build` passes
- [x] All 80 Playwright e2e tests pass (77 existing + 3 new pages)
- [ ] Visual review of new template cards on `/resources`
- [ ] Visual review of landing page showing 3 templates (Base App, AI Chat App, Data App)
- [ ] Walk through each new template detail page to verify steps render correctly with code snippets