### PR TITLE
Fix recipes based on real deployment testing

### DIFF
--- a/src/pages/resources/_recipes/ai-chat-model-serving.mdx
+++ b/src/pages/resources/_recipes/ai-chat-model-serving.mdx
@@ -4,7 +4,7 @@ Build a streaming chat app powered by Databricks AI Gateway (model serving). Use
 
 ### 1. Identify your model serving endpoint
 
-List available serving endpoints in your workspace. Pick the endpoint name you want to use for chat (e.g. a foundation model endpoint or a custom model endpoint).
+List available serving endpoints in your workspace. Pick the endpoint name you want to use for chat (e.g. a foundation model endpoint like `databricks-claude-haiku-4-5` or a custom model endpoint).
 
 ```bash
 databricks serving-endpoints list --profile <PROFILE> -o json
@@ -32,11 +32,23 @@ bunx shadcn@latest add @ai-elements/all
 
 `DATABRICKS_HOST` is your workspace URL. `DATABRICKS_TOKEN` is a personal access token or service principal token. `DATABRICKS_SERVING_ENDPOINT` is the name of the model serving endpoint you identified in step 1.
 
+For local development, add these to `.env`:
+
 ```bash
 echo 'DATABRICKS_HOST=https://<workspace>.cloud.databricks.com
 DATABRICKS_TOKEN=<your-token>
 DATABRICKS_SERVING_ENDPOINT=<endpoint-name>' >> .env
 ```
+
+For deployment, add the environment variables to `app.yaml`:
+
+```yaml
+env:
+  - name: DATABRICKS_SERVING_ENDPOINT
+    value: "<endpoint-name>"
+```
+
+The app has access to the workspace host and token automatically at runtime.
 
 ### 5. Create the Databricks AI provider
 
@@ -112,13 +124,13 @@ export function ChatPage() {
 }
 ```
 
-### 8. Run and test locally
-
-Open the chat page in your browser and send a message. Responses stream from your Databricks model serving endpoint through the AI SDK.
+### 8. Deploy and test
 
 ```bash
-bun run dev
+databricks apps deploy --profile <PROFILE>
 ```
+
+Open the chat page in your browser and send a message. Responses stream from your Databricks model serving endpoint through the AI SDK.
 
 #### References
 

--- a/src/pages/resources/_recipes/databricks-local-bootstrap.mdx
+++ b/src/pages/resources/_recipes/databricks-local-bootstrap.mdx
@@ -32,12 +32,17 @@ Always run workspace commands with `--profile <PROFILE>`.
 databricks auth profiles
 ```
 
-### 5. Scaffold a new Databricks app folder
+### 5. Scaffold a new Databricks app
 
-This creates a new workspace folder for app development and skips auto-run so code can be reviewed first.
+Use `--version latest` to get the latest AppKit template with all available plugins (lakebase, genie, analytics). Add `--features` to enable specific plugins.
 
 ```bash
-databricks apps init --name <app-name> --description "<desc>" --run none --profile <PROFILE>
+databricks apps init \
+  --name <app-name> \
+  --description "<desc>" \
+  --version latest \
+  --run none \
+  --profile <PROFILE>
 ```
 
 ### 6. Install Databricks agent skills
@@ -53,6 +58,16 @@ npx skills add databricks/databricks-agent-skills --all
 ```bash
 npx skills list
 ```
+
+### 8. Deploy your app
+
+Deploy the scaffolded app to your Databricks workspace:
+
+```bash
+databricks apps deploy --profile <PROFILE>
+```
+
+The CLI validates, builds, uploads, and starts your app. Once deployed, it prints the app URL.
 
 #### References
 

--- a/src/pages/resources/_recipes/genie-conversational-analytics.mdx
+++ b/src/pages/resources/_recipes/genie-conversational-analytics.mdx
@@ -6,17 +6,38 @@ Embed a Databricks AI/BI Genie chat interface so users can explore data through 
 
 Open your Databricks workspace, navigate to AI/BI Genie, and create a new Genie space connected to your data tables. Copy the space ID from the URL — you will need it for configuration.
 
-### 2. Set the Genie space environment variable
+### 2. Scaffold with the Genie feature
 
-Add your Genie space ID to the environment. The Genie plugin reads this value to connect to the right space.
+When scaffolding your app, enable the `genie` feature and provide the space ID:
+
+```bash
+databricks apps init \
+  --name <app-name> \
+  --version latest \
+  --features=genie \
+  --set 'genie.genie-space.id=<your-space-id>' \
+  --run none --profile <PROFILE>
+```
+
+### 3. Configure the Genie space environment variable
+
+For local development, add the space ID to `.env`:
 
 ```bash
 echo 'DATABRICKS_GENIE_SPACE_ID=<your-space-id>' >> .env
 ```
 
-### 3. Enable the Genie plugin
+For deployment, add it to `app.yaml`:
 
-Add the genie plugin to your server entry point:
+```yaml
+env:
+  - name: DATABRICKS_GENIE_SPACE_ID
+    value: "<your-space-id>"
+```
+
+### 4. Enable the Genie plugin
+
+The scaffolded server entry point includes the genie plugin. If adding to an existing app:
 
 ```typescript
 import { createApp, server, genie } from "@databricks/appkit";
@@ -29,7 +50,7 @@ createApp({
 }).catch(console.error);
 ```
 
-### 4. Add the GenieChat component to a page
+### 5. Add the GenieChat component to a page
 
 Import `GenieChat` from `@databricks/appkit-ui` and render it in a container:
 
@@ -45,13 +66,13 @@ export function GeniePage() {
 }
 ```
 
-### 5. Run and test locally
-
-Open the Genie page in your browser and ask a natural-language question about your data to verify the integration.
+### 6. Deploy and test
 
 ```bash
-bun run dev
+databricks apps deploy --profile <PROFILE>
 ```
+
+Open the Genie page in your browser and ask a natural-language question about your data to verify the integration.
 
 #### References
 

--- a/src/pages/resources/_recipes/lakebase-data-persistence.mdx
+++ b/src/pages/resources/_recipes/lakebase-data-persistence.mdx
@@ -1,23 +1,79 @@
 ## Lakebase Data Persistence
 
-Add a managed Postgres database to your Databricks app using the Lakebase plugin. Covers schema setup, table creation, and full CRUD REST API routes.
+Add a managed Postgres database to your Databricks app using the Lakebase plugin. Covers Lakebase project creation, schema setup, table creation, and full CRUD REST API routes.
 
-### 1. Enable the Lakebase plugin
+### 1. Create a Lakebase project
 
-Add the lakebase plugin to your server entry point. Use `autoStart: false` on the server plugin so you can run database setup before accepting requests:
+Create a new Lakebase Postgres project. This provisions a managed Postgres cluster with a default branch and endpoint:
+
+```bash
+databricks postgres create-project <project-name> --profile <PROFILE>
+```
+
+Verify the project, branch, and endpoint were created:
+
+```bash
+databricks postgres list-branches projects/<project-name> --profile <PROFILE> -o json
+databricks postgres list-endpoints projects/<project-name>/branches/production --profile <PROFILE> -o json
+```
+
+Note the endpoint host from the output — you will need it for configuration.
+
+### 2. Scaffold with the Lakebase feature
+
+When scaffolding your app, enable the `lakebase` feature and provide the Postgres connection details:
+
+```bash
+databricks apps init \
+  --name <app-name> \
+  --version latest \
+  --features=lakebase \
+  --set 'lakebase.postgres.branch=projects/<project-name>/branches/production' \
+  --set 'lakebase.postgres.database=projects/<project-name>/branches/production/databases/<db-name>' \
+  --set 'lakebase.postgres.host=<endpoint-host>' \
+  --set 'lakebase.postgres.databaseName=<db-name>' \
+  --set 'lakebase.postgres.endpointPath=projects/<project-name>/branches/production/endpoints/primary' \
+  --set 'lakebase.postgres.port=5432' \
+  --set 'lakebase.postgres.sslmode=require' \
+  --run none --profile <PROFILE>
+```
+
+### 3. Configure app.yaml for deployment
+
+The Lakebase connection is configured via environment variables in `app.yaml`. Update it with your endpoint details:
+
+```yaml
+command: ["npm", "run", "start"]
+env:
+  - name: PGHOST
+    value: "<endpoint-host>"
+  - name: PGPORT
+    value: "5432"
+  - name: PGDATABASE
+    value: "databricks_postgres"
+  - name: PGSSLMODE
+    value: "require"
+  - name: LAKEBASE_ENDPOINT
+    value: "projects/<project-name>/branches/production/endpoints/primary"
+```
+
+### 4. Enable the Lakebase plugin
+
+The scaffolded server entry point includes the lakebase plugin. Use `autoStart: false` on the server plugin so you can run database setup before accepting requests:
 
 ```typescript
 import { createApp, server, lakebase } from "@databricks/appkit";
 
 createApp({ plugins: [server({ autoStart: false }), lakebase()] })
   .then(async (appkit) => {
-    // setup routes then start
+    await setupSchema(appkit);
+    registerRoutes(appkit);
     await appkit.server.start();
   })
   .catch(console.error);
 ```
 
-### 2. Define your database schema
+### 5. Define your database schema
 
 Create a schema and table using raw SQL. Lakebase provides a Postgres-compatible interface through `appkit.lakebase.query()`:
 
@@ -37,7 +93,7 @@ await appkit.lakebase.query(SETUP_SCHEMA);
 await appkit.lakebase.query(CREATE_TABLE);
 ```
 
-### 3. Create CRUD API routes
+### 6. Create CRUD API routes
 
 Use `appkit.server.extend()` to register Express routes that call `appkit.lakebase.query()` with parameterized SQL:
 
@@ -75,35 +131,20 @@ appkit.server.extend((app) => {
 });
 ```
 
-### 4. Wire up schema setup and start the server
-
-Run the schema setup before registering routes and starting the server:
-
-```typescript
-createApp({ plugins: [server({ autoStart: false }), lakebase()] })
-  .then(async (appkit) => {
-    await appkit.lakebase.query(SETUP_SCHEMA);
-    await appkit.lakebase.query(CREATE_TABLE);
-    registerRoutes(appkit);
-    await appkit.server.start();
-  })
-  .catch(console.error);
-```
-
-### 5. Run and test locally
-
-Verify the endpoints with curl:
+### 7. Deploy and test
 
 ```bash
-bun run dev
+databricks apps deploy --profile <PROFILE>
 ```
 
+Verify the endpoints with curl once the app is running:
+
 ```bash
-curl -X POST http://localhost:3000/api/items \
+curl -X POST https://<app-url>/api/items \
   -H 'Content-Type: application/json' \
   -d '{"title":"My first item"}'
 
-curl http://localhost:3000/api/items
+curl https://<app-url>/api/items
 ```
 
 #### References

--- a/src/pages/resources/_recipes/sql-analytics-dashboard.mdx
+++ b/src/pages/resources/_recipes/sql-analytics-dashboard.mdx
@@ -2,19 +2,32 @@
 
 Build interactive dashboards with parameterized SQL queries and chart components. Uses the Analytics plugin for SQL Warehouse queries and AppKit UI for visualizations.
 
-### 1. Enable the Analytics plugin
+### 1. Identify your SQL Warehouse
 
-Add the analytics plugin to your server entry point:
+List available SQL Warehouses in your workspace:
 
-```typescript
-import { createApp, server, analytics } from "@databricks/appkit";
-
-createApp({
-  plugins: [server(), analytics()],
-}).catch(console.error);
+```bash
+databricks warehouses list --profile <PROFILE> -o json
 ```
 
-### 2. Create parameterized SQL query files
+Note the warehouse `id` — you will need it for configuration.
+
+### 2. Scaffold with the Analytics feature
+
+When scaffolding your app, enable the `analytics` feature and provide the SQL Warehouse ID:
+
+```bash
+databricks apps init \
+  --name <app-name> \
+  --version latest \
+  --features=analytics \
+  --set 'analytics.sql-warehouse.id=<warehouse-id>' \
+  --run none --profile <PROFILE>
+```
+
+The scaffold creates a `databricks.yml` with an `sql_warehouse` resource and sample SQL query files under `config/queries/`.
+
+### 3. Create parameterized SQL query files
 
 Add `.sql` files under `config/queries/`. Use `:param_name` for parameters and `@param` annotations for type safety:
 
@@ -27,7 +40,7 @@ WHERE month_num <= :max_month_num
 ORDER BY month_num;
 ```
 
-### 3. Build the dashboard UI with charts
+### 4. Build the dashboard UI with charts
 
 Import `useAnalyticsQuery` for data fetching and chart components for visualization:
 
@@ -72,7 +85,7 @@ export function DashboardPage() {
 }
 ```
 
-### 4. Add interactive filters with typed parameters
+### 5. Add interactive filters with typed parameters
 
 Use `sql.string()` and `sql.number()` helpers for type-safe query parameters. Bind them to UI controls like `Select` or `Input` to let users filter the dashboard interactively:
 
@@ -83,13 +96,13 @@ const params = {
 };
 ```
 
-### 5. Run and test locally
-
-Open the dashboard page and verify that charts render with data from your SQL Warehouse. Adjust filters to see the queries update.
+### 6. Deploy and test
 
 ```bash
-bun run dev
+databricks apps deploy --profile <PROFILE>
 ```
+
+Open the dashboard page and verify that charts render with data from your SQL Warehouse. Adjust filters to see the queries update.
 
 #### References
 


### PR DESCRIPTION
## Summary

Updates all 5 recipe MDX files based on actually deploying each template to a live Databricks workspace and verifying the apps run successfully.

- **Bootstrap**: Added `--version latest` flag (required for lakebase/genie features), added deploy step
- **Lakebase**: Added Lakebase project creation via CLI, `app.yaml` env var configuration for deployment, full scaffold command with all `--set` flags
- **AI Chat**: Added `app.yaml` deployment config, noted workspace auto-injects host/token at runtime
- **Genie**: Added scaffold command with `--features=genie`, `app.yaml` config for space ID
- **Analytics**: Added `databricks warehouses list` CLI step, scaffold with `--features=analytics` and warehouse ID

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run fmt` applied
- [x] `bun run build` passes
- [x] All 80 tests pass (14 smoke + 66 e2e + static assets)
- [x] All 5 templates deployed and verified running on dbc-df6b51a2-a992