### PR TITLE
Add Lakebase recipe docs

### DIFF
--- a/recipes/etl-lakehouse-sync-autoscaling.md
+++ b/recipes/etl-lakehouse-sync-autoscaling.md
@@ -1,0 +1,180 @@
+# ETL: Sync Lakebase Tables to Unity Catalog (Autoscaling — Lakehouse Sync)
+
+Replicate your Lakebase Autoscaling Postgres tables into Unity Catalog as managed Delta tables. **Lakehouse Sync** captures every row-level change using CDC and writes them as **SCD Type 2 history** — giving you a full audit trail of how your operational data changed over time, queryable from the lakehouse.
+
+> This recipe is for **Lakebase Autoscaling** (projects/branches/endpoints with scale-to-zero). For Lakebase Provisioned, see the [Provisioned ETL recipe](./etl-register-uc-provisioned.md).
+
+## When to use this
+
+- You want to analyze operational data (orders, user activity, support tickets) in the lakehouse
+- You need a historical record of every insert, update, and delete from your Postgres tables
+- You want to join operational data with analytics data in Spark, SQL, or BI tools
+- You need to feed Lakebase data into downstream pipelines or ML models
+
+## Prerequisites
+
+- A Databricks workspace with Lakebase enabled (**AWS only** — Lakehouse Sync Beta is not yet available on Azure)
+- A **Lakebase Autoscaling project** with at least one branch containing tables with data
+- The Lakebase database must be **registered in Unity Catalog** ([register it](https://docs.databricks.com/aws/en/oltp/projects/register-uc))
+- Tables you want to sync must have a **primary key** or `REPLICA IDENTITY FULL` set
+
+> **Note:** Lakehouse Sync is currently in **Beta on AWS only** (all Autoscaling regions). Azure support is not yet available. It is a native Lakebase feature — no external compute, pipelines, or jobs required, and there is no incremental charge for replication beyond the underlying Lakebase compute and storage costs.
+
+## How it works
+
+Lakehouse Sync uses Change Data Capture (CDC) to stream changes from Lakebase Postgres into Unity Catalog. For each synced table, a Delta history table is created:
+
+```
+lb_<table_name>_history
+```
+
+Each row includes metadata columns:
+- `_change_type` — `insert`, `update_preimage`, `update_postimage`, or `delete`
+- `_lsn` — Log Sequence Number for ordering changes
+- `_commit_timestamp` — When the change was captured
+
+## Step 1 — Verify table replica identity
+
+Lakehouse Sync requires the right replica identity for capturing changes. Connect to your Lakebase database and check:
+
+```sql
+SELECT n.nspname AS table_schema,
+       c.relname AS table_name,
+       CASE c.relreplident
+         WHEN 'd' THEN 'default'
+         WHEN 'n' THEN 'nothing'
+         WHEN 'f' THEN 'full'
+         WHEN 'i' THEN 'index'
+       END AS replica_identity
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'r'
+  AND n.nspname = 'public'
+ORDER BY n.nspname, c.relname;
+```
+
+If a table shows `default` or `nothing`, set it to `FULL`:
+
+```sql
+ALTER TABLE <table_name> REPLICA IDENTITY FULL;
+```
+
+## Step 2 — Check for unsupported data types
+
+```sql
+SELECT c.table_schema, c.table_name, c.column_name, c.udt_name AS data_type
+FROM information_schema.columns c
+JOIN pg_catalog.pg_type t ON t.typname = c.udt_name
+WHERE c.table_schema = 'public'
+  AND c.table_name IN (
+    SELECT tablename FROM pg_tables WHERE schemaname = c.table_schema
+  )
+  AND NOT (
+    c.udt_name IN (
+      'bool', 'int2', 'int4', 'int8', 'text', 'varchar', 'bpchar',
+      'jsonb', 'numeric', 'date', 'timestamp', 'timestamptz',
+      'real', 'float4', 'float8'
+    )
+    OR t.typcategory = 'E'
+  )
+ORDER BY c.table_schema, c.table_name, c.ordinal_position;
+```
+
+If unsupported types appear, restructure those columns before enabling sync.
+
+## Step 3 — Enable Lakehouse Sync
+
+> **Note:** Lakehouse Sync is configured through the Databricks UI. There is no CLI or REST API support for enabling it yet.
+
+1. Navigate to **Catalog** in the workspace sidebar
+2. Open your **Lakebase Autoscaling project** and select the **branch**
+3. Click **Lakehouse Sync**
+4. Click **Start Sync**
+5. Select the **source Postgres database and schema**
+6. Select the **destination Unity Catalog catalog and schema**
+7. Choose which **tables** to sync
+8. Click **Start**
+
+## Step 4 — Monitor sync status
+
+Check active syncs from Postgres:
+
+```sql
+SELECT * FROM wal2delta.tables;
+```
+
+In the Databricks UI, the **Lakehouse Sync** tab on your branch shows sync status, lag, and errors.
+
+## Step 5 — Query the history tables
+
+### Latest state of each row
+
+```sql
+SELECT *
+FROM (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY id ORDER BY _lsn DESC) AS rn
+  FROM <catalog>.<schema>.lb_<table_name>_history
+  WHERE _change_type IN ('insert', 'update_postimage', 'delete')
+)
+WHERE rn = 1
+  AND _change_type != 'delete';
+```
+
+### Full change history for a record
+
+```sql
+SELECT *
+FROM <catalog>.<schema>.lb_<table_name>_history
+WHERE id = 12345
+ORDER BY _lsn;
+```
+
+## Handling schema changes
+
+If you need to change a synced table's schema in Postgres, use the rename-and-swap pattern:
+
+```sql
+CREATE TABLE users_v2 (
+  id INT PRIMARY KEY,
+  name TEXT,
+  new_column TEXT
+);
+
+ALTER TABLE users_v2 REPLICA IDENTITY FULL;
+
+INSERT INTO users_v2 SELECT *, NULL FROM users;
+
+BEGIN;
+ALTER TABLE users RENAME TO users_backup;
+ALTER TABLE users_v2 RENAME TO users;
+COMMIT;
+```
+
+## What you end up with
+
+- **Delta history tables** in Unity Catalog (`lb_<table_name>_history`) with full SCD Type 2 change tracking
+- **Continuous replication** — changes stream from Postgres to Delta automatically
+- **No external compute** — Lakehouse Sync is a native Lakebase feature
+- Operational data queryable in Spark SQL, notebooks, BI tools, and downstream pipelines
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Table not appearing in sync | Ensure it has a primary key or `REPLICA IDENTITY FULL` |
+| Unsupported data type error | Check column types with the query in Step 2 |
+| Sync lag increasing | Check Lakebase endpoint health and compute scaling |
+| Missing changes on update/delete | Verify `REPLICA IDENTITY FULL` — `default` only captures PK columns |
+
+## Limitations
+
+- **AWS only** — Lakehouse Sync Beta is available in all Autoscaling regions on AWS. Azure support is not yet available.
+- **No incremental charge** — replication cost is included in your Lakebase compute and storage.
+- **Works alongside synced tables** — you can use Lakehouse Sync in a project/schema that also has Reverse ETL synced tables.
+
+## Learn more
+
+- [Lakehouse Sync (Autoscaling)](https://docs.databricks.com/aws/en/oltp/projects/lakehouse-sync)
+- [Register Lakebase in Unity Catalog](https://docs.databricks.com/aws/en/oltp/projects/register-uc)
+- [SCD Type 2 in Databricks](https://docs.databricks.com/aws/en/ingestion/lakeflow-connect/scd)

--- a/recipes/etl-register-uc-provisioned.md
+++ b/recipes/etl-register-uc-provisioned.md
@@ -1,0 +1,152 @@
+# ETL: Access Lakebase Data from Unity Catalog (Provisioned — Database Catalog)
+
+Register your Lakebase Provisioned database as a **read-only Unity Catalog catalog** so you can query operational data from the lakehouse, join it with analytics tables, and feed it into dashboards, pipelines, and ML models — all through standard SQL.
+
+> This recipe is for **Lakebase Provisioned** (manually scaled instances). For Lakebase Autoscaling (projects with scale-to-zero and native CDC replication), see the [Autoscaling ETL recipe](./etl-lakehouse-sync-autoscaling.md).
+>
+> **Note:** New Lakebase instances are created as Autoscaling projects by default as of March 12, 2026. If you're starting fresh, consider using Autoscaling with Lakehouse Sync for full CDC-based replication.
+
+## When to use this
+
+- You want to query Lakebase operational data from Spark SQL, notebooks, or BI tools
+- You need to join Lakebase tables with lakehouse data (federated queries)
+- You want Unity Catalog governance (permissions, lineage, audit logs) on your Lakebase data
+- You want to browse Lakebase schemas and tables in Catalog Explorer
+
+## How it differs from Autoscaling Lakehouse Sync
+
+| | Provisioned (this recipe) | Autoscaling (Lakehouse Sync) |
+|---|---|---|
+| **Mechanism** | Registers Postgres as a read-only UC catalog; queries go to Postgres via federation | Native CDC replication into Delta tables (SCD Type 2 history) |
+| **Data location** | Data stays in Postgres; queries are federated | Data is copied into Delta tables in Unity Catalog |
+| **History tracking** | No change history — queries reflect current Postgres state | Full SCD Type 2 change history |
+| **Compute** | Requires a serverless SQL warehouse for queries | No external compute — native Lakebase feature |
+| **Latency** | Real-time (reads from live Postgres) | Near real-time (CDC streaming lag) |
+
+> **Note on Lakeflow Connect Plugin:** Provisioned previously had a Lakeflow Connect Plugin for Lakebase (Private Preview) that provided CDC-based replication similar to Lakehouse Sync. This plugin will **not** be taken to Public Preview or GA. If you need CDC replication from Lakebase to Unity Catalog, migrate to Autoscaling and use native Lakehouse Sync.
+
+## Prerequisites
+
+- A Databricks workspace with Lakebase enabled
+- A **Lakebase Provisioned instance** with at least one database
+- `CREATE CATALOG` privileges on the Unity Catalog metastore
+- A **serverless SQL warehouse** (required to query the registered catalog)
+
+## Step 1 — Register the database in Unity Catalog
+
+### Via CLI
+
+```bash
+databricks database create-database-catalog <CATALOG_NAME> <INSTANCE_NAME> <DATABASE_NAME> --profile <PROFILE>
+```
+
+| Placeholder | Value |
+|-------------|-------|
+| `<CATALOG_NAME>` | Name for the new Unity Catalog catalog |
+| `<INSTANCE_NAME>` | Your Lakebase Provisioned instance name |
+| `<DATABASE_NAME>` | Postgres database to register (e.g., `databricks_postgres`) |
+
+If the database doesn't exist yet, add `--create-database-if-not-exists`.
+
+### Via UI
+
+1. Click **Apps** in the top right → select **Lakebase Postgres**
+2. Click **Provisioned** → select your instance
+3. Go to **Catalogs** → click **Add catalog**
+4. Enter a **Catalog name** and select the **Postgres database** (or enter a new name to create one)
+5. Click **Create**
+
+### Via REST API
+
+```
+POST /api/2.0/database/catalogs
+```
+
+```json
+{
+  "name": "<CATALOG_NAME>",
+  "database_instance_name": "<INSTANCE_NAME>",
+  "database_name": "<DATABASE_NAME>"
+}
+```
+
+## Step 2 — Verify registration
+
+```bash
+databricks database get-database-catalog <CATALOG_NAME> --profile <PROFILE>
+```
+
+Then browse to **Catalog** in the workspace sidebar — your Lakebase catalog should appear alongside other UC catalogs.
+
+## Step 3 — Query your Lakebase data
+
+Make sure you have a serverless SQL warehouse running as your compute resource. Then query directly:
+
+```sql
+-- Query a Lakebase table through Unity Catalog
+SELECT * FROM <catalog_name>.<schema>.<table>
+WHERE created_at > current_date - INTERVAL 7 DAYS;
+```
+
+```sql
+-- Join Lakebase operational data with lakehouse analytics
+SELECT
+  o.order_id,
+  o.status,
+  o.total_amount,
+  c.lifetime_value,
+  c.segment
+FROM <catalog_name>.public.orders o
+JOIN analytics.gold.customers c
+  ON o.customer_id = c.customer_id
+WHERE o.created_at > current_date - INTERVAL 30 DAYS;
+```
+
+## Step 4 — Manage access
+
+Grant read access to teams:
+
+```sql
+GRANT USE CATALOG ON CATALOG <catalog_name> TO `<group_name>`;
+GRANT SELECT ON CATALOG <catalog_name> TO `<group_name>`;
+```
+
+## Delete the catalog
+
+```bash
+databricks database delete-database-catalog <CATALOG_NAME> --profile <PROFILE>
+```
+
+> Delete all synced tables from the catalog first. Each source table supports max 20 synced tables, and pending deletions count toward this limit (cleanup can take up to 3 days).
+
+## What you end up with
+
+- A **read-only Unity Catalog catalog** mirroring your Lakebase database structure
+- **Federated queries** — query Lakebase data from Spark SQL alongside lakehouse tables
+- **Unity Catalog governance** — permissions, lineage, and audit on Lakebase data
+- **Catalog Explorer** — browse Lakebase schemas, tables, and views alongside other data sources
+
+## Limitations
+
+- The catalog is **read-only** — modify data through Lakebase directly
+- One catalog per Postgres database — register each database separately
+- Metadata is cached — click refresh in Catalog Explorer to see new objects
+- Database instances are **single-workspace scoped** — no cross-workspace access to table contents
+- Database names can only contain alphanumeric characters and underscores (no hyphens)
+- **No CDC replication** — unlike Autoscaling's Lakehouse Sync, this approach does not replicate data or track change history; queries are federated to live Postgres
+- **Lakeflow Connect Plugin (deprecated path)** — the Private Preview plugin for Provisioned CDC will not go to GA; migrate to Autoscaling for CDC-based ETL
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Catalog not appearing | Ensure you have `CREATE CATALOG` metastore privileges |
+| Tables not visible | Attach a serverless SQL warehouse and refresh the catalog view |
+| Query errors | Confirm the SQL warehouse is running and can reach the instance |
+| Permission denied | Grant `USE CATALOG` + `SELECT` to the querying user/group |
+
+## Learn more
+
+- [Register your database in Unity Catalog (Provisioned)](https://docs.databricks.com/aws/en/oltp/instances/register-uc)
+- [Database Instances CLI](https://docs.databricks.com/aws/en/dev-tools/cli/reference/database-commands)
+- [Upgrade to Autoscaling](https://docs.databricks.com/aws/en/oltp/upgrade-to-autoscaling)

--- a/recipes/reverse-etl-synced-tables-autoscaling.md
+++ b/recipes/reverse-etl-synced-tables-autoscaling.md
@@ -1,0 +1,184 @@
+# Reverse ETL: Sync a Unity Catalog Table to Lakebase (Autoscaling)
+
+Serve lakehouse data through Lakebase Autoscaling Postgres so your applications can query it with sub-10ms latency. This creates a **synced table** — a managed copy of your Unity Catalog table in Lakebase that stays up to date automatically.
+
+> This recipe is for **Lakebase Autoscaling** (projects/branches/endpoints with scale-to-zero). For Lakebase Provisioned (manually scaled instances), see the [Provisioned Reverse ETL recipe](./reverse-etl-synced-tables-provisioned.md).
+
+## When to use this
+
+- Your app needs fast lookup-style queries against analytics data (user profiles, feature values, risk scores)
+- You want to serve gold tables, ML outputs, or enriched records through a standard Postgres connection
+- You need ACID transactions and sub-10ms reads alongside your operational state
+
+## Prerequisites
+
+- A Databricks workspace with Lakebase enabled
+- A **Lakebase Autoscaling project** with a branch and endpoint ([create one](https://docs.databricks.com/aws/en/oltp/projects/manage-projects#create-projects), or use `databricks postgres create-project`)
+- A **Unity Catalog table** to sync (Delta, Iceberg, view, or materialized view)
+- The source table must have a **primary key** (mandatory for all synced tables)
+- Permissions: `USE_SCHEMA` and `CREATE_TABLE` on the schema where the synced table will be created
+
+**Available regions:**
+- **AWS**: us-east-1, us-east-2, us-west-2, ca-central-1, sa-east-1, eu-central-1, eu-west-1, eu-west-2, ap-south-1, ap-southeast-1, ap-southeast-2
+- **Azure** (GA March 2026): australiaeast, brazilsouth, canadacentral, centralindia, centralus, eastus, northeurope, southcentralus, southeastasia, uksouth, westus2
+
+## Choose a sync mode
+
+| Mode | Behavior | Best for |
+|------|----------|----------|
+| **Snapshot** | One-time full copy | Source changes >10% of rows per cycle, or source doesn't support CDF (views, Iceberg) |
+| **Triggered** | Incremental updates on demand or on a schedule | Known cadence of changes, good cost/freshness balance |
+| **Continuous** | Real-time streaming (seconds of latency) | Changes must appear in Lakebase near-instantly |
+
+> **Triggered** and **Continuous** modes require [Change Data Feed (CDF)](https://docs.databricks.com/aws/en/delta/delta-change-data-feed) enabled on the source table. If it's not enabled, run:
+>
+> ```sql
+> ALTER TABLE <catalog>.<schema>.<table> SET TBLPROPERTIES (delta.enableChangeDataFeed = true);
+> ```
+
+## Sync throughput
+
+Autoscaling CUs are physically 8x smaller than Provisioned CUs, so per-CU throughput differs:
+
+| Mode | Rows/sec per CU |
+|------|-----------------|
+| **Snapshot** (initial + full refresh) | ~2,000 |
+| **Triggered / Continuous** (incremental) | ~150 |
+
+> A 10x speedup for large-table snapshot sync (writing Postgres pages directly, leveraging separation of storage and compute) is coming for Autoscaling only.
+
+## Create a synced table
+
+### Option A: Create via UI
+
+1. Go to **Catalog** in the workspace sidebar → select the source Unity Catalog table
+2. Click **Create synced table**
+3. Verify the **Primary key** (usually auto-detected)
+4. Select your Lakebase **project**, **branch**, and **database**
+5. Set **Database type** to **Lakebase Serverless (Autoscaling)**
+6. Set **Sync mode** to Snapshot, Triggered, or Continuous
+7. Enter a **Table name** for the synced table
+8. Choose whether to create a **new pipeline** or **reuse an existing one** (see pipeline guidance below)
+9. Click **Create**
+
+The synced table appears in Catalog. The **Overview** tab shows sync status, pipeline health, and last sync timestamp. Use **Sync now** for manual refresh.
+
+### Option B: Create via `/database/` API (hybrid instances)
+
+> As of March 12, 2026, new Lakebase instances created via the `/database/` API default to the Autoscaling platform. These **hybrid instances** can be managed via both `/database/` and `/postgres/` APIs. The native `/postgres/` API does not yet support synced table endpoints, but the `/database/` API works for these hybrid instances.
+
+```bash
+databricks database create-synced-database-table \
+  --json '{
+    "name": "<CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME>",
+    "database_instance_name": "<INSTANCE_NAME>",
+    "logical_database_name": "<POSTGRES_DATABASE>",
+    "spec": {
+      "source_table_full_name": "<CATALOG>.<SCHEMA>.<SOURCE_TABLE>",
+      "primary_key_columns": ["<PRIMARY_KEY_COLUMN>"],
+      "scheduling_policy": "<SNAPSHOT|TRIGGERED|CONTINUOUS>",
+      "create_database_objects_if_missing": true
+    }
+  }' --profile <PROFILE>
+```
+
+> If your Lakebase database is **registered as a Unity Catalog catalog**, you can omit `database_instance_name` and `logical_database_name`.
+
+Verify:
+
+```bash
+databricks database get-synced-database-table <CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME> --profile <PROFILE>
+```
+
+> **Important:** If your Autoscaling project was created via the `/postgres/` API (not `/database/`), programmatic synced table creation is not yet supported. Use the UI instead. This gap is expected to close soon.
+
+## Pipeline reuse guidance
+
+How you set up pipelines depends on your sync mode:
+
+| Sync mode | Recommendation | Why |
+|-----------|---------------|-----|
+| **Continuous** | **Reuse** a pipeline across ~10 tables | Cost-advantageous — e.g., 1 pipeline for 10 tables ≈ $204/table/month vs $2,044/table/month for individual pipelines |
+| **Snapshot / Triggered** | **Separate** pipelines per table | Allows re-snapshotting individual tables without impacting others |
+
+## Schedule ongoing syncs
+
+The initial snapshot runs automatically on creation. For **Snapshot** and **Triggered** modes, subsequent syncs need to be triggered.
+
+### Option 1: Trigger on source table updates (UI)
+
+1. Go to **Workflows** in the sidebar
+2. Create or open a job
+3. Add a **Database Table Sync pipeline** task
+4. Under **Schedules & Triggers**, add a **Table update** trigger pointing to your source table
+
+### Option 2: Trigger via SDK
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+table = w.database.get_synced_database_table(
+    name="<CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME>"
+)
+pipeline_id = table.data_synchronization_status.pipeline_id
+
+w.pipelines.start_update(pipeline_id=pipeline_id)
+```
+
+## Query the synced data in Postgres
+
+Once synced, the table is available in Lakebase Postgres. The Unity Catalog schema becomes the Postgres schema:
+
+```sql
+SELECT * FROM "<schema>"."<synced_table_name>" WHERE "user_id" = 12345;
+```
+
+Connect with any standard Postgres client (psql, DBeaver, your application's Postgres driver).
+
+## What you end up with
+
+- A **synced table** in Unity Catalog that tracks the sync pipeline
+- A **read-only Postgres table** in Lakebase that your apps can query with sub-10ms latency
+- A **managed Lakeflow pipeline** that keeps the data in sync based on your chosen mode
+- Up to **16 connections** per sync to your Lakebase database
+
+## Important constraints
+
+- **Primary key is mandatory.** Synced tables always require a primary key — it enables efficient point lookups and incremental updates. Rows with nulls in PK columns are excluded from the sync.
+- **Duplicate primary keys fail the sync** unless you configure a `timeseries_key` for deduplication (latest value wins per PK). Using a timeseries key has a performance penalty.
+- **Schema changes**: For Triggered/Continuous mode, only **additive** changes (e.g., adding a column) propagate. Dropping or renaming columns requires recreating the synced table.
+- **FGAC tables**: Direct sync of Fine-Grained Access Control tables fails. **Workaround**: create a view (`SELECT * FROM table`), then sync the view in Snapshot mode. Caveat: runs as the sync creator and only sees their visible rows.
+- **Connection limits**: Autoscaling supports up to 4,000 concurrent connections (varies by compute size). Each sync uses up to 16 connections.
+- **Read-only in Postgres**: Synced tables should only be read from Postgres. Writing to them interferes with the sync pipeline.
+
+## Cost guidance
+
+Cost formula: `[Rows / (Speed × CUs × 3600)] × DLT Hourly Rate`
+
+Example costs (181M rows, 1 CU, $2.80/hr DLT rate):
+
+| Mode | Monthly cost |
+|------|-------------|
+| Snapshot (daily) | ~$2,110 |
+| Triggered (daily, 5% changes) | ~$1,407 |
+| Continuous (10 tables, 1 pipeline) | ~$204/table |
+| Continuous (1 table, 1 pipeline) | ~$2,044 |
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| CDF not enabled warning | Run `ALTER TABLE ... SET TBLPROPERTIES (delta.enableChangeDataFeed = true)` on the source |
+| Schema not visible in create dialog | Confirm you have `USE_SCHEMA` and `CREATE_TABLE` on the target schema |
+| Null bytes in string columns | Clean source data: `SELECT REPLACE(col, CAST(CHAR(0) AS STRING), '') AS col FROM table` |
+| Sync failing | Check the pipeline in the synced table's Overview tab for error details |
+| FGAC table sync fails | Create a view over the table and sync the view in Snapshot mode |
+| Duplicate primary key failure | Add a `timeseries_key` to deduplicate (latest wins) |
+
+## Learn more
+
+- [Synced tables (Autoscaling)](https://docs.databricks.com/aws/en/oltp/projects/sync-tables)
+- [Change Data Feed](https://docs.databricks.com/aws/en/delta/delta-change-data-feed)
+- [Lakebase Autoscaling](https://docs.databricks.com/aws/en/oltp/projects/)

--- a/recipes/reverse-etl-synced-tables-provisioned.md
+++ b/recipes/reverse-etl-synced-tables-provisioned.md
@@ -1,0 +1,202 @@
+# Reverse ETL: Sync a Unity Catalog Table to Lakebase (Provisioned)
+
+Serve lakehouse data through Lakebase Provisioned Postgres so your applications can query it with low latency. This creates a **synced table** — a managed copy of your Unity Catalog table in Lakebase that stays up to date automatically.
+
+> This recipe is for **Lakebase Provisioned** (manually scaled instances with fixed CU capacity). For Lakebase Autoscaling (projects with scale-to-zero), see the [Autoscaling Reverse ETL recipe](./reverse-etl-synced-tables-autoscaling.md).
+>
+> **Note:** New Lakebase instances are created as Autoscaling projects by default as of March 12, 2026. See [Autoscaling by default](https://docs.databricks.com/aws/en/oltp/upgrade-to-autoscaling) for migration details.
+
+## When to use this
+
+- Your app needs fast lookup-style queries against analytics data
+- You want to serve gold tables, ML outputs, or enriched records through a standard Postgres connection
+- You're on Lakebase Provisioned and want full CLI/API automation for synced table creation
+
+## Prerequisites
+
+- A Databricks workspace with Lakebase enabled
+- A **Lakebase Provisioned instance** ([create one](https://docs.databricks.com/aws/en/oltp/instances/instance) or use `databricks database create-database-instance`)
+- `CAN USE` permissions on the database instance
+- A **Unity Catalog table** to sync (Delta, Iceberg, view, or materialized view)
+- Databricks CLI >= v0.205 (for CLI path)
+
+## Choose a sync mode
+
+| Mode | Behavior | Best for | Throughput (per CU) |
+|------|----------|----------|---------------------|
+| **Snapshot** | Full copy each run | Source changes >10% of rows, or no CDF support (views, Iceberg) | ~15,000 rows/sec |
+| **Triggered** | Incremental updates on demand or on a schedule | Known cadence, good cost/freshness balance | ~1,200 rows/sec |
+| **Continuous** | Real-time streaming (min 15-second intervals) | Near real-time freshness required | ~1,200 rows/sec |
+
+> Provisioned CUs are physically 8x larger than Autoscaling CUs, so per-CU throughput is higher.
+
+> **Triggered** and **Continuous** modes require [Change Data Feed (CDF)](https://docs.databricks.com/aws/en/delta/delta-change-data-feed) enabled:
+>
+> ```sql
+> ALTER TABLE <catalog>.<schema>.<table> SET TBLPROPERTIES (delta.enableChangeDataFeed = true);
+> ```
+
+## Option A: Create via CLI
+
+```bash
+databricks database create-synced-database-table \
+  --json '{
+    "name": "<CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME>",
+    "database_instance_name": "<INSTANCE_NAME>",
+    "logical_database_name": "<POSTGRES_DATABASE>",
+    "spec": {
+      "source_table_full_name": "<CATALOG>.<SCHEMA>.<SOURCE_TABLE>",
+      "primary_key_columns": ["<PRIMARY_KEY_COLUMN>"],
+      "scheduling_policy": "<SNAPSHOT|TRIGGERED|CONTINUOUS>",
+      "create_database_objects_if_missing": true
+    }
+  }' --profile <PROFILE>
+```
+
+> If your Lakebase database is already **registered as a Unity Catalog catalog**, you can omit `database_instance_name` and `logical_database_name` — they're inferred from the registered catalog. If you do specify them, they must match the registered catalog's values.
+
+Verify:
+
+```bash
+databricks database get-synced-database-table <CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME> --profile <PROFILE>
+```
+
+The response includes `unity_catalog_provisioning_state` (`PROVISIONING` → `ACTIVE`) and `data_synchronization_status` with pipeline progress.
+
+## Option B: Create via REST API
+
+```
+POST /api/2.0/database/synced_tables
+```
+
+```json
+{
+  "name": "<CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME>",
+  "database_instance_name": "<INSTANCE_NAME>",
+  "logical_database_name": "<POSTGRES_DATABASE>",
+  "spec": {
+    "source_table_full_name": "<CATALOG>.<SCHEMA>.<SOURCE_TABLE>",
+    "primary_key_columns": ["<PRIMARY_KEY_COLUMN>"],
+    "scheduling_policy": "CONTINUOUS",
+    "create_database_objects_if_missing": true,
+    "timeseries_key": "<OPTIONAL_TIMESTAMP_COLUMN>",
+    "new_pipeline_spec": {
+      "budget_policy_id": "<OPTIONAL_BUDGET_POLICY>",
+      "storage_catalog": "<OPTIONAL_STORAGE_CATALOG>",
+      "storage_schema": "<OPTIONAL_STORAGE_SCHEMA>"
+    }
+  }
+}
+```
+
+### Spec fields reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `source_table_full_name` | Yes | Full 3-part name of the source UC table |
+| `primary_key_columns` | Yes | Column(s) that uniquely identify each row |
+| `scheduling_policy` | Yes | `SNAPSHOT`, `TRIGGERED`, or `CONTINUOUS` |
+| `create_database_objects_if_missing` | No | Auto-create Postgres schema/database objects if they don't exist |
+| `timeseries_key` | No | Timestamp column for deduplication when rows share a primary key |
+| `existing_pipeline_id` | No | Reuse an existing Lakeflow pipeline instead of creating a new one |
+| `new_pipeline_spec.budget_policy_id` | No | Budget policy for the managed sync pipeline |
+| `new_pipeline_spec.storage_catalog` | No | Catalog for pipeline staging storage |
+| `new_pipeline_spec.storage_schema` | No | Schema for pipeline staging storage |
+
+## Option C: Create via UI
+
+1. Go to **Catalog** → select the source Unity Catalog table
+2. Click **Create synced table**
+3. Select your **instance**, **Postgres database**, **primary key**, and **sync mode**
+4. Choose new or existing pipeline, optionally set a budget policy
+5. Click **Create**
+
+## Schedule ongoing syncs
+
+The initial snapshot runs automatically. For **Snapshot** and **Triggered** modes, subsequent syncs need to be triggered.
+
+### Trigger on source table updates (Workflows)
+
+1. Go to **Workflows** → create or open a job
+2. Add a **Database Table Sync pipeline** task
+3. Under **Schedules & Triggers**, add a **Table update** trigger pointing to your source table
+
+### Trigger via SDK
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+table = w.database.get_synced_database_table(
+    name="<CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME>"
+)
+pipeline_id = table.data_synchronization_status.pipeline_id
+
+w.pipelines.start_update(pipeline_id=pipeline_id)
+```
+
+## Query the synced data in Postgres
+
+```sql
+SELECT * FROM "<schema>"."<synced_table_name>" WHERE "user_id" = 12345;
+```
+
+Query via the Lakebase SQL editor, psql, DBeaver, notebooks, or your application's Postgres driver.
+
+## Delete a synced table
+
+Deletion is a two-step process:
+
+```bash
+# 1. Delete from Unity Catalog (stops sync pipeline)
+databricks database delete-synced-database-table <CATALOG>.<SCHEMA>.<SYNCED_TABLE_NAME> --profile <PROFILE>
+```
+
+```sql
+-- 2. Drop from Postgres (frees storage)
+DROP TABLE "<database>"."<schema>"."<synced_table_name>";
+```
+
+## Pipeline reuse guidance
+
+| Sync mode | Recommendation | Why |
+|-----------|---------------|-----|
+| **Continuous** | **Reuse** a pipeline across ~10 tables | Cost-advantageous for always-on workloads |
+| **Snapshot / Triggered** | **Separate** pipelines per table | Allows re-snapshotting individual tables without impacting others |
+
+## What you end up with
+
+- A **synced table** in Unity Catalog that tracks the sync pipeline
+- A **read-only Postgres table** in Lakebase queryable by your apps
+- A **managed Lakeflow pipeline** that keeps the data in sync
+- Up to **16 connections** per sync to the database instance
+
+## Important constraints
+
+- **Primary key is mandatory.** Enables efficient point lookups and incremental row-level updates. Rows with nulls in PK columns are excluded.
+- **Duplicate primary keys fail the sync** unless you set a `timeseries_key` for deduplication (performance penalty).
+- **Schema changes**: Triggered/Continuous mode supports only **additive** changes (e.g., new columns). Dropping/renaming columns requires recreating the synced table.
+- **FGAC tables**: Direct sync fails. **Workaround**: create a view (`SELECT * FROM table`), sync in Snapshot mode. Runs as sync creator, only sees their visible rows.
+- **Connection limits**: Provisioned supports up to 1,000 concurrent connections. Each sync uses up to 16 connections.
+- **Size limits**: 2 TB total logical data across all tables. During full refresh, old + new versions both count toward the limit; keep under 1 TB if you need refreshes.
+- **Read-only in Postgres**: Writing to synced tables interferes with the sync pipeline.
+- **Naming**: Postgres database, schema, and table names may only contain `[A-Za-z0-9_]`. No hyphens.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| CDF not enabled warning | Run `ALTER TABLE ... SET TBLPROPERTIES (delta.enableChangeDataFeed = true)` on source |
+| Duplicate primary key failure | Add a `timeseries_key` to deduplicate (latest wins) |
+| Null bytes in strings | Clean source: `SELECT REPLACE(col, CAST(CHAR(0) AS STRING), '') AS col FROM table` |
+| Instance size exceeded | Uncompressed data exceeds 2 TB limit; drop tables to free space |
+| Schema not visible | Confirm `USE_SCHEMA` + `CREATE_TABLE` permissions |
+| FGAC table sync fails | Create a view over the table and sync the view in Snapshot mode |
+
+## Learn more
+
+- [Synced tables (Provisioned)](https://docs.databricks.com/aws/en/oltp/instances/sync-data/sync-table)
+- [Database Instances API](https://docs.databricks.com/api/workspace/database/createsynceddatabasetable)
+- [Change Data Feed](https://docs.databricks.com/aws/en/delta/delta-change-data-feed)
+- [Upgrade to Autoscaling](https://docs.databricks.com/aws/en/oltp/upgrade-to-autoscaling)


### PR DESCRIPTION
Adds 4 recipe docs covering Lakebase ETL and Reverse ETL patterns (Autoscaling and Provisioned) in a new recipes/ directory.