### PR TITLE
WIP: Update AI Chat App Template recipes for AI SDK v6 and deploy-first workflow

### DIFF
--- a/content/recipes/ai-chat-model-serving.md
+++ b/content/recipes/ai-chat-model-serving.md
@@ -1,133 +1,268 @@
-## AI Chat with Databricks Model Serving
+## Streaming AI Chat with Model Serving
 
-Build a streaming AI chat experience in a Databricks App using AI SDK, AI Elements, and a Databricks Model Serving endpoint.
+Build a streaming AI chat experience in a Databricks App using Vercel AI SDK with Databricks Model Serving and OpenAI-compatible endpoints.
 
 ### 1. Follow the prerequisite recipes first
 
 Complete these recipes before adding chat:
 
 - [`Databricks Local Bootstrap`](/resources/base-app-template#databricks-local-bootstrap)
-- [`Lakebase Data Persistence`](/resources/data-app-template#lakebase-data-persistence)
-- [`Create a Databricks Model Serving endpoint`](/resources/ai-chat-app-template#create-a-databricks-model-serving-endpoint)
+- [`Query AI Gateway Endpoints`](/resources/ai-chat-app-template#query-ai-gateway-endpoints)
 
-### 2. Install AI SDK and AI Elements packages
+:::tip[Deploy before local development]
+Lakebase tables are owned by the identity that creates them. Deploy the app first so the service principal creates and owns the schemas. Then grant yourself local dev access:
 
 ```bash
-npm install ai @ai-sdk/react
-npx shadcn@latest add @ai-elements/all
+databricks psql --project <project-name> --profile <PROFILE> -- -c "
+  CREATE EXTENSION IF NOT EXISTS databricks_auth;
+  SELECT databricks_create_role('<your-email>', 'USER');
+  GRANT databricks_superuser TO \"<your-email>\";
+"
 ```
 
-### 3. Install AI SDK and AI Elements agent skills
+> **Note**: If you are the Lakebase project owner, `databricks_create_role` may fail with `role already exists` and `GRANT databricks_superuser` may fail with `permission denied to grant role`. Both errors are safe to ignore — the project owner already has the necessary access.
 
-Install and verify the Databricks agent skills, then add AI SDK and AI Elements skills from your agent skill registry.
+If you run `npm run dev` before deploying, your user creates schemas that the deployed service principal cannot access. `CREATE SCHEMA IF NOT EXISTS` appears to succeed even on schemas you don't own, but subsequent `CREATE TABLE` fails with `permission denied`.
+:::
+
+### 2. Install AI SDK packages
 
 ```bash
+npm install ai@6 @ai-sdk/react@3 @ai-sdk/openai @databricks/sdk-experimental
+```
+
+> **Version note**: This recipe was tested with `ai@6.1`, `@ai-sdk/react@3.1`, and `@ai-sdk/openai@3.x` (the scaffold's `--version latest` installs `@ai-sdk/openai@^3`). The `TextStreamChatTransport`, `sendMessage({ text })`, and transport-based `useChat` APIs are AI SDK v6-specific. If a future minor release changes these APIs, pin to these versions.
+
+> **Note**: `@databricks/sdk-experimental` is included in the scaffolded `package.json`. It is listed here for reference if adding AI chat to an existing project.
+
+> **Optional**: For pre-built UI components, install individual AI Elements:
+> ```bash
+> # AI Elements CLI needs components.json in root directory
+> cp client/components.json .
+> npx ai-elements@latest add message
+> npx ai-elements@latest add prompt-input
+> npx ai-elements@latest add code-block
+> ```
+> This basic recipe works without AI Elements - they're optional prebuilt components.
+
+### 3. Install Databricks agent skills
+
+Install agent skills to help coding agents understand Databricks patterns:
+
+```bash
+cd <app-name>
 npx skills add databricks/databricks-agent-skills --all
-npx skills add <ai-sdk-skill-id> --all
-npx skills add <ai-elements-skill-id> --all
 npx skills list
 ```
 
-### 4. Configure environment variables for model serving
+> **Note**: This installs skills for Databricks Apps, AppKit, Lakebase, and AI Gateway patterns. Essential for agent-driven development.
 
-Set your workspace URL and endpoint name for local development:
+### 4. Configure environment variables for AI Gateway
+
+Configure your Databricks workspace ID and model endpoint:
+
+For local development (`.env`):
 
 ```bash
-echo 'DATABRICKS_HOST=https://<workspace>.cloud.databricks.com
-DATABRICKS_SERVING_ENDPOINT=<endpoint-name>' >> .env
+echo 'DATABRICKS_WORKSPACE_ID=<your-workspace-id>' >> .env
+echo 'DATABRICKS_ENDPOINT=<your-endpoint>' >> .env
+echo 'DATABRICKS_CONFIG_PROFILE=DEFAULT' >> .env
 ```
 
-For deployment, keep endpoint selection in `app.yaml`:
+For deployment in Databricks Apps (`app.yaml`):
 
 ```yaml
 env:
-  - name: DATABRICKS_SERVING_ENDPOINT
-    value: "<endpoint-name>"
+  - name: DATABRICKS_WORKSPACE_ID
+    value: '<your-workspace-id>'
+  - name: DATABRICKS_ENDPOINT
+    value: '<your-endpoint>'
 ```
 
-### 5. Use Databricks SDK auth chain in server runtime (recommended)
+> **Workspace ID**: AppKit auto-discovers this at runtime. For explicit setup, run `databricks api get /api/2.1/unity-catalog/current-metastore-assignment --profile <PROFILE>` and use the `workspace_id` field.
 
-In Databricks Apps runtime, prefer the Databricks SDK auth chain (service principal/workspace auth) instead of requiring `DATABRICKS_TOKEN` in app env:
+> **Model compatibility**: This recipe uses OpenAI-compatible models served via Databricks AI Gateway, which support the AI SDK's streaming API. The AI Gateway URL uses the `/mlflow/v1` path (not `/openai/v1`).
+
+> **Find your endpoint**: Run `databricks serving-endpoints list --profile <PROFILE>` to see available models. Common endpoints include `databricks-meta-llama-3-3-70b-instruct` and `databricks-claude-sonnet-4`, but availability varies by workspace.
+
+### 5. Configure authentication helper
+
+Create a helper function that works for both local development and deployed apps:
 
 ```typescript
-import { getWorkspaceClient } from "@databricks/appkit";
+import { Config } from '@databricks/sdk-experimental';
 
-const workspaceClient = getWorkspaceClient({});
+async function getDatabricksToken() {
+  // For deployed apps, use service principal token
+  if (process.env.DATABRICKS_TOKEN) {
+    return process.env.DATABRICKS_TOKEN;
+  }
+
+  // For local dev, use CLI profile auth via Databricks SDK
+  const config = new Config({
+    profile: process.env.DATABRICKS_CONFIG_PROFILE || 'DEFAULT',
+  });
+  await config.ensureResolved();
+  const headers = new Headers();
+  await config.authenticate(headers);
+  const authHeader = headers.get('Authorization');
+  if (!authHeader) {
+    throw new Error('Failed to get Databricks token. Check your CLI profile or set DATABRICKS_TOKEN.');
+  }
+  return authHeader.replace('Bearer ', '');
+}
 ```
 
-### 6. Add `/api/chat` route using serving endpoint query
+This function uses the Databricks SDK auth chain, which reads ~/.databrickscfg profiles and handles OAuth token refresh. For deployed apps, set DATABRICKS_TOKEN directly.
 
-Create a server route that accepts chat messages and queries the serving endpoint:
+> **User identity in deployed apps**: Databricks Apps injects user identity via request headers. Extract it with `req.header("x-forwarded-email")` or `req.header("x-forwarded-user")`. Use this for chat persistence and access control.
+
+### 6. Add `/api/chat` route with streaming
+
+Create a server route using the AI SDK's streaming support:
 
 ```typescript
-import { getWorkspaceClient } from "@databricks/appkit";
-
-const workspaceClient = getWorkspaceClient({});
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText } from "ai";
 
 app.post("/api/chat", async (req, res) => {
   const { messages } = req.body;
-  const endpoint = process.env.DATABRICKS_SERVING_ENDPOINT;
-  if (!endpoint) {
-    res.status(500).json({ error: "DATABRICKS_SERVING_ENDPOINT is missing" });
-    return;
+
+  // AI SDK v6 client sends UIMessage objects with a parts array.
+  // Convert to CoreMessage format for streamText().
+  interface UIMessage {
+    role: string;
+    parts?: Array<{ type: string; text?: string }>;
+    content?: string;
   }
 
-  const result = await workspaceClient.servingEndpoints.query({
-    name: endpoint,
-    messages,
-  });
+  const coreMessages = (messages as UIMessage[]).map((m) => ({
+    role: m.role as "user" | "assistant" | "system",
+    content:
+      m.parts
+        ?.filter((p) => p.type === "text" && p.text)
+        .map((p) => p.text)
+        .join("") ?? m.content ?? "",
+  }));
 
-  res.json({
-    message: result.choices?.[0]?.message ?? null,
-  });
+  try {
+    const token = await getDatabricksToken();
+    const endpoint =
+      process.env.DATABRICKS_ENDPOINT || '<your-endpoint>';
+
+    // Configure Databricks AI Gateway as OpenAI-compatible provider
+    const databricks = createOpenAI({
+      baseURL: `https://${process.env.DATABRICKS_WORKSPACE_ID}.ai-gateway.cloud.databricks.com/mlflow/v1`,
+      apiKey: token,
+    });
+
+    // Stream the response using AI SDK v6
+    const result = streamText({
+      model: databricks.chat(endpoint),
+      messages: coreMessages,
+      maxOutputTokens: 1000,
+    });
+
+    // v6 API: pipe the text stream to the Express response
+    result.pipeTextStreamToResponse(res);
+  } catch (err) {
+    const message = (err as Error).message;
+    console.error(`[chat] Streaming request failed:`, message);
+    res.status(502).json({
+      error: "Chat request failed",
+      detail: message,
+    });
+  }
 });
 ```
 
-### 7. Render the chat UI with `useChat`
+### 7. Render the streaming chat UI
 
-Use `useChat` for transport and AI Elements for composition. Keep your existing chat UI structure and point requests at `/api/chat`.
+Use `useChat` from the AI SDK with `TextStreamChatTransport` for streaming support:
 
 ```tsx
 import { useChat } from "@ai-sdk/react";
+import { TextStreamChatTransport } from "ai";
+import { useState, useRef, useEffect } from "react";
 
 export function ChatPage() {
-  const { messages, input, handleInputChange, handleSubmit } = useChat({
-    api: "/api/chat",
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // v6 API: useChat with transport, sendMessage, and status
+  const { messages, sendMessage, status } = useChat({
+    transport: new TextStreamChatTransport({ api: "/api/chat" }),
   });
 
+  // Restore focus when status returns to ready
+  useEffect(() => {
+    if (status === "ready") {
+      inputRef.current?.focus();
+    }
+  }, [status]);
+
   return (
-    <div className="flex flex-col h-[600px]">
+    <div className="flex flex-col h-[calc(100vh-4rem)] -m-6">
       <div className="flex-1 overflow-y-auto space-y-4 p-4">
         {messages.map((m) => (
           <div key={m.id} className={m.role === "user" ? "text-right" : ""}>
             <span className="text-sm font-medium">
               {m.role === "user" ? "You" : "Assistant"}
             </span>
-            <p>{m.content}</p>
+            {m.parts.map((part, i) =>
+              part.type === "text" ? (
+                <p key={`${m.id}-${i}`} className="whitespace-pre-wrap">
+                  {part.text}
+                </p>
+              ) : null
+            )}
           </div>
         ))}
+        {status === "submitted" && <div className="p-4">Loading...</div>}
       </div>
-      <form onSubmit={handleSubmit} className="border-t p-4 flex gap-2">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (input.trim()) {
+            void sendMessage({ text: input });
+            setInput("");
+          }
+        }}
+        className="border-t p-4 flex gap-2"
+      >
         <input
+          ref={inputRef}
           value={input}
-          onChange={handleInputChange}
+          onChange={(e) => setInput(e.target.value)}
           placeholder="Ask a question..."
           className="flex-1 border rounded px-3 py-2"
+          disabled={status !== "ready"}
         />
-        <button type="submit">Send</button>
+        <button type="submit" disabled={status !== "ready"}>
+          {status === "submitted" || status === "streaming"
+            ? "Sending..."
+            : "Send"}
+        </button>
       </form>
     </div>
   );
 }
 ```
 
-### 8. Add chat persistence in Lakebase
+> **Layout tip**: The scaffold wraps page content in a `<main>` with `p-6` padding. For a full-bleed chat layout, use `h-[calc(100vh-4rem)] -m-6` on the chat container to break out of the padding and fill the viewport below the nav bar. The code above includes this pattern.
 
-Persist chat sessions and messages using this recipe:
+The AI SDK v6 `useChat` hook with `TextStreamChatTransport`:
 
-- [`Lakebase Chat Persistence`](/resources/ai-chat-app-template#lakebase-chat-persistence)
+- Uses a transport-based architecture (replaces `api` string option)
+- Streams text responses token-by-token from the server
+- Messages use `parts` arrays instead of `content` strings
+- `sendMessage({ text })` replaces `handleSubmit`
+- Input state is managed externally with `useState`
+- `status` tracks the request lifecycle: `ready`, `submitted`, `streaming`, `error`
 
-### 9. Deploy and verify
+> **ESLint note**: If you use a `useRef` inside `useMemo` to build the transport (for example, to read a dynamic `chatId`), the `react-hooks/refs` rule may warn about reading refs during render. This is a false positive when refs are only read inside callbacks. Suppress with `// eslint-disable-next-line` or use module-level state instead.
+
+### 8. Deploy and verify
 
 ```bash
 databricks apps deploy --profile <PROFILE>
@@ -135,10 +270,14 @@ databricks apps list --profile <PROFILE>
 databricks apps logs <app-name> --profile <PROFILE>
 ```
 
-Open the app URL while signed in to Databricks, send a message, and verify streamed responses plus persisted chat history.
+> **Lint on deploy**: The AppKit scaffold includes an `ast-grep` rule (`no-double-type-assertion`) that runs during `databricks apps deploy`. If your code uses `as unknown as X` double type assertions, the deploy will fail validation. Fix these individually or adjust the rule in `.ast-grep/`.
+
+Open the app URL while signed in to Databricks, send a message, and verify streaming responses appear token-by-token from the AI Gateway endpoint.
+
+> **Note**: This recipe uses AI SDK v6. Databricks AI Gateway endpoints support the Chat Completions format, which the AI SDK uses by default when the base URL includes `/mlflow/v1`.
 
 #### References
 
-- [Databricks AI Gateway](https://docs.databricks.com/en/ai-gateway/)
-- [Databricks Model Serving endpoints](https://docs.databricks.com/en/machine-learning/model-serving/create-manage-serving-endpoints.html)
+- [Model Serving Overview](https://docs.databricks.com/aws/en/machine-learning/model-serving/)
+- [Serving Endpoints](https://docs.databricks.com/aws/en/machine-learning/model-serving/create-foundation-model-endpoints)
 - [AI Elements docs](https://ui.shadcn.com/docs/registry/ai-elements)

--- a/content/recipes/ai-chat-model-serving.md
+++ b/content/recipes/ai-chat-model-serving.md
@@ -31,33 +31,19 @@ If you run `npm run dev` before deploying, your user creates schemas that the de
 npm install ai@6 @ai-sdk/react@3 @ai-sdk/openai @databricks/sdk-experimental
 ```
 
-> **Version note**: This recipe was tested with `ai@6.1`, `@ai-sdk/react@3.1`, and `@ai-sdk/openai@3.x` (the scaffold's `--version latest` installs `@ai-sdk/openai@^3`). The `TextStreamChatTransport`, `sendMessage({ text })`, and transport-based `useChat` APIs are AI SDK v6-specific. If a future minor release changes these APIs, pin to these versions.
+> **Version note**: This recipe uses AI SDK v6 APIs (`TextStreamChatTransport`, `sendMessage({ text })`, transport-based `useChat`). Tested with `ai@6.1`, `@ai-sdk/react@3.1`, and `@ai-sdk/openai@3.x`.
 
 > **Note**: `@databricks/sdk-experimental` is included in the scaffolded `package.json`. It is listed here for reference if adding AI chat to an existing project.
 
-> **Optional**: For pre-built UI components, install individual AI Elements:
+> **Optional**: For pre-built chat UI components, initialize shadcn and add AI Elements:
+>
 > ```bash
-> # AI Elements CLI needs components.json in root directory
-> cp client/components.json .
-> npx ai-elements@latest add message
-> npx ai-elements@latest add prompt-input
-> npx ai-elements@latest add code-block
+> npx shadcn@latest init
 > ```
-> This basic recipe works without AI Elements - they're optional prebuilt components.
+>
+> This basic recipe works without AI Elements — they're optional prebuilt components.
 
-### 3. Install Databricks agent skills
-
-Install agent skills to help coding agents understand Databricks patterns:
-
-```bash
-cd <app-name>
-npx skills add databricks/databricks-agent-skills --all
-npx skills list
-```
-
-> **Note**: This installs skills for Databricks Apps, AppKit, Lakebase, and AI Gateway patterns. Essential for agent-driven development.
-
-### 4. Configure environment variables for AI Gateway
+### 3. Configure environment variables for AI Gateway
 
 Configure your Databricks workspace ID and model endpoint:
 
@@ -74,9 +60,9 @@ For deployment in Databricks Apps (`app.yaml`):
 ```yaml
 env:
   - name: DATABRICKS_WORKSPACE_ID
-    value: '<your-workspace-id>'
+    value: "<your-workspace-id>"
   - name: DATABRICKS_ENDPOINT
-    value: '<your-endpoint>'
+    value: "<your-endpoint>"
 ```
 
 > **Workspace ID**: AppKit auto-discovers this at runtime. For explicit setup, run `databricks api get /api/2.1/unity-catalog/current-metastore-assignment --profile <PROFILE>` and use the `workspace_id` field.
@@ -85,12 +71,12 @@ env:
 
 > **Find your endpoint**: Run `databricks serving-endpoints list --profile <PROFILE>` to see available models. Common endpoints include `databricks-meta-llama-3-3-70b-instruct` and `databricks-claude-sonnet-4`, but availability varies by workspace.
 
-### 5. Configure authentication helper
+### 4. Configure authentication helper
 
 Create a helper function that works for both local development and deployed apps:
 
 ```typescript
-import { Config } from '@databricks/sdk-experimental';
+import { Config } from "@databricks/sdk-experimental";
 
 async function getDatabricksToken() {
   // For deployed apps, use service principal token
@@ -100,16 +86,18 @@ async function getDatabricksToken() {
 
   // For local dev, use CLI profile auth via Databricks SDK
   const config = new Config({
-    profile: process.env.DATABRICKS_CONFIG_PROFILE || 'DEFAULT',
+    profile: process.env.DATABRICKS_CONFIG_PROFILE || "DEFAULT",
   });
   await config.ensureResolved();
   const headers = new Headers();
   await config.authenticate(headers);
-  const authHeader = headers.get('Authorization');
+  const authHeader = headers.get("Authorization");
   if (!authHeader) {
-    throw new Error('Failed to get Databricks token. Check your CLI profile or set DATABRICKS_TOKEN.');
+    throw new Error(
+      "Failed to get Databricks token. Check your CLI profile or set DATABRICKS_TOKEN.",
+    );
   }
-  return authHeader.replace('Bearer ', '');
+  return authHeader.replace("Bearer ", "");
 }
 ```
 
@@ -117,38 +105,33 @@ This function uses the Databricks SDK auth chain, which reads ~/.databrickscfg p
 
 > **User identity in deployed apps**: Databricks Apps injects user identity via request headers. Extract it with `req.header("x-forwarded-email")` or `req.header("x-forwarded-user")`. Use this for chat persistence and access control.
 
-### 6. Add `/api/chat` route with streaming
+### 5. Add `/api/chat` route with streaming
 
 Create a server route using the AI SDK's streaming support:
 
 ```typescript
 import { createOpenAI } from "@ai-sdk/openai";
-import { streamText } from "ai";
+import { streamText, type UIMessage } from "ai";
 
 app.post("/api/chat", async (req, res) => {
   const { messages } = req.body;
 
   // AI SDK v6 client sends UIMessage objects with a parts array.
   // Convert to CoreMessage format for streamText().
-  interface UIMessage {
-    role: string;
-    parts?: Array<{ type: string; text?: string }>;
-    content?: string;
-  }
-
   const coreMessages = (messages as UIMessage[]).map((m) => ({
     role: m.role as "user" | "assistant" | "system",
     content:
       m.parts
         ?.filter((p) => p.type === "text" && p.text)
         .map((p) => p.text)
-        .join("") ?? m.content ?? "",
+        .join("") ??
+      m.content ??
+      "",
   }));
 
   try {
     const token = await getDatabricksToken();
-    const endpoint =
-      process.env.DATABRICKS_ENDPOINT || '<your-endpoint>';
+    const endpoint = process.env.DATABRICKS_ENDPOINT || "<your-endpoint>";
 
     // Configure Databricks AI Gateway as OpenAI-compatible provider
     const databricks = createOpenAI({
@@ -176,33 +159,24 @@ app.post("/api/chat", async (req, res) => {
 });
 ```
 
-### 7. Render the streaming chat UI
+### 6. Render the streaming chat UI
 
 Use `useChat` from the AI SDK with `TextStreamChatTransport` for streaming support:
 
 ```tsx
 import { useChat } from "@ai-sdk/react";
 import { TextStreamChatTransport } from "ai";
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 
 export function ChatPage() {
   const [input, setInput] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  // v6 API: useChat with transport, sendMessage, and status
   const { messages, sendMessage, status } = useChat({
     transport: new TextStreamChatTransport({ api: "/api/chat" }),
   });
 
-  // Restore focus when status returns to ready
-  useEffect(() => {
-    if (status === "ready") {
-      inputRef.current?.focus();
-    }
-  }, [status]);
-
   return (
-    <div className="flex flex-col h-[calc(100vh-4rem)] -m-6">
+    <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto space-y-4 p-4">
         {messages.map((m) => (
           <div key={m.id} className={m.role === "user" ? "text-right" : ""}>
@@ -214,7 +188,7 @@ export function ChatPage() {
                 <p key={`${m.id}-${i}`} className="whitespace-pre-wrap">
                   {part.text}
                 </p>
-              ) : null
+              ) : null,
             )}
           </div>
         ))}
@@ -231,7 +205,6 @@ export function ChatPage() {
         className="border-t p-4 flex gap-2"
       >
         <input
-          ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Ask a question..."
@@ -249,20 +222,7 @@ export function ChatPage() {
 }
 ```
 
-> **Layout tip**: The scaffold wraps page content in a `<main>` with `p-6` padding. For a full-bleed chat layout, use `h-[calc(100vh-4rem)] -m-6` on the chat container to break out of the padding and fill the viewport below the nav bar. The code above includes this pattern.
-
-The AI SDK v6 `useChat` hook with `TextStreamChatTransport`:
-
-- Uses a transport-based architecture (replaces `api` string option)
-- Streams text responses token-by-token from the server
-- Messages use `parts` arrays instead of `content` strings
-- `sendMessage({ text })` replaces `handleSubmit`
-- Input state is managed externally with `useState`
-- `status` tracks the request lifecycle: `ready`, `submitted`, `streaming`, `error`
-
-> **ESLint note**: If you use a `useRef` inside `useMemo` to build the transport (for example, to read a dynamic `chatId`), the `react-hooks/refs` rule may warn about reading refs during render. This is a false positive when refs are only read inside callbacks. Suppress with `// eslint-disable-next-line` or use module-level state instead.
-
-### 8. Deploy and verify
+### 7. Deploy and verify
 
 ```bash
 databricks apps deploy --profile <PROFILE>
@@ -270,11 +230,7 @@ databricks apps list --profile <PROFILE>
 databricks apps logs <app-name> --profile <PROFILE>
 ```
 
-> **Lint on deploy**: The AppKit scaffold includes an `ast-grep` rule (`no-double-type-assertion`) that runs during `databricks apps deploy`. If your code uses `as unknown as X` double type assertions, the deploy will fail validation. Fix these individually or adjust the rule in `.ast-grep/`.
-
 Open the app URL while signed in to Databricks, send a message, and verify streaming responses appear token-by-token from the AI Gateway endpoint.
-
-> **Note**: This recipe uses AI SDK v6. Databricks AI Gateway endpoints support the Chat Completions format, which the AI SDK uses by default when the base URL includes `/mlflow/v1`.
 
 #### References
 

--- a/content/recipes/databricks-local-bootstrap.md
+++ b/content/recipes/databricks-local-bootstrap.md
@@ -60,7 +60,7 @@ databricks auth profiles
 
 ### 5. Scaffold a new Databricks app
 
-Run this from the directory where you want the project created. The CLI creates a new folder named after `--name` inside the current directory. Use `--version latest` to get the latest AppKit template. Add `--features` to enable specific plugins (e.g., `--features=genie,lakebase`).
+Run this from the directory where you want the project created. The CLI creates a new folder named after `--name` inside the current directory. Use `--version latest` to get the latest AppKit template. Add `--features` to enable specific plugins (e.g., `--features=lakebase` for database persistence).
 
 ```bash
 databricks apps init \
@@ -71,6 +71,13 @@ databricks apps init \
   --profile <PROFILE>
 ```
 
+Then enter the project and install dependencies:
+
+```bash
+cd <app-name>
+npm install
+```
+
 ### 6. Install Databricks agent skills
 
 Install the agent skills for the agents and editors you actively use.
@@ -78,6 +85,8 @@ Install the agent skills for the agents and editors you actively use.
 ```bash
 npx skills add databricks/databricks-agent-skills -y -a claude-code -a cursor -a codex
 ```
+
+> **Alternative**: You can also use `databricks experimental aitools skills install` from the Databricks CLI. Both commands work.
 
 Use `-y` for noninteractive installs and add one or more `-a <agent-name>` flags for your specific agents.
 

--- a/content/recipes/databricks-local-bootstrap.md
+++ b/content/recipes/databricks-local-bootstrap.md
@@ -86,8 +86,6 @@ Install the agent skills for the agents and editors you actively use.
 npx skills add databricks/databricks-agent-skills -y -a claude-code -a cursor -a codex
 ```
 
-> **Alternative**: You can also use `databricks experimental aitools skills install` from the Databricks CLI. Both commands work.
-
 Use `-y` for noninteractive installs and add one or more `-a <agent-name>` flags for your specific agents.
 
 ### 7. Verify installed skills

--- a/content/recipes/foundation-models-api.md
+++ b/content/recipes/foundation-models-api.md
@@ -1,0 +1,138 @@
+## Query AI Gateway Endpoints
+
+Access Databricks foundation models through AI Gateway endpoints with built-in governance, monitoring, and production-readiness features.
+
+### 1. Understand AI Gateway endpoints
+
+**AI Gateway** is a governance layer on top of model serving endpoints that provides permissions, rate limiting, payload logging, and AI guardrails. Currently in beta, AI Gateway is becoming the default way to access foundation models in Databricks.
+
+**Note**: AI Gateway is built into all Foundation Model API endpoints. If you need to access non-AI Gateway endpoints, use the Databricks SDK's `servingEndpoints.query()` method directly.
+
+### 2. Check if AI Gateway is available
+
+All Foundation Model API endpoints have AI Gateway built-in. To verify, check if a known FM endpoint has the `ai_gateway` configuration:
+
+```bash
+databricks serving-endpoints get <your-endpoint> --profile <PROFILE> --output json | grep -q '"ai_gateway"' && echo "✓ AI Gateway available" || echo "✗ No AI Gateway"
+```
+
+Or using Python SDK:
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+try:
+    # Try a known FM endpoint
+    ep = w.serving_endpoints.get("<your-endpoint>")
+    if ep.ai_gateway is not None:
+        print("✓ AI Gateway available with usage tracking")
+    else:
+        print("✗ No AI Gateway config")
+except Exception as e:
+    print(f"Endpoint not found: {e}")
+```
+
+**Note**: The SDK's `list()` method does NOT include `ai_gateway` - you must use `get()` on a specific endpoint.
+
+### 3. Choose your model
+
+List available AI Gateway endpoints in your workspace:
+
+```bash
+databricks serving-endpoints list --profile <PROFILE>
+```
+
+Common AI Gateway endpoint names:
+
+- `databricks-meta-llama-3-3-70b-instruct`
+- `databricks-gemini-3-1-flash-lite`
+- `databricks-dbrx-instruct`
+
+> **Note**: When using this template with a coding agent, specify which endpoint to use based on what's available in your workspace. Endpoint names may vary.
+
+> **Important**: Endpoint availability varies by workspace. Always run `databricks serving-endpoints list` to check what's available before configuring your app.
+
+### 4. Configure environment variables
+
+For local development (`.env`):
+
+```bash
+DATABRICKS_ENDPOINT=<your-endpoint>
+```
+
+For deployment (`app.yaml`):
+
+```yaml
+env:
+  - name: DATABRICKS_ENDPOINT
+    value: "<your-endpoint>"
+```
+
+### 5. Query AI Gateway endpoints
+
+```typescript
+import { getWorkspaceClient } from "@databricks/appkit";
+
+// {} tells the SDK to use default auth chain (env vars / profile).
+// Do NOT omit — getWorkspaceClient() with no argument will throw.
+const workspaceClient = getWorkspaceClient({});
+const endpoint =
+  process.env.DATABRICKS_ENDPOINT || "<your-endpoint>";
+
+async function queryModel(messages: any[]) {
+  const result = await workspaceClient.servingEndpoints.query({
+    name: endpoint,
+    messages: messages,
+    max_tokens: 1000,
+  });
+
+  return result;
+}
+```
+
+**For streaming responses:** For OpenAI-compatible models, use the Vercel AI SDK's `createOpenAI` provider with AI Gateway:
+
+```typescript
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText } from "ai";
+
+const databricks = createOpenAI({
+  baseURL: `https://${process.env.DATABRICKS_WORKSPACE_ID}.ai-gateway.cloud.databricks.com/mlflow/v1`,
+  apiKey: token,
+});
+
+const result = streamText({
+  model: databricks.chat(endpoint), // e.g., "databricks-gpt-5-4-mini"
+  messages,
+  maxOutputTokens: 1000,
+});
+
+// AI SDK v6: pipe the text stream to the Express response
+result.pipeTextStreamToResponse(res);
+```
+
+> **Auth for streaming**: The streaming example above requires a bearer token for `createOpenAI()`. See the [Streaming AI Chat recipe](#streaming-ai-chat-with-model-serving) for the full auth helper pattern using `@databricks/sdk-experimental`.
+
+> **Note**: This pattern works with OpenAI-compatible models (`databricks-gpt-5-4-mini`, `databricks-gpt-oss-120b`). Native Databricks models use the MLflow unified API.
+>
+> **Workspace ID**: AppKit auto-discovers this at runtime. For explicit setup, run `databricks api get /api/2.1/unity-catalog/current-metastore-assignment --profile <PROFILE>` and use the `workspace_id` field.
+
+See the [Streaming AI Chat recipe](/resources/ai-chat-app-template#streaming-ai-chat-with-model-serving) for a complete implementation.
+
+### 6. Test the endpoint
+
+Query an AI Gateway endpoint:
+
+```bash
+databricks serving-endpoints query <your-endpoint> \
+  --json '{"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100}' \
+  --profile <PROFILE>
+```
+
+#### References
+
+- [AI Gateway Overview](https://docs.databricks.com/aws/en/ai-gateway/overview-beta)
+- [AI Gateway and Serving Endpoints](https://docs.databricks.com/aws/en/ai-gateway/overview-serving-endpoints)
+- [Vercel AI SDK](https://sdk.vercel.ai/docs) - For streaming implementations

--- a/content/recipes/foundation-models-api.md
+++ b/content/recipes/foundation-models-api.md
@@ -16,26 +16,6 @@ All Foundation Model API endpoints have AI Gateway built-in. To verify, check if
 databricks serving-endpoints get <your-endpoint> --profile <PROFILE> --output json | grep -q '"ai_gateway"' && echo "✓ AI Gateway available" || echo "✗ No AI Gateway"
 ```
 
-Or using Python SDK:
-
-```python
-from databricks.sdk import WorkspaceClient
-
-w = WorkspaceClient()
-
-try:
-    # Try a known FM endpoint
-    ep = w.serving_endpoints.get("<your-endpoint>")
-    if ep.ai_gateway is not None:
-        print("✓ AI Gateway available with usage tracking")
-    else:
-        print("✗ No AI Gateway config")
-except Exception as e:
-    print(f"Endpoint not found: {e}")
-```
-
-**Note**: The SDK's `list()` method does NOT include `ai_gateway` - you must use `get()` on a specific endpoint.
-
 ### 3. Choose your model
 
 List available AI Gateway endpoints in your workspace:
@@ -78,8 +58,7 @@ import { getWorkspaceClient } from "@databricks/appkit";
 // {} tells the SDK to use default auth chain (env vars / profile).
 // Do NOT omit — getWorkspaceClient() with no argument will throw.
 const workspaceClient = getWorkspaceClient({});
-const endpoint =
-  process.env.DATABRICKS_ENDPOINT || "<your-endpoint>";
+const endpoint = process.env.DATABRICKS_ENDPOINT || "<your-endpoint>";
 
 async function queryModel(messages: any[]) {
   const result = await workspaceClient.servingEndpoints.query({

--- a/content/recipes/lakebase-chat-persistence.md
+++ b/content/recipes/lakebase-chat-persistence.md
@@ -4,17 +4,139 @@ Persist chat sessions and messages in Lakebase so users can resume history acros
 
 This recipe uses a simplified relational shape inspired by common production chat schemas (`chat` plus `message`) and adapts it to Databricks AppKit + Lakebase.
 
-### 1. Create chat tables
+### 1. Create a Lakebase project
 
-Create two tables:
+Create a new Lakebase Postgres project. This provisions a managed Postgres cluster with a default branch and endpoint:
 
-- `app.chats`: one row per chat session
-- `app.messages`: one row per message
+```bash
+databricks postgres create-project <project-name> --profile <PROFILE>
+```
+
+Verify the project, branch, and endpoint were created:
+
+```bash
+databricks postgres list-branches \
+  projects/<project-name> \
+  --profile <PROFILE> -o json
+
+databricks postgres list-endpoints \
+  projects/<project-name>/branches/production \
+  --profile <PROFILE> -o json
+
+databricks postgres list-databases \
+  projects/<project-name>/branches/production \
+  --profile <PROFILE> -o json
+```
+
+Note these values from the output:
+
+- endpoint host (`...status.hosts.host`) for `lakebase.postgres.host`
+- endpoint path (`...name`) for `lakebase.postgres.endpointPath`
+- database resource path (`...name`) for `lakebase.postgres.database`
+- PostgreSQL database name (`...status.postgres_database`) for `lakebase.postgres.databaseName` and `PGDATABASE`
+
+### 2. Scaffold with the Lakebase feature
+
+If you haven't scaffolded yet, include `--features=lakebase`:
+
+```bash
+databricks apps init \
+  --name <app-name> \
+  --version latest \
+  --features=lakebase \
+  --set 'lakebase.postgres.branch=projects/<project-name>/branches/production' \
+  --set 'lakebase.postgres.database=projects/<project-name>/branches/production/databases/<db-name>' \
+  --set 'lakebase.postgres.databaseName=<postgres-database-name>' \
+  --set 'lakebase.postgres.endpointPath=projects/<project-name>/branches/production/endpoints/primary' \
+  --set 'lakebase.postgres.host=<endpoint-host>' \
+  --set 'lakebase.postgres.port=5432' \
+  --set 'lakebase.postgres.sslmode=require' \
+  --run none --profile <PROFILE>
+```
+
+Use the values returned by `list-databases` and `list-endpoints`.
+
+If you already scaffolded without `--features=lakebase`, add the `lakebase()` plugin manually. See the [Lakebase Data Persistence recipe](/resources/data-app-template#lakebase-data-persistence) for the full manual setup (server.ts, databricks.yml, app.yaml).
+
+### 3. Configure Lakebase environment variables
+
+For local development, add the Postgres connection details to `.env`:
+
+```bash
+PGHOST=<endpoint-host>
+PGPORT=5432
+PGDATABASE=<postgres-database-name>
+PGSSLMODE=require
+LAKEBASE_ENDPOINT=projects/<project-name>/branches/production/endpoints/primary
+```
+
+For deployment, the platform injects Postgres connection values automatically through the app resource. Add the Lakebase endpoint to `app.yaml`:
+
+```yaml
+env:
+  - name: LAKEBASE_ENDPOINT
+    valueFrom: postgres
+```
+
+And add the postgres resource to `databricks.yml`:
+
+```yaml
+resources:
+  apps:
+    app:
+      resources:
+        - name: postgres
+          postgres:
+            branch: projects/<project-name>/branches/production
+            database: projects/<project-name>/branches/production/databases/<db-name>
+            permission: CAN_CONNECT_AND_CREATE
+```
+
+### 4. Deploy before local development
+
+Deploy the app now so the service principal creates and owns the Lakebase connection:
+
+```bash
+databricks apps deploy --profile <PROFILE>
+```
+
+Then grant yourself local dev access:
+
+```bash
+databricks psql --project <project-name> --profile <PROFILE> -- -c "
+  CREATE EXTENSION IF NOT EXISTS databricks_auth;
+  SELECT databricks_create_role('<your-email>', 'USER');
+  GRANT databricks_superuser TO \"<your-email>\";
+"
+```
+
+> **Note**: If you are the Lakebase project owner, `databricks_create_role` may fail with `role already exists` and `GRANT databricks_superuser` may fail with `permission denied to grant role`. Both errors are safe to ignore — the project owner already has the necessary access.
+
+This gives you DML access (read/write) for local development. The service principal remains the owner of any schemas and tables it creates.
+
+:::warning[If you already ran locally before deploying]
+If you ran `npm run dev` before deploying, your user owns the schemas and the deployed service principal cannot access them. `CREATE SCHEMA IF NOT EXISTS` silently no-ops on schemas owned by another principal — it appears to succeed but grants no privileges.
+
+**To recover**, drop the user-owned schema so the SP can recreate it:
+
+```bash
+databricks psql --project <project-name> --profile <PROFILE> -- -c "DROP SCHEMA IF EXISTS chat CASCADE;"
+```
+
+Then redeploy with `databricks apps deploy`.
+:::
+
+### 5. Create chat tables
+
+Create two tables in a `chat` schema:
+
+- `chat.chats`: one row per chat session
+- `chat.messages`: one row per message
 
 ```sql
-CREATE SCHEMA IF NOT EXISTS app;
+CREATE SCHEMA IF NOT EXISTS chat;
 
-CREATE TABLE IF NOT EXISTS app.chats (
+CREATE TABLE IF NOT EXISTS chat.chats (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id TEXT NOT NULL,
   title TEXT NOT NULL,
@@ -22,55 +144,57 @@ CREATE TABLE IF NOT EXISTS app.chats (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE TABLE IF NOT EXISTS app.messages (
+CREATE TABLE IF NOT EXISTS chat.messages (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  chat_id UUID NOT NULL REFERENCES app.chats(id) ON DELETE CASCADE,
+  chat_id UUID NOT NULL REFERENCES chat.chats(id) ON DELETE CASCADE,
   role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
   content TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_chat_id_created_at
-  ON app.messages(chat_id, created_at);
+  ON chat.messages(chat_id, created_at);
 ```
 
-### 2. Run setup from your server bootstrap
+### 6. Run setup from your server bootstrap
 
 In `server/server.ts`, keep `autoStart: false` and run schema setup before `appkit.server.start()`.
 
-### 3. Add persistence helpers
+### 7. Add persistence helpers
 
 Create `server/lib/chat-store.ts` and use parameterized queries:
+
+> **Getting userId**: In deployed Databricks Apps, use `req.header("x-forwarded-email")` from the request headers. For local development, use a hardcoded test user ID.
 
 ```typescript
 export async function createChat(
   appkit: AppKitWithLakebase,
-  input: { userId: string; title: string },
+  input: { userId: string; title: string }
 ) {
   const result = await appkit.lakebase.query(
-    `INSERT INTO app.chats (user_id, title)
+    `INSERT INTO chat.chats (user_id, title)
      VALUES ($1, $2)
      RETURNING id, user_id, title, created_at, updated_at`,
-    [input.userId, input.title],
+    [input.userId, input.title]
   );
   return result.rows[0];
 }
 
 export async function appendMessage(
   appkit: AppKitWithLakebase,
-  input: { chatId: string; role: string; content: string },
+  input: { chatId: string; role: string; content: string }
 ) {
   const result = await appkit.lakebase.query(
-    `INSERT INTO app.messages (chat_id, role, content)
+    `INSERT INTO chat.messages (chat_id, role, content)
      VALUES ($1, $2, $3)
      RETURNING id, chat_id, role, content, created_at`,
-    [input.chatId, input.role, input.content],
+    [input.chatId, input.role, input.content]
   );
   return result.rows[0];
 }
 ```
 
-### 4. Persist in the `/api/chat` flow
+### 8. Persist in the `/api/chat` flow
 
 In your chat route:
 
@@ -81,7 +205,7 @@ In your chat route:
 
 Use an explicit `chatId` on the client and pass it in each request body.
 
-### 5. Add history endpoints
+### 9. Add history endpoints
 
 Add REST endpoints for your chat UI:
 
@@ -89,13 +213,13 @@ Add REST endpoints for your chat UI:
 - `GET /api/chats/:chatId/messages` -> load ordered history
 - `DELETE /api/chats/:chatId` -> delete chat and cascade messages
 
-### 6. Update the client to load and resume chats
+### 10. Update the client to load and resume chats
 
 - keep selected `chatId` in state or URL
-- call `GET /api/chats/:chatId/messages` when opening a chat
-- send `chatId` in every `/api/chat` request
+- fetch history with `GET /api/chats/:chatId/messages` and call `setMessages()` from the `useChat` return value to load it into the chat (AI SDK v6 uses `messages` in `ChatInit`, not `initialMessages`)
+- send `chatId` in every `/api/chat` request — pass it via a custom `fetch` wrapper on the `TextStreamChatTransport` constructor (there is no `onResponse` option on the transport; use the custom `fetch` to read response headers like `X-Chat-Id`)
 
-### 7. Verify persistence end-to-end
+### 11. Verify persistence end-to-end
 
 ```bash
 databricks apps deploy --profile <PROFILE>

--- a/content/recipes/lakebase-data-persistence.md
+++ b/content/recipes/lakebase-data-persistence.md
@@ -121,7 +121,7 @@ interface AppKitWithLakebase {
   lakebase: {
     query(
       text: string,
-      params?: unknown[]
+      params?: unknown[],
     ): Promise<{ rows: Record<string, unknown>[] }>;
   };
   server: {
@@ -166,7 +166,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
     app.get("/api/lakebase/todos", async (_req, res) => {
       try {
         const result = await appkit.lakebase.query(
-          "SELECT id, title, completed, created_at FROM app.todos ORDER BY created_at DESC"
+          "SELECT id, title, completed, created_at FROM app.todos ORDER BY created_at DESC",
         );
         res.json(result.rows);
       } catch (err) {
@@ -184,7 +184,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
         }
         const result = await appkit.lakebase.query(
           "INSERT INTO app.todos (title) VALUES ($1) RETURNING id, title, completed, created_at",
-          [parsed.data.title.trim()]
+          [parsed.data.title.trim()],
         );
         res.status(201).json(result.rows[0]);
       } catch (err) {
@@ -202,7 +202,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
         }
         const result = await appkit.lakebase.query(
           "UPDATE app.todos SET completed = NOT completed WHERE id = $1 RETURNING id, title, completed, created_at",
-          [id]
+          [id],
         );
         if (result.rows.length === 0) {
           res.status(404).json({ error: "Todo not found" });
@@ -224,7 +224,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
         }
         const result = await appkit.lakebase.query(
           "DELETE FROM app.todos WHERE id = $1 RETURNING id",
-          [id]
+          [id],
         );
         if (result.rows.length === 0) {
           res.status(404).json({ error: "Todo not found" });
@@ -298,7 +298,7 @@ export function LakebasePage() {
       })
       .then(setTodos)
       .catch((err) =>
-        setError(err instanceof Error ? err.message : "Failed to load todos")
+        setError(err instanceof Error ? err.message : "Failed to load todos"),
       )
       .finally(() => setLoading(false));
   }, []);

--- a/content/recipes/lakebase-data-persistence.md
+++ b/content/recipes/lakebase-data-persistence.md
@@ -121,7 +121,7 @@ interface AppKitWithLakebase {
   lakebase: {
     query(
       text: string,
-      params?: unknown[],
+      params?: unknown[]
     ): Promise<{ rows: Record<string, unknown>[] }>;
   };
   server: {
@@ -166,7 +166,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
     app.get("/api/lakebase/todos", async (_req, res) => {
       try {
         const result = await appkit.lakebase.query(
-          "SELECT id, title, completed, created_at FROM app.todos ORDER BY created_at DESC",
+          "SELECT id, title, completed, created_at FROM app.todos ORDER BY created_at DESC"
         );
         res.json(result.rows);
       } catch (err) {
@@ -184,7 +184,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
         }
         const result = await appkit.lakebase.query(
           "INSERT INTO app.todos (title) VALUES ($1) RETURNING id, title, completed, created_at",
-          [parsed.data.title.trim()],
+          [parsed.data.title.trim()]
         );
         res.status(201).json(result.rows[0]);
       } catch (err) {
@@ -202,7 +202,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
         }
         const result = await appkit.lakebase.query(
           "UPDATE app.todos SET completed = NOT completed WHERE id = $1 RETURNING id, title, completed, created_at",
-          [id],
+          [id]
         );
         if (result.rows.length === 0) {
           res.status(404).json({ error: "Todo not found" });
@@ -224,7 +224,7 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
         }
         const result = await appkit.lakebase.query(
           "DELETE FROM app.todos WHERE id = $1 RETURNING id",
-          [id],
+          [id]
         );
         if (result.rows.length === 0) {
           res.status(404).json({ error: "Todo not found" });
@@ -239,6 +239,24 @@ export async function setupSampleLakebaseRoutes(appkit: AppKitWithLakebase) {
   });
 }
 ```
+
+:::warning[Deploy first to avoid schema ownership errors]
+Lakebase tables are owned by the identity that creates them. If you create the `app` schema locally, your user owns it and the deployed service principal gets `permission denied for schema app`.
+
+**Recommended workflow:** Deploy the app first so the service principal creates and owns the schema. Then grant yourself access for local development:
+
+```bash
+databricks psql --project <project-name> --profile <PROFILE> -- -c "
+  CREATE EXTENSION IF NOT EXISTS databricks_auth;
+  SELECT databricks_create_role('<your-email>', 'USER');
+  GRANT databricks_superuser TO \"<your-email>\";
+"
+```
+
+This gives you DML access (read/write) but not DDL (create/alter). The service principal remains the schema owner.
+
+If you already created tables locally, drop and recreate the schema so the SP owns it, or add tables in a separate schema (the [Chat Persistence recipe](/resources/ai-chat-app-template#lakebase-chat-persistence) uses a `chat` schema for this reason).
+:::
 
 #### Create `client/src/pages/lakebase/LakebasePage.tsx`
 
@@ -280,7 +298,7 @@ export function LakebasePage() {
       })
       .then(setTodos)
       .catch((err) =>
-        setError(err instanceof Error ? err.message : "Failed to load todos"),
+        setError(err instanceof Error ? err.message : "Failed to load todos")
       )
       .finally(() => setLoading(false));
   }, []);
@@ -403,7 +421,9 @@ export function LakebasePage() {
                   </button>
 
                   <span
-                    className={`flex-1 ${todo.completed ? "line-through text-muted-foreground" : ""}`}
+                    className={`flex-1 ${
+                      todo.completed ? "line-through text-muted-foreground" : ""
+                    }`}
                   >
                     {todo.title}
                   </span>
@@ -431,6 +451,8 @@ export function LakebasePage() {
   );
 }
 ```
+
+> **Note**: The scaffolded component may trigger `@typescript-eslint/no-misused-promises` warnings on async `onSubmit` and `onClick` handlers. These are pre-existing in the AppKit template. Wrap handlers with `void` (e.g., `onClick={() => void toggleTodo(todo.id)}`) or add `// eslint-disable-next-line` comments to suppress.
 
 #### Update `client/src/App.tsx`
 

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -32,15 +32,23 @@ export const recipes: Recipe[] = [
   },
   {
     id: "ai-chat-model-serving",
-    name: "AI Chat with Databricks Model Serving",
+    name: "Streaming AI Chat with Model Serving",
     description:
-      "Build a streaming chat app in Databricks Apps powered by Databricks AI Gateway (model serving) with AI SDK and AI Elements.",
-    tags: ["AI SDK", "AI Gateway", "Model Serving", "Chat"],
+      "Build a streaming AI chat experience using AI SDK, AI Elements, and Databricks Model Serving endpoints.",
+    tags: ["AI", "Chat", "AI SDK", "Model Serving"],
     prerequisites: [
       "databricks-local-bootstrap",
       "lakebase-data-persistence",
-      "model-serving-endpoint-creation",
+      "foundation-models-api",
     ],
+  },
+  {
+    id: "foundation-models-api",
+    name: "Query AI Gateway Endpoints",
+    description:
+      "Query AI Gateway endpoints for production-ready access to foundation models with built-in governance.",
+    tags: ["AI", "AI Gateway", "Foundation Models"],
+    prerequisites: ["databricks-local-bootstrap"],
   },
   {
     id: "model-serving-endpoint-creation",
@@ -85,12 +93,13 @@ export const recipes: Recipe[] = [
 ];
 
 const recipeIndex: Record<string, Recipe> = Object.fromEntries(
-  recipes.map((recipe) => [recipe.id, recipe]),
+  recipes.map((recipe) => [recipe.id, recipe])
 );
 
 export const recipesInOrder: Recipe[] = [
   "databricks-local-bootstrap",
   "lakebase-data-persistence",
+  "foundation-models-api",
   "model-serving-endpoint-creation",
   "ai-chat-model-serving",
   "lakebase-chat-persistence",
@@ -143,11 +152,10 @@ export const templates: Template[] = [
     id: "ai-chat-app-template",
     name: "AI Chat App Template",
     description:
-      "Databricks local bootstrap with Lakebase setup, model serving endpoint creation, AI SDK chat integration, and persisted chat history.",
+      "Databricks local bootstrap, Model Serving integration, AI SDK streaming chat, and Lakebase-persisted chat history.",
     recipeIds: [
       "databricks-local-bootstrap",
-      "lakebase-data-persistence",
-      "model-serving-endpoint-creation",
+      "foundation-models-api",
       "ai-chat-model-serving",
       "lakebase-chat-persistence",
     ],
@@ -193,5 +201,5 @@ export const templatePreviewItems: TemplatePreviewItem[] = templates.map(
     title: template.name,
     description: template.description,
     tags: template.tags,
-  }),
+  })
 );

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -34,7 +34,7 @@ export const recipes: Recipe[] = [
     id: "ai-chat-model-serving",
     name: "Streaming AI Chat with Model Serving",
     description:
-      "Build a streaming AI chat experience using AI SDK, AI Elements, and Databricks Model Serving endpoints.",
+      "Build a streaming AI chat experience using AI SDK and Databricks Model Serving endpoints.",
     tags: ["AI", "Chat", "AI SDK", "Model Serving"],
     prerequisites: [
       "databricks-local-bootstrap",
@@ -93,7 +93,7 @@ export const recipes: Recipe[] = [
 ];
 
 const recipeIndex: Record<string, Recipe> = Object.fromEntries(
-  recipes.map((recipe) => [recipe.id, recipe])
+  recipes.map((recipe) => [recipe.id, recipe]),
 );
 
 export const recipesInOrder: Recipe[] = [
@@ -201,5 +201,5 @@ export const templatePreviewItems: TemplatePreviewItem[] = templates.map(
     title: template.name,
     description: template.description,
     tags: template.tags,
-  })
+  }),
 );

--- a/src/pages/resources/ai-chat-app-template.tsx
+++ b/src/pages/resources/ai-chat-app-template.tsx
@@ -3,8 +3,7 @@ import { TemplateDetail } from "@/components/templates/template-detail";
 import { templates } from "@/lib/recipes/recipes";
 import { useAllRawRecipeMarkdown } from "@/lib/use-raw-content-markdown";
 import DatabricksLocalBootstrap from "@site/content/recipes/databricks-local-bootstrap.md";
-import LakebaseDataPersistence from "@site/content/recipes/lakebase-data-persistence.md";
-import ModelServingEndpointCreation from "@site/content/recipes/model-serving-endpoint-creation.md";
+import FoundationModelsApi from "@site/content/recipes/foundation-models-api.md";
 import AiChatModelServing from "@site/content/recipes/ai-chat-model-serving.md";
 import LakebaseChatPersistence from "@site/content/recipes/lakebase-chat-persistence.md";
 
@@ -23,9 +22,7 @@ export default function AiChatAppTemplatePage(): ReactNode {
     <TemplateDetail template={template} rawMarkdown={rawMarkdown}>
       <DatabricksLocalBootstrap />
       <hr />
-      <LakebaseDataPersistence />
-      <hr />
-      <ModelServingEndpointCreation />
+      <FoundationModelsApi />
       <hr />
       <AiChatModelServing />
       <hr />


### PR DESCRIPTION
## Summary

Rewrite the AI Chat App Template recipes based on hands-on build testing with AI SDK v6 and Databricks AI Gateway.

- **Streaming AI Chat**: AI SDK v6 API fixes (TextStreamChatTransport, parts arrays, sendMessage, maxOutputTokens), UIMessage-to-CoreMessage conversion, input focus restore, realistic layout override for scaffold padding
- **Lakebase Chat Persistence**: Add Lakebase project setup steps (create-project, scaffold with --features=lakebase, env vars, databricks.yml), deploy-first workflow with CLI permission grants, concrete recovery step for schema ownership trap, correct AI SDK v6 client guidance (no onResponse/initialMessages)
- **Query AI Gateway Endpoints**: New recipe replacing model-serving-endpoint-creation, with endpoint placeholders and workspace-specific discovery
- Remove todo CRUD recipe (lakebase-data-persistence) from AI Chat App Template page
- Add idempotency notes for databricks_create_role/GRANT commands
- Update @ai-sdk/openai version note to reflect v3.x

## Test plan

- [ ] `npm run build` passes
- [ ] AI Chat App Template page renders all four recipes in order
- [ ] Copy-as-markdown export includes all recipe content
- [ ] Follow instructions top-to-bottom and verify a working chat app deploys