### PR TITLE
Add docs-verify tests for Lakebase, Apps, and Deploy workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "npm run build && vitest run && npx playwright test",
     "test:smoke": "vitest run",
     "test:e2e": "npx playwright test",
+    "test:docs-verify": "vitest run --config vitest.docs-verify.config.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/tests/docs-verify/docs-verify-apps.test.ts
+++ b/tests/docs-verify/docs-verify-apps.test.ts
@@ -1,0 +1,237 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, test, expect, afterAll } from "vitest";
+import { cli, scaffoldApp, installAndBuild } from "../helpers/scaffold-app";
+
+const PROFILE = process.env.DATABRICKS_PROFILE;
+if (!PROFILE) {
+  throw new Error(
+    "DATABRICKS_PROFILE env var is required. Set it to a configured CLI profile name.",
+  );
+}
+const TEST_RUN_ID = Date.now().toString(36);
+const TEST_DIR = mkdtempSync(resolve(tmpdir(), "devhub-test-apps-"));
+const BASE_APP_NAME = `devhub-test-base-${TEST_RUN_ID}`;
+const LAKEBASE_APP_NAME = `devhub-test-lkb-${TEST_RUN_ID}`;
+
+const SKIP_CLEANUP = Boolean(process.env.SKIP_CLEANUP);
+console.log(`[setup] temp dir: ${TEST_DIR}`);
+
+afterAll(
+  () => {
+    if (SKIP_CLEANUP) {
+      console.log(`[cleanup] SKIP_CLEANUP set, keeping ${TEST_DIR}`);
+      return;
+    }
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+      console.log(`[cleanup] Removed ${TEST_DIR}`);
+    }
+  },
+  30_000,
+);
+
+describe("CLI prerequisites", { timeout: 30_000 }, () => {
+  test("databricks CLI is installed and meets minimum version", () => {
+    const version = execSync("databricks -v", { encoding: "utf-8" }).trim();
+    expect(version).toMatch(/Databricks CLI v0\.\d+\.\d+/);
+    const match = version.match(/v0\.(\d+)\.\d+/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThanOrEqual(295);
+  });
+
+  test("profile is authenticated and valid", () => {
+    const output = cli("auth profiles", PROFILE);
+    expect(output).toContain(PROFILE);
+    expect(output).toContain("YES");
+  });
+
+  test("workspace is reachable", () => {
+    const output = cli("workspace list /", PROFILE, { timeoutMs: 30_000 });
+    expect(output).toBeTruthy();
+  });
+});
+
+describe("Apps CLI reference", { timeout: 60_000 }, () => {
+  test("apps list is accessible", () => {
+    const output = cli("apps list", PROFILE, { timeoutMs: 30_000 });
+    expect(output).toBeTruthy();
+  });
+
+  test("apps init --help shows expected flags", () => {
+    const output = execSync("databricks apps init --help", {
+      encoding: "utf-8",
+    });
+    expect(output).toContain("--name");
+    expect(output).toContain("--version");
+    expect(output).toContain("--features");
+    expect(output).toContain("--set");
+    expect(output).toContain("--deploy");
+    expect(output).toContain("--run");
+    expect(output).toContain("--output-dir");
+    expect(output).toContain("--template");
+  });
+
+  test("apps manifest shows available plugins", () => {
+    const output = cli("apps manifest", PROFILE);
+    const manifest = JSON.parse(output);
+    expect(manifest.plugins).toBeTruthy();
+
+    const pluginNames = Object.keys(manifest.plugins);
+    expect(pluginNames).toContain("analytics");
+    expect(pluginNames).toContain("lakebase");
+    expect(pluginNames).toContain("genie");
+    expect(pluginNames).toContain("files");
+    expect(pluginNames).toContain("server");
+    console.log("[apps] available plugins:", pluginNames.join(", "));
+  });
+});
+
+describe("Scaffold base app (no features)", { timeout: 120_000 }, () => {
+  let appDir: string;
+
+  test("databricks apps init creates a project", () => {
+    appDir = scaffoldApp({
+      name: BASE_APP_NAME,
+      outputDir: TEST_DIR,
+      profile: PROFILE,
+    });
+    expect(existsSync(appDir)).toBe(true);
+  });
+
+  test("generated project has expected structure", () => {
+    const expectedFiles = [
+      "package.json",
+      "app.yaml",
+      "databricks.yml",
+      "server/server.ts",
+      "client/src/App.tsx",
+      "client/src/main.tsx",
+      "client/index.html",
+      "tsconfig.json",
+    ];
+    for (const file of expectedFiles) {
+      expect(
+        existsSync(resolve(appDir, file)),
+        `expected ${file} to exist`,
+      ).toBe(true);
+    }
+    console.log("[apps] all expected files present");
+  });
+
+  test("app.yaml has correct command", () => {
+    const appYaml = readFileSync(resolve(appDir, "app.yaml"), "utf-8");
+    expect(appYaml).toContain("npm");
+    expect(appYaml).toContain("start");
+    console.log("[apps] app.yaml:", appYaml.trim());
+  });
+
+  test("databricks.yml has app name and workspace host", () => {
+    const bundleYaml = readFileSync(resolve(appDir, "databricks.yml"), "utf-8");
+    expect(bundleYaml).toContain(BASE_APP_NAME);
+    expect(bundleYaml).toContain("host:");
+    console.log(
+      "[apps] databricks.yml (first 500 chars):",
+      bundleYaml.slice(0, 500),
+    );
+  });
+
+  test("server/server.ts imports createApp and server", () => {
+    const serverTs = readFileSync(
+      resolve(appDir, "server/server.ts"),
+      "utf-8",
+    );
+    expect(serverTs).toContain("createApp");
+    expect(serverTs).toContain("server");
+    console.log("[apps] server.ts:", serverTs.trim());
+  });
+
+  test("npm install and build succeed", () => {
+    installAndBuild(appDir);
+    expect(existsSync(resolve(appDir, "node_modules"))).toBe(true);
+    expect(existsSync(resolve(appDir, "dist"))).toBe(true);
+    expect(existsSync(resolve(appDir, "client/dist"))).toBe(true);
+  });
+});
+
+describe("Scaffold app with Lakebase feature", { timeout: 120_000 }, () => {
+  let appDir: string;
+
+  test("databricks apps init --features=lakebase creates a project", () => {
+    appDir = scaffoldApp({
+      name: LAKEBASE_APP_NAME,
+      outputDir: TEST_DIR,
+      profile: PROFILE,
+      features: "lakebase",
+      setFlags: [
+        "lakebase.postgres.branch=projects/fake/branches/production",
+        "lakebase.postgres.database=projects/fake/branches/production/databases/databricks_postgres",
+        "lakebase.postgres.databaseName=databricks_postgres",
+        "lakebase.postgres.endpointPath=projects/fake/branches/production/endpoints/primary",
+        "lakebase.postgres.host=localhost",
+        "lakebase.postgres.port=5432",
+        "lakebase.postgres.sslmode=require",
+      ],
+    });
+    expect(existsSync(appDir)).toBe(true);
+  });
+
+  test("generated project has Lakebase routes", () => {
+    const todoRoutes = readFileSync(
+      resolve(appDir, "server/routes/lakebase/todo-routes.ts"),
+      "utf-8",
+    );
+    expect(todoRoutes).toContain("appkit.lakebase.query");
+    expect(todoRoutes).toContain("/api/lakebase/todos");
+    console.log(
+      "[apps+lakebase] todo-routes.ts exists with lakebase query calls",
+    );
+  });
+
+  test("server.ts uses autoStart: false with lakebase", () => {
+    const serverTs = readFileSync(
+      resolve(appDir, "server/server.ts"),
+      "utf-8",
+    );
+    expect(serverTs).toContain("autoStart: false");
+    expect(serverTs).toContain("lakebase");
+    expect(serverTs).toContain("setupSampleLakebaseRoutes");
+    console.log("[apps+lakebase] server.ts:", serverTs.trim());
+  });
+
+  test("app.yaml includes LAKEBASE_ENDPOINT env var", () => {
+    const appYaml = readFileSync(resolve(appDir, "app.yaml"), "utf-8");
+    expect(appYaml).toContain("LAKEBASE_ENDPOINT");
+    console.log("[apps+lakebase] app.yaml:", appYaml.trim());
+  });
+
+  test("databricks.yml includes postgres resource", () => {
+    const bundleYaml = readFileSync(
+      resolve(appDir, "databricks.yml"),
+      "utf-8",
+    );
+    expect(bundleYaml).toContain("postgres");
+    console.log(
+      "[apps+lakebase] databricks.yml (first 800 chars):",
+      bundleYaml.slice(0, 800),
+    );
+  });
+
+  test("client has Lakebase page", () => {
+    const content = readFileSync(
+      resolve(appDir, "client/src/pages/lakebase/LakebasePage.tsx"),
+      "utf-8",
+    );
+    expect(content).toContain("/api/lakebase/todos");
+    console.log("[apps+lakebase] LakebasePage.tsx exists with API calls");
+  });
+
+  test("npm install and build succeed", () => {
+    installAndBuild(appDir);
+    expect(existsSync(resolve(appDir, "node_modules"))).toBe(true);
+    expect(existsSync(resolve(appDir, "dist"))).toBe(true);
+    expect(existsSync(resolve(appDir, "client/dist"))).toBe(true);
+  });
+});

--- a/tests/docs-verify/docs-verify-deploy.test.ts
+++ b/tests/docs-verify/docs-verify-deploy.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, test, expect, afterAll } from "vitest";
+import {
+  cli,
+  cliJson,
+  scaffoldApp,
+  installAndBuild,
+} from "../helpers/scaffold-app";
+
+const PROFILE = process.env.DATABRICKS_PROFILE;
+if (!PROFILE) {
+  throw new Error(
+    "DATABRICKS_PROFILE env var is required. Set it to a configured CLI profile name.",
+  );
+}
+const TEST_DIR = mkdtempSync(resolve(tmpdir(), "devhub-test-deploy-"));
+const APP_NAME = `devhub-dply-${Date.now().toString(36)}`;
+const appDir = resolve(TEST_DIR, APP_NAME);
+
+const SKIP_CLEANUP = Boolean(process.env.SKIP_CLEANUP);
+console.log(`[setup] temp dir: ${TEST_DIR}`);
+
+afterAll(
+  () => {
+    if (SKIP_CLEANUP) {
+      console.log(
+        `[cleanup] SKIP_CLEANUP set, keeping app ${APP_NAME} and ${TEST_DIR}`,
+      );
+      return;
+    }
+
+    try {
+      console.log(`[cleanup] Deleting app ${APP_NAME} from workspace`);
+      cli("apps delete --auto-approve", PROFILE, {
+        cwd: appDir,
+        timeoutMs: 300_000,
+      });
+      console.log(`[cleanup] App ${APP_NAME} deleted from workspace`);
+    } catch (e) {
+      console.warn(
+        "[cleanup] workspace delete failed:",
+        (e as Error).message,
+      );
+      try {
+        cli(`apps delete ${APP_NAME}`, PROFILE, { timeoutMs: 60_000 });
+        console.log(`[cleanup] App ${APP_NAME} deleted via direct API`);
+      } catch (e2) {
+        console.warn(
+          "[cleanup] direct API delete also failed:",
+          (e2 as Error).message,
+        );
+      }
+    }
+
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+      console.log(`[cleanup] Removed ${TEST_DIR}`);
+    }
+  },
+  600_000,
+);
+
+describe("Scaffold and build", { timeout: 180_000 }, () => {
+  test("scaffold, install, and build", () => {
+    scaffoldApp({
+      name: APP_NAME,
+      outputDir: TEST_DIR,
+      profile: PROFILE,
+    });
+    installAndBuild(appDir);
+    expect(existsSync(resolve(appDir, "dist"))).toBe(true);
+    expect(existsSync(resolve(appDir, "client/dist"))).toBe(true);
+  });
+});
+
+describe("Deploy to workspace", { timeout: 1_200_000 }, () => {
+  test("databricks apps deploy succeeds", () => {
+    cli("apps deploy --skip-validation", PROFILE, {
+      cwd: appDir,
+      timeoutMs: 1_200_000,
+    });
+  });
+
+  test("databricks apps get shows app status", () => {
+    const app = cliJson<{
+      name: string;
+      url: string;
+      compute_status: { state: string };
+      active_deployment: { status: { state: string } };
+    }>(`apps get ${APP_NAME}`, PROFILE);
+
+    console.log("[deploy] app name:", app.name);
+    console.log("[deploy] app url:", app.url);
+    console.log("[deploy] compute state:", app.compute_status?.state);
+    console.log(
+      "[deploy] deployment state:",
+      app.active_deployment?.status?.state,
+    );
+
+    expect(app.name).toBe(APP_NAME);
+    expect(app.url).toBeTruthy();
+  });
+
+  test("databricks apps logs returns output", () => {
+    const output = cli(`apps logs ${APP_NAME} --tail-lines 20`, PROFILE, {
+      timeoutMs: 30_000,
+    });
+    console.log("[deploy] logs (last 300 chars):", output.slice(-300));
+    expect(output).toBeTruthy();
+  });
+});

--- a/tests/docs-verify/docs-verify-lakebase.test.ts
+++ b/tests/docs-verify/docs-verify-lakebase.test.ts
@@ -1,0 +1,366 @@
+import { execSync } from "node:child_process";
+import { describe, test, expect, afterAll } from "vitest";
+import { cli, cliJson } from "../helpers/scaffold-app";
+
+const sleepSync = (ms: number) =>
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+const PROFILE = process.env.DATABRICKS_PROFILE;
+if (!PROFILE) {
+  throw new Error(
+    "DATABRICKS_PROFILE env var is required. Set it to a configured CLI profile name.",
+  );
+}
+const TEST_PREFIX = "devhub-test";
+const TEST_RUN_ID = Date.now().toString(36);
+const PROJECT_ID = `${TEST_PREFIX}-${TEST_RUN_ID}`;
+
+function retry<T>(
+  fn: () => T,
+  { attempts = 3, delayMs = 5_000, retryIf = () => true }: {
+    attempts?: number;
+    delayMs?: number;
+    retryIf?: (err: Error) => boolean;
+  } = {},
+): T {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return fn();
+    } catch (e) {
+      const err = e as Error;
+      if (i === attempts - 1 || !retryIf(err)) throw err;
+      console.warn(`[retry] attempt ${i + 1}/${attempts} failed: ${err.message}`);
+      sleepSync(delayMs);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+const isTransient = (err: Error) =>
+  err.message.includes("not authorized") || err.message.includes("TEMPORARILY_UNAVAILABLE");
+
+function pollOperation(operationName: string, maxAttempts = 60, delayS = 5) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const op = cliJson<{ done: boolean; name: string }>(
+      `postgres get-operation ${operationName}`,
+      PROFILE,
+    );
+    if (op.done) {
+      console.log(
+        `[lakebase] operation done after ~${i * delayS}s: ${operationName}`,
+      );
+      return op;
+    }
+    sleepSync(delayS * 1000);
+  }
+  throw new Error(
+    `Operation ${operationName} did not complete in ${maxAttempts * delayS}s`,
+  );
+}
+
+const SKIP_CLEANUP = Boolean(process.env.SKIP_CLEANUP);
+let createOperationName: string;
+
+afterAll(
+  () => {
+    if (SKIP_CLEANUP) {
+      console.log(
+        `[cleanup] SKIP_CLEANUP set, keeping project ${PROJECT_ID}`,
+      );
+      return;
+    }
+
+    try {
+      if (createOperationName) {
+        pollOperation(createOperationName);
+      }
+      console.log(`[cleanup] Deleting project ${PROJECT_ID}`);
+      const deleteOutput = cliJson<{ done: boolean; name: string }>(
+        `postgres delete-project projects/${PROJECT_ID} --no-wait`,
+        PROFILE,
+      );
+      if (!deleteOutput.done) {
+        pollOperation(deleteOutput.name);
+      }
+      console.log(`[cleanup] Project ${PROJECT_ID} deleted`);
+    } catch (e) {
+      console.warn("[cleanup] failed:", (e as Error).message);
+    }
+  },
+  600_000,
+);
+
+describe("Lakebase workflow", { timeout: 600_000 }, () => {
+  let branchName: string;
+  let endpointName: string;
+
+  test("create a Lakebase project", () => {
+    const op = cliJson<{ done: boolean; name: string }>(
+      `postgres create-project ${PROJECT_ID} --no-wait`,
+      PROFILE,
+      { timeoutMs: 60_000 },
+    );
+    expect(op.name).toBeTruthy();
+    createOperationName = op.name;
+    console.log("[lakebase] create-project operation:", op.name);
+    console.log("[lakebase] done immediately:", op.done);
+  });
+
+  test("poll create operation via get-operation", () => {
+    pollOperation(createOperationName);
+  });
+
+  test("list branches for the project", () => {
+    const branches = cliJson<Array<{ name: string }>>(
+      `postgres list-branches projects/${PROJECT_ID}`,
+      PROFILE,
+    );
+    expect(branches.length).toBeGreaterThan(0);
+
+    branchName = branches[0].name;
+    expect(branchName).toContain("production");
+    console.log("[lakebase] branch name:", branchName);
+  });
+
+  test("list endpoints for the production branch", () => {
+    const endpoints = cliJson<
+      Array<{ name: string; status: { hosts: { host: string } } }>
+    >(`postgres list-endpoints ${branchName}`, PROFILE);
+    expect(endpoints.length).toBeGreaterThan(0);
+
+    endpointName = endpoints[0].name;
+    expect(endpoints[0].status?.hosts?.host).toBeTruthy();
+    console.log("[lakebase] endpoint name:", endpointName);
+    console.log("[lakebase] endpoint host:", endpoints[0].status.hosts.host);
+  });
+
+  test("list databases for the production branch", () => {
+    const databases = cliJson<
+      Array<{ name: string; status: { postgres_database: string } }>
+    >(`postgres list-databases ${branchName}`, PROFILE);
+    expect(databases.length).toBeGreaterThan(0);
+
+    expect(databases[0].status?.postgres_database).toBeTruthy();
+    console.log("[lakebase] database name:", databases[0].status.postgres_database);
+  });
+
+  test("update endpoint: set pg_settings (log slow queries)", () => {
+    const spec = JSON.stringify({
+      spec: {
+        settings: {
+          pg_settings: {
+            log_min_duration_statement: "1000",
+          },
+        },
+      },
+    });
+    retry(
+      () => cli(
+        `postgres update-endpoint ${endpointName} "spec.settings" --json '${spec}'`,
+        PROFILE,
+        { timeoutMs: 120_000 },
+      ),
+      { retryIf: isTransient },
+    );
+    console.log("[lakebase] update-endpoint pg_settings done");
+  });
+
+  test("update endpoint: set autoscaling 0.5-1.0 CU", () => {
+    const spec = JSON.stringify({
+      spec: {
+        autoscaling_limit_min_cu: 0.5,
+        autoscaling_limit_max_cu: 1.0,
+      },
+    });
+    retry(
+      () => cli(
+        `postgres update-endpoint ${endpointName} "spec.autoscaling_limit_min_cu,spec.autoscaling_limit_max_cu" --json '${spec}'`,
+        PROFILE,
+        { timeoutMs: 120_000 },
+      ),
+      { retryIf: isTransient },
+    );
+    console.log("[lakebase] update-endpoint autoscaling 0.5-1.0 CU done");
+  });
+
+  test("get endpoint: verify type, autoscaling, and settings", () => {
+    const endpoint = cliJson<{
+      name: string;
+      status: {
+        endpoint_type: string;
+        autoscaling_limit_min_cu: number;
+        autoscaling_limit_max_cu: number;
+        current_state: string;
+        settings: {
+          pg_settings?: Record<string, string>;
+        };
+      };
+    }>(`postgres get-endpoint ${endpointName}`, PROFILE);
+
+    console.log("[lakebase] endpoint status:", JSON.stringify(endpoint.status));
+
+    expect(endpoint.status.endpoint_type).toBe("ENDPOINT_TYPE_READ_WRITE");
+    expect(endpoint.status.autoscaling_limit_min_cu).toBe(0.5);
+    expect(endpoint.status.autoscaling_limit_max_cu).toBe(1.0);
+    expect(endpoint.status.current_state).toBe("ACTIVE");
+    expect(endpoint.status.settings.pg_settings?.log_min_duration_statement).toBe("1000");
+  });
+
+  test("generate database credential (positional arg, not flag)", () => {
+    const output = cli(
+      `postgres generate-database-credential ${endpointName}`,
+      PROFILE,
+    );
+    expect(output).toBeTruthy();
+    console.log(
+      "[lakebase] credential generated (has password):",
+      output.includes("password"),
+    );
+  });
+
+  test("update project: set default_endpoint_settings with scale-to-zero", () => {
+    const spec = JSON.stringify({
+      spec: {
+        default_endpoint_settings: {
+          autoscaling_limit_min_cu: 0.5,
+          autoscaling_limit_max_cu: 1.0,
+          suspend_timeout_duration: "300s",
+        },
+      },
+    });
+    const project = cliJson<{
+      status: {
+        default_endpoint_settings: {
+          autoscaling_limit_min_cu: number;
+          autoscaling_limit_max_cu: number;
+          suspend_timeout_duration: string;
+        };
+      };
+    }>(
+      `postgres update-project projects/${PROJECT_ID} "spec.default_endpoint_settings" --json '${spec}'`,
+      PROFILE,
+      { timeoutMs: 120_000 },
+    );
+    expect(project.status.default_endpoint_settings.suspend_timeout_duration).toBe("300s");
+    expect(project.status.default_endpoint_settings.autoscaling_limit_min_cu).toBe(0.5);
+    expect(project.status.default_endpoint_settings.autoscaling_limit_max_cu).toBe(1.0);
+    console.log("[lakebase] project default_endpoint_settings updated");
+  });
+
+  test("create branch: new endpoint inherits project defaults", () => {
+    const branch = cliJson<{ name: string }>(
+      `postgres create-branch projects/${PROJECT_ID} test-defaults --json '${JSON.stringify({
+        spec: {
+          source_branch: `projects/${PROJECT_ID}/branches/production`,
+          no_expiry: true,
+        },
+      })}'`,
+      PROFILE,
+      { timeoutMs: 60_000 },
+    );
+    console.log("[lakebase] created branch:", branch.name);
+
+    const endpoints = cliJson<
+      Array<{
+        name: string;
+        status: {
+          autoscaling_limit_min_cu: number;
+          autoscaling_limit_max_cu: number;
+          suspend_timeout_duration?: string;
+        };
+      }>
+    >(`postgres list-endpoints ${branch.name}`, PROFILE);
+
+    expect(endpoints.length).toBeGreaterThan(0);
+    const ep = endpoints[0];
+    expect(ep.status.autoscaling_limit_min_cu).toBe(0.5);
+    expect(ep.status.autoscaling_limit_max_cu).toBe(1.0);
+    expect(ep.status.suspend_timeout_duration).toBe("300s");
+    console.log("[lakebase] new branch endpoint inherited defaults:", JSON.stringify(ep.status));
+  });
+
+  test("update endpoint: set scale-to-zero directly (feature-gated)", () => {
+    const spec = JSON.stringify({
+      spec: { suspend_timeout_duration: "300s" },
+    });
+    try {
+      cli(
+        `postgres update-endpoint ${endpointName} "spec.suspend_timeout_duration" --json '${spec}'`,
+        PROFILE,
+        { timeoutMs: 120_000 },
+      );
+      console.log("[lakebase] update-endpoint suspend_timeout_duration done");
+    } catch (e) {
+      const msg = (e as Error).message;
+      if (msg.includes("Unknown field path")) {
+        console.warn(
+          "[lakebase] suspend_timeout_duration via update-endpoint not supported on this workspace (feature-gated, skipping)",
+        );
+        return;
+      }
+      throw e;
+    }
+
+    const endpoint = cliJson<{
+      status: { suspend_timeout_duration?: string };
+    }>(`postgres get-endpoint ${endpointName}`, PROFILE);
+    expect(endpoint.status.suspend_timeout_duration).toBe("300s");
+    console.log(
+      "[lakebase] suspend_timeout_duration verified:",
+      endpoint.status.suspend_timeout_duration,
+    );
+  });
+});
+
+describe("Lakebase CLI reference", () => {
+  test("postgres subcommands match what we document", () => {
+    const output = execSync("databricks postgres --help", {
+      encoding: "utf-8",
+    });
+    const expectedCommands = [
+      "create-project",
+      "create-branch",
+      "create-endpoint",
+      "delete-project",
+      "delete-branch",
+      "delete-endpoint",
+      "get-project",
+      "get-branch",
+      "get-endpoint",
+      "get-operation",
+      "list-projects",
+      "list-branches",
+      "list-endpoints",
+      "generate-database-credential",
+      "update-project",
+      "update-branch",
+      "update-endpoint",
+    ];
+    for (const cmd of expectedCommands) {
+      expect(output).toContain(cmd);
+    }
+  });
+
+  test("create-project takes PROJECT_ID as positional arg", () => {
+    const output = execSync("databricks postgres create-project --help", {
+      encoding: "utf-8",
+    });
+    expect(output).toContain("PROJECT_ID");
+    expect(output).toContain("--no-wait");
+  });
+
+  test("generate-database-credential takes ENDPOINT as positional arg", () => {
+    const output = execSync(
+      "databricks postgres generate-database-credential --help",
+      { encoding: "utf-8" },
+    );
+    expect(output).toContain("ENDPOINT");
+  });
+
+  test("get-operation takes NAME as positional arg", () => {
+    const output = execSync("databricks postgres get-operation --help", {
+      encoding: "utf-8",
+    });
+    expect(output).toContain("NAME");
+  });
+});

--- a/tests/helpers/scaffold-app.ts
+++ b/tests/helpers/scaffold-app.ts
@@ -1,0 +1,68 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function run(
+  command: string,
+  options?: { cwd?: string; timeoutMs?: number },
+): string {
+  const result = execSync(command, {
+    encoding: "utf-8",
+    timeout: options?.timeoutMs ?? 30_000,
+    cwd: options?.cwd,
+    stdio: "pipe",
+  });
+  return result.trim();
+}
+
+export function cli(
+  command: string,
+  profile: string,
+  options?: { cwd?: string; timeoutMs?: number },
+): string {
+  return run(`databricks ${command} --profile ${profile}`, options);
+}
+
+export function cliJson<T = unknown>(
+  command: string,
+  profile: string,
+  options?: { cwd?: string; timeoutMs?: number },
+): T {
+  return JSON.parse(cli(`${command} -o json`, profile, options)) as T;
+}
+
+export function scaffoldApp(options: {
+  name: string;
+  outputDir: string;
+  profile: string;
+  features?: string;
+  setFlags?: string[];
+}): string {
+  const appDir = resolve(options.outputDir, options.name);
+  const args = [
+    "databricks apps init",
+    `--name ${options.name}`,
+    "--run none",
+    `--output-dir ${options.outputDir}`,
+    `--profile ${options.profile}`,
+  ];
+  if (options.features) {
+    args.push(`--features=${options.features}`);
+  }
+  for (const flag of options.setFlags ?? []) {
+    args.push(`--set ${flag}`);
+  }
+
+  run(args.join(" "), { timeoutMs: 60_000 });
+
+  if (!existsSync(appDir)) {
+    throw new Error(`Expected ${appDir} to exist after apps init`);
+  }
+
+  return appDir;
+}
+
+export function installAndBuild(appDir: string): void {
+  run("npm install", { cwd: appDir, timeoutMs: 120_000 });
+  run("npm run build", { cwd: appDir, timeoutMs: 120_000 });
+}

--- a/vitest.docs-verify.config.ts
+++ b/vitest.docs-verify.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
-    exclude: ["tests/docs-verify/**"],
+    include: ["tests/docs-verify/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Basic tests that verify documented Databricks CLI workflows, to help test and write accurate docs. Run separately via `DATABRICKS_PROFILE=<profile> bun run test:docs-verify`. 