### PR TITLE
fix: register heading anchors with Docusaurus broken link checker

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
   projectName: "devhub", // Usually your repo name.
 
   onBrokenLinks: "throw",
+  onBrokenAnchors: "throw",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -1,13 +1,24 @@
 import MDXComponents from "@theme-original/MDXComponents";
 import type { MDXComponentsObject } from "@theme/MDXComponents";
 import CodeBlock from "@theme/CodeBlock";
+import useBrokenLinks from "@docusaurus/useBrokenLinks";
 import type { ComponentPropsWithoutRef } from "react";
 
 import { cn } from "@/lib/utils";
 
-function H1({ className, ...props }: ComponentPropsWithoutRef<"h1">) {
+// Custom heading components must register their anchors with the broken link
+// checker, otherwise every heading is reported as a false-positive broken anchor.
+// See: https://github.com/facebook/docusaurus/issues/9880
+// Docs: https://docusaurus.io/docs/docusaurus-core#useBrokenLinks
+function useAnchor(id: string | undefined) {
+  useBrokenLinks().collectAnchor(id);
+}
+
+function H1({ className, id, ...props }: ComponentPropsWithoutRef<"h1">) {
+  useAnchor(id);
   return (
     <h1
+      id={id}
       className={cn(
         "mt-2 mb-4 scroll-m-24 text-3xl font-black tracking-tight text-db-navy md:text-4xl dark:text-white",
         className,
@@ -17,9 +28,11 @@ function H1({ className, ...props }: ComponentPropsWithoutRef<"h1">) {
   );
 }
 
-function H2({ className, ...props }: ComponentPropsWithoutRef<"h2">) {
+function H2({ className, id, ...props }: ComponentPropsWithoutRef<"h2">) {
+  useAnchor(id);
   return (
     <h2
+      id={id}
       className={cn(
         "mt-10 mb-3 scroll-m-24 border-b border-db-border pb-2.5 text-2xl font-bold tracking-tight text-db-navy first:mt-8 dark:text-white",
         className,
@@ -29,9 +42,11 @@ function H2({ className, ...props }: ComponentPropsWithoutRef<"h2">) {
   );
 }
 
-function H3({ className, ...props }: ComponentPropsWithoutRef<"h3">) {
+function H3({ className, id, ...props }: ComponentPropsWithoutRef<"h3">) {
+  useAnchor(id);
   return (
     <h3
+      id={id}
       className={cn(
         "mt-8 mb-2.5 scroll-m-24 text-xl font-semibold tracking-tight text-db-navy dark:text-white",
         className,
@@ -41,9 +56,11 @@ function H3({ className, ...props }: ComponentPropsWithoutRef<"h3">) {
   );
 }
 
-function H4({ className, ...props }: ComponentPropsWithoutRef<"h4">) {
+function H4({ className, id, ...props }: ComponentPropsWithoutRef<"h4">) {
+  useAnchor(id);
   return (
     <h4
+      id={id}
       className={cn(
         "mt-6 mb-2 scroll-m-24 text-lg font-semibold tracking-tight text-db-navy dark:text-white",
         className,
@@ -53,9 +70,11 @@ function H4({ className, ...props }: ComponentPropsWithoutRef<"h4">) {
   );
 }
 
-function H5({ className, ...props }: ComponentPropsWithoutRef<"h5">) {
+function H5({ className, id, ...props }: ComponentPropsWithoutRef<"h5">) {
+  useAnchor(id);
   return (
     <h5
+      id={id}
       className={cn(
         "mt-5 mb-1.5 scroll-m-24 text-base font-semibold tracking-tight text-db-navy dark:text-white",
         className,
@@ -65,9 +84,11 @@ function H5({ className, ...props }: ComponentPropsWithoutRef<"h5">) {
   );
 }
 
-function H6({ className, ...props }: ComponentPropsWithoutRef<"h6">) {
+function H6({ className, id, ...props }: ComponentPropsWithoutRef<"h6">) {
+  useAnchor(id);
   return (
     <h6
+      id={id}
       className={cn(
         "mt-4 mb-1.5 scroll-m-24 text-sm font-semibold tracking-tight text-db-navy/90 dark:text-white/90",
         className,


### PR DESCRIPTION
Custom MDX heading components (H1-H6) bypassed Docusaurus's built-in `Heading` component, which registers anchors via `useBrokenLinks().collectAnchor()`.

This caused 1,638 false-positive "Broken anchor" warnings across all 155 doc pages. Add a `useAnchor` helper that registers each heading's id, and set `onBrokenAnchors: "throw"` to catch real broken anchors going forward.

For related details, see:
- https://github.com/facebook/docusaurus/issues/9880
- https://docusaurus.io/docs/docusaurus-core#useBrokenLinks