### PR TITLE
Fix site config, duplicate headings, and code block copy button

### DIFF
--- a/api/content-markdown.ts
+++ b/api/content-markdown.ts
@@ -123,8 +123,6 @@ function readTemplateMarkdown(rootDir: string, slug: string): string {
       );
     }
 
-    lines.push(`## ${recipe.name}`);
-    lines.push("");
     lines.push(recipeContent.trim());
     lines.push("");
   }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -18,15 +18,15 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: "https://your-docusaurus-site.example.com",
+  url: "https://dev.databricks.com",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "facebook", // Usually your GitHub org/user name.
-  projectName: "docusaurus", // Usually your repo name.
+  organizationName: "databricks", // Usually your GitHub org/user name.
+  projectName: "devhub", // Usually your repo name.
 
   onBrokenLinks: "throw",
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -886,6 +886,19 @@
     @apply bg-black/2 dark:bg-white/3;
   }
 
+  .theme-code-block [class*="buttonGroup"] {
+    right: 0.5rem !important;
+    top: 0.5rem !important;
+  }
+
+  .theme-code-block [class*="buttonGroup"] button {
+    opacity: 0.5 !important;
+  }
+
+  .theme-code-block:hover [class*="buttonGroup"] button {
+    opacity: 1 !important;
+  }
+
   .recipe-content-card .theme-code-block {
     @apply my-8 min-w-0 w-full overflow-hidden rounded-xl border border-black/12 shadow-md dark:border-white/12;
   }

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -1,5 +1,6 @@
 import MDXComponents from "@theme-original/MDXComponents";
 import type { MDXComponentsObject } from "@theme/MDXComponents";
+import CodeBlock from "@theme/CodeBlock";
 import type { ComponentPropsWithoutRef } from "react";
 
 import { cn } from "@/lib/utils";
@@ -164,18 +165,29 @@ function Img({ className, ...props }: ComponentPropsWithoutRef<"img">) {
   );
 }
 
-function InlineCode({ className, ...props }: ComponentPropsWithoutRef<"code">) {
-  const isLikelyCodeBlock = Boolean(className?.includes("language-"));
+function InlineCode({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"code">) {
+  const languageMatch = className?.match(/language-(\w+)/);
+
+  if (languageMatch) {
+    const code =
+      typeof children === "string" ? children.replace(/\n$/, "") : children;
+    return <CodeBlock language={languageMatch[1]}>{code}</CodeBlock>;
+  }
 
   return (
     <code
       className={cn(
-        !isLikelyCodeBlock &&
-          "rounded-md border border-db-border bg-db-bg px-1.5 py-0.5 font-mono text-[0.88em] text-db-navy dark:bg-db-navy/35 dark:text-white",
+        "rounded-md border border-db-border bg-db-bg px-1.5 py-0.5 font-mono text-[0.88em] text-db-navy dark:bg-db-navy/35 dark:text-white",
         className,
       )}
       {...props}
-    />
+    >
+      {children}
+    </code>
   );
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "devCommand": "docusaurus start --port $PORT",
+  "devCommand": "docusaurus start --port $PORT --no-open",
   "functions": {
     "api/mcp.ts": {
       "includeFiles": "docs/**",


### PR DESCRIPTION
Minor tweaks while playing with the site:
- Set production URL to dev.databricks.com and update related org/project name config
- Fix duplicate `##` headings in template markdown API by removing redundant heading injection (recipe files already include their own)
- Fix code blocks inside list items rendering as inline code by promoting language-* code elements to full CodeBlock components
- Fix code copy button positioned off-screen due to `--ifm-pre-padding` shorthand breaking Docusaurus's `calc()` positioning
- Suppress Docusaurus auto-opening the internal port during `vercel dev`