### PR TITLE
docs: add Common / All Options tabbed CLI examples with option tables

### DIFF
--- a/docs/agents/ai-gateway.md
+++ b/docs/agents/ai-gateway.md
@@ -8,9 +8,24 @@ AI Gateway is a governance and monitoring layer for model serving endpoints. It 
 
 ## List available endpoints
 
-```bash
-databricks serving-endpoints list --profile <PROFILE>
+```bash title="Common"
+databricks serving-endpoints list -o json
 ```
+
+```bash title="All Options"
+databricks serving-endpoints list \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                          |
+| ----------- | -------- | ------------------------------------ |
+| `--debug`   | no       | Enable debug logging                 |
+| `-o json`   | no       | Output as JSON (default: text)       |
+| `--target`  | no       | Bundle target to use (if applicable) |
+| `--profile` | no       | Databricks CLI profile name          |
 
 Foundation Model API endpoints (prefixed `databricks-`) are available in most workspaces with AI Gateway built in. For example, `databricks-claude-sonnet-4-6`. Availability varies by workspace.
 
@@ -59,9 +74,25 @@ Foundation Model API endpoints (prefixed `databricks-`) are available in most wo
 
 ## Inspect an endpoint
 
-```bash
-databricks serving-endpoints get <endpoint-name> -o json --profile <PROFILE>
+```bash title="Common"
+databricks serving-endpoints get databricks-claude-sonnet-4-6 -o json
 ```
+
+```bash title="All Options"
+databricks serving-endpoints get $ENDPOINT_NAME \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                          |
+| ----------- | -------- | ------------------------------------ |
+| `NAME`      | yes      | Serving endpoint name                |
+| `--debug`   | no       | Enable debug logging                 |
+| `-o json`   | no       | Output as JSON (default: text)       |
+| `--target`  | no       | Bundle target to use (if applicable) |
+| `--profile` | no       | Databricks CLI profile name          |
 
 Check for `ai_gateway` in the response to confirm AI Gateway is configured on the endpoint.
 
@@ -103,11 +134,38 @@ Check for `ai_gateway` in the response to confirm AI Gateway is configured on th
 
 ## Query an endpoint
 
-```bash
-databricks serving-endpoints query <endpoint-name> \
-  --json '{"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100}' \
-  --profile <PROFILE>
+```bash title="Common"
+databricks serving-endpoints query databricks-claude-sonnet-4-6 \
+  --json '{"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100}'
 ```
+
+```bash title="All Options"
+databricks serving-endpoints query $ENDPOINT_NAME \
+  --json '{"messages": [{"role": "user", "content": "Hello"}]}' \
+  --max-tokens 100 \
+  --temperature 0.7 \
+  --n 1 \
+  --stream \
+  --client-request-id $REQUEST_ID \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option                | Required | Description                                           |
+| --------------------- | -------- | ----------------------------------------------------- |
+| `NAME`                | yes      | Serving endpoint name                                 |
+| `--json`              | no       | Inline JSON or `@path/to/file.json` with request body |
+| `--max-tokens`        | no       | Max tokens for completions and chat endpoints         |
+| `--temperature`       | no       | Sampling temperature                                  |
+| `--n`                 | no       | Number of candidates to generate                      |
+| `--stream`            | no       | Enable streaming responses                            |
+| `--client-request-id` | no       | Request identifier for inference/usage tables         |
+| `--debug`             | no       | Enable debug logging                                  |
+| `-o json`             | no       | Output as JSON (default: text)                        |
+| `--target`            | no       | Bundle target to use (if applicable)                  |
+| `--profile`           | no       | Databricks CLI profile name                           |
 
 <details>
 <summary>Example response</summary>
@@ -136,27 +194,62 @@ databricks serving-endpoints query <endpoint-name> \
 
 ## Create a serving endpoint
 
-```bash
-databricks serving-endpoints create <endpoint-name> \
+```bash title="Common"
+databricks serving-endpoints create my-model-endpoint \
   --json '{
     "config": {
       "served_entities": [
         {
-          "name": "<entity-name>",
-          "entity_name": "<foundation-model-or-registered-model>",
+          "name": "my-entity",
+          "entity_name": "my-registered-model",
           "workload_size": "Small",
           "scale_to_zero_enabled": true
         }
       ]
     }
-  }' \
-  --profile <PROFILE>
+  }'
 ```
+
+```bash title="All Options"
+databricks serving-endpoints create $ENDPOINT_NAME \
+  --json @$CONFIG_FILE \
+  --route-optimized \
+  --budget-policy-id $BUDGET_POLICY_ID \
+  --description "$DESCRIPTION" \
+  --no-wait \
+  --timeout 20m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option               | Required | Description                                                  |
+| -------------------- | -------- | ------------------------------------------------------------ |
+| `NAME`               | yes      | Endpoint name (alphanumeric, dashes, underscores)            |
+| `--json`             | yes      | Inline JSON or `@path/to/file.json` with endpoint config     |
+| `--route-optimized`  | no       | Enable route optimization                                    |
+| `--budget-policy-id` | no       | Budget policy to apply                                       |
+| `--description`      | no       | Endpoint description                                         |
+| `--no-wait`          | no       | Return immediately instead of waiting for NOT_UPDATING state |
+| `--timeout`          | no       | Max time to wait for completion (default: 20m)               |
+| `--debug`            | no       | Enable debug logging                                         |
+| `-o json`            | no       | Output as JSON (default: text)                               |
+| `--target`           | no       | Bundle target to use (if applicable)                         |
+| `--profile`          | no       | Databricks CLI profile name                                  |
 
 Wait for the endpoint to reach READY state:
 
-```bash
-databricks serving-endpoints get <endpoint-name> -o json --profile <PROFILE>
+```bash title="Common"
+databricks serving-endpoints get my-model-endpoint -o json
+```
+
+```bash title="All Options"
+databricks serving-endpoints get $ENDPOINT_NAME \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
 ```
 
 ## Governance features

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -76,12 +76,34 @@ For deployed apps, the platform injects `DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID
 
 Create an experiment for agent tracing:
 
-```bash
-DATABRICKS_USERNAME=$(databricks current-user me --profile <PROFILE> -o json | jq -r .userName)
+```bash title="Common"
+DATABRICKS_USERNAME=$(databricks current-user me -o json | jq -r .userName)
 databricks experiments create-experiment \
-  /Users/$DATABRICKS_USERNAME/my-agent-experiment \
-  --profile <PROFILE>
+  /Users/$DATABRICKS_USERNAME/my-agent-experiment
 ```
+
+```bash title="All Options"
+DATABRICKS_USERNAME=$(databricks current-user me \
+  --profile $DATABRICKS_PROFILE -o json | jq -r .userName)
+databricks experiments create-experiment \
+  /Users/$DATABRICKS_USERNAME/$EXPERIMENT_NAME \
+  --artifact-location $ARTIFACT_LOCATION \
+  --json '{}' \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option                | Required | Description                                           |
+| --------------------- | -------- | ----------------------------------------------------- |
+| `NAME`                | yes      | Experiment name (typically `/Users/<email>/<name>`)   |
+| `--artifact-location` | no       | Storage location for experiment artifacts             |
+| `--json`              | no       | Inline JSON or `@path/to/file.json` with request body |
+| `--debug`             | no       | Enable debug logging                                  |
+| `-o json`             | no       | Output as JSON (default: text)                        |
+| `--target`            | no       | Bundle target to use (if applicable)                  |
+| `--profile`           | no       | Databricks CLI profile name                           |
 
 Add the returned `experiment_id` to your `.env`:
 
@@ -118,13 +140,45 @@ Customize evaluation by editing `agent_server/evaluate_agent.py` to adjust the d
 
 The template uses [Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/):
 
-```bash
-databricks bundle validate --profile <PROFILE>
-databricks bundle deploy --profile <PROFILE>
-databricks bundle run agent_openai_agents_sdk --profile <PROFILE>
+```bash title="Common"
+databricks bundle validate
+databricks bundle deploy
+databricks bundle run agent_openai_agents_sdk
 ```
 
-`bundle deploy` uploads files and configures resources. `bundle run` starts the app. Both are required for each update.
+```bash title="All Options"
+databricks bundle validate \
+  --strict \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+
+databricks bundle deploy \
+  --auto-approve \
+  --force-lock \
+  --force \
+  --fail-on-active-runs \
+  --cluster-id $CLUSTER_ID \
+  --plan $PLAN_FILE \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+
+databricks bundle run agent_openai_agents_sdk \
+  --no-wait \
+  --restart \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+See [Deploy](/docs/agents/getting-started#deploy) for option tables for each command. `bundle deploy` uploads files and configures resources. `bundle run` starts the app. Both are required for each update.
 
 To grant access to additional resources (serving endpoints, Genie spaces, Vector Search), add them to `databricks.yml` and redeploy.
 
@@ -171,13 +225,64 @@ For streaming, add `"stream": true` to the request body.
 
 ## Managing the app
 
-```bash
-databricks apps get <app-name> -o json --profile <PROFILE>
-databricks apps logs <app-name> --profile <PROFILE>
-databricks apps stop <app-name> --profile <PROFILE>
-databricks apps start <app-name> --profile <PROFILE>
-databricks apps delete <app-name> --profile <PROFILE>
+```bash title="Common"
+databricks apps get agent-openai-agents-sdk -o json
+databricks apps logs agent-openai-agents-sdk
+databricks apps stop agent-openai-agents-sdk
+databricks apps start agent-openai-agents-sdk
+databricks apps delete agent-openai-agents-sdk
 ```
+
+```bash title="All Options"
+databricks apps get $APP_NAME \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+
+databricks apps logs $APP_NAME \
+  --follow \
+  --tail-lines 200 \
+  --timeout 5m \
+  --source APP \
+  --search "$SEARCH_TERM" \
+  --output-file $LOG_FILE \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+
+databricks apps stop $APP_NAME \
+  --no-wait \
+  --timeout 20m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+
+databricks apps start $APP_NAME \
+  --no-wait \
+  --timeout 20m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+
+databricks apps delete $APP_NAME \
+  --auto-approve \
+  --force-lock \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
+
+See [Apps development](/docs/apps/development) for option tables covering `get`, `logs`, `stop`, `start`, and `delete`. `apps delete` prompts for confirmation; pass `--auto-approve` in CI to skip the prompt.
 
 ## Related recipes
 

--- a/docs/agents/getting-started.md
+++ b/docs/agents/getting-started.md
@@ -26,27 +26,26 @@ The template includes an agent with a code interpreter tool, a chat UI, MLflow t
 
 ## Run locally
 
-```bash
+```bash title="Common"
 uv run quickstart
+```
+
+```bash title="All Options"
+uv run quickstart \
+  --profile $DATABRICKS_PROFILE \
+  --lakebase-autoscaling-project $PROJECT_ID \
+  --lakebase-autoscaling-branch $BRANCH_ID
+```
+
+Without Lakebase (for example CI or templates that do not use Lakebase):
+
+```bash
+uv run quickstart --skip-lakebase
 ```
 
 The quickstart script verifies your environment, configures Databricks authentication, creates an MLflow experiment for tracing, and starts the agent server with a built-in chat UI at `http://localhost:8000` (override with `--port`). If port 3000 is in use, set `CHAT_APP_PORT` in `.env` to a free port.
 
-For non-interactive setup (CI or coding agents):
-
-```bash
-uv run quickstart --profile <PROFILE> --skip-lakebase
-```
-
-If your template requires Lakebase (memory-enabled agents), pass the project and branch instead of skipping:
-
-```bash
-uv run quickstart --profile <PROFILE> \
-  --lakebase-autoscaling-project <PROJECT> \
-  --lakebase-autoscaling-branch <BRANCH>
-```
-
-See [Lakebase Getting Started](/docs/lakebase/getting-started) for creating or finding projects.
+See [Lakebase Getting Started](/docs/lakebase/getting-started) for creating or finding projects when you use Lakebase-backed templates.
 
 For subsequent runs:
 
@@ -68,26 +67,118 @@ The template uses [Databricks Asset Bundles](https://docs.databricks.com/aws/en/
 
 Validate the configuration:
 
-```bash
-databricks bundle validate --profile <PROFILE>
+```bash title="Common"
+databricks bundle validate
 ```
+
+```bash title="All Options"
+databricks bundle validate \
+  --strict \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                                                       |
+| ----------- | -------- | ----------------------------------------------------------------- |
+| `--strict`  | no       | Treat warnings as errors                                          |
+| `--debug`   | no       | Enable debug logging                                              |
+| `-o json`   | no       | Output as JSON (default: text)                                    |
+| `--var`     | no       | Set values for bundle config variables (e.g. `--var="key=value"`) |
+| `--target`  | no       | Bundle target (e.g. `dev`, `prod`)                                |
+| `--profile` | no       | Databricks CLI profile name                                       |
 
 Deploy and start the app:
 
-```bash
-databricks bundle deploy --profile <PROFILE>
-databricks bundle run agent_openai_agents_sdk --profile <PROFILE>
+```bash title="Common"
+databricks bundle deploy
+databricks bundle run agent_openai_agents_sdk
 ```
 
+```bash title="All Options"
+databricks bundle deploy \
+  --auto-approve \
+  --force-lock \
+  --force \
+  --fail-on-active-runs \
+  --cluster-id $CLUSTER_ID \
+  --plan $PLAN_FILE \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+
+databricks bundle run agent_openai_agents_sdk \
+  --no-wait \
+  --restart \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+### `databricks bundle deploy`
+
+| Option                  | Required | Description                                                       |
+| ----------------------- | -------- | ----------------------------------------------------------------- |
+| `--auto-approve`        | no       | Skip confirmation prompts                                         |
+| `--force-lock`          | no       | Force acquisition of deployment lock                              |
+| `--force`               | no       | Force-override Git branch validation                              |
+| `--fail-on-active-runs` | no       | Fail if jobs or pipelines are running                             |
+| `--cluster-id`          | no       | Override cluster in deployment                                    |
+| `--plan`                | no       | Path to JSON plan file                                            |
+| `--debug`               | no       | Enable debug logging                                              |
+| `-o json`               | no       | Output as JSON (default: text)                                    |
+| `--var`                 | no       | Set values for bundle config variables (e.g. `--var="key=value"`) |
+| `--target`              | no       | Bundle target (e.g. `dev`, `prod`)                                |
+| `--profile`             | no       | Databricks CLI profile name                                       |
+
+### `databricks bundle run`
+
+| Option      | Required | Description                                                                |
+| ----------- | -------- | -------------------------------------------------------------------------- |
+| `KEY`       | yes      | Bundle resource key from `databricks.yml` (e.g. `agent_openai_agents_sdk`) |
+| `--no-wait` | no       | Return immediately instead of waiting for completion                       |
+| `--restart` | no       | Restart if already running                                                 |
+| `--debug`   | no       | Enable debug logging                                                       |
+| `-o json`   | no       | Output as JSON (default: text)                                             |
+| `--var`     | no       | Set values for bundle config variables (e.g. `--var="key=value"`)          |
+| `--target`  | no       | Bundle target (e.g. `dev`, `prod`)                                         |
+| `--profile` | no       | Databricks CLI profile name                                                |
+
 `bundle deploy` uploads code and configures resources. `bundle run` starts (or restarts) the app with the new code. Both are required for each update. The resource key (`agent_openai_agents_sdk`) is defined in `databricks.yml`. The app name (`agent-openai-agents-sdk`) is what appears in the workspace.
+
+In CI, pass `--auto-approve` to `bundle deploy` to skip confirmation prompts that occur when the plan includes destructive actions (e.g., recreating a UC schema or pipeline).
 
 ## Verify
 
 Check the app status:
 
-```bash
-databricks apps get agent-openai-agents-sdk -o json --profile <PROFILE>
+```bash title="Common"
+databricks apps get agent-openai-agents-sdk -o json
 ```
+
+```bash title="All Options"
+databricks apps get $APP_NAME \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                                                       |
+| ----------- | -------- | ----------------------------------------------------------------- |
+| `NAME`      | yes      | App name                                                          |
+| `--debug`   | no       | Enable debug logging                                              |
+| `-o json`   | no       | Output as JSON (default: text)                                    |
+| `--target`  | no       | Bundle target to use (if applicable)                              |
+| `--var`     | no       | Set values for bundle config variables (e.g. `--var="key=value"`) |
+| `--profile` | no       | Databricks CLI profile name                                       |
 
 Query the deployed agent using the `url` field from the `apps get` output (OAuth required, PATs are not supported):
 

--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -10,12 +10,34 @@ Monitor, debug, and improve agents using MLflow tracing, evaluation, and Databri
 
 Create an experiment to store traces and evaluation results:
 
-```bash
-DATABRICKS_USERNAME=$(databricks current-user me --profile <PROFILE> -o json | jq -r .userName)
+```bash title="Common"
+DATABRICKS_USERNAME=$(databricks current-user me -o json | jq -r .userName)
 databricks experiments create-experiment \
-  /Users/$DATABRICKS_USERNAME/my-agent-experiment \
-  --profile <PROFILE>
+  /Users/$DATABRICKS_USERNAME/my-agent-experiment
 ```
+
+```bash title="All Options"
+DATABRICKS_USERNAME=$(databricks current-user me \
+  --profile $DATABRICKS_PROFILE -o json | jq -r .userName)
+databricks experiments create-experiment \
+  /Users/$DATABRICKS_USERNAME/$EXPERIMENT_NAME \
+  --artifact-location $ARTIFACT_LOCATION \
+  --json '{}' \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option                | Required | Description                                           |
+| --------------------- | -------- | ----------------------------------------------------- |
+| `NAME`                | yes      | Experiment name (typically `/Users/<email>/<name>`)   |
+| `--artifact-location` | no       | Storage location for experiment artifacts             |
+| `--json`              | no       | Inline JSON or `@path/to/file.json` with request body |
+| `--debug`             | no       | Enable debug logging                                  |
+| `-o json`             | no       | Output as JSON (default: text)                        |
+| `--target`            | no       | Bundle target to use (if applicable)                  |
+| `--profile`           | no       | Databricks CLI profile name                           |
 
 Set the returned `experiment_id` in your `.env`:
 

--- a/docs/apps/development.md
+++ b/docs/apps/development.md
@@ -25,21 +25,73 @@ LAKEBASE_ENDPOINT=projects/<project>/branches/production/endpoints/primary
 
 ## Deploy
 
-From the project root (where `databricks.yml` lives):
-
-```bash
-databricks apps deploy --profile <PROFILE>
+```bash title="Common"
+databricks apps deploy
 ```
+
+```bash title="All Options"
+databricks apps deploy $APP_NAME \
+  --deployment-id $DEPLOYMENT_ID \
+  --json @$CONFIG_FILE \
+  --source-code-path $SOURCE_PATH \
+  --mode SNAPSHOT \
+  --skip-validation \
+  --skip-tests \
+  --force \
+  --no-wait \
+  --timeout 20m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option               | Required | Description                                                                                |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `APP_NAME`           | no       | App name. Omit when running from a project directory (auto-detected from `databricks.yml`) |
+| `--skip-validation`  | no       | Skip project validation (build, typecheck, lint)                                           |
+| `--skip-tests`       | no       | Skip running tests during validation (default: true)                                       |
+| `--force`            | no       | Force-override Git branch validation                                                       |
+| `--no-wait`          | no       | Return immediately instead of waiting for SUCCEEDED state                                  |
+| `--timeout`          | no       | Max time to wait for completion (default: 20m)                                             |
+| `--mode`             | no       | Source code mode: `AUTO_SYNC` or `SNAPSHOT`                                                |
+| `--deployment-id`    | no       | Unique deployment identifier                                                               |
+| `--source-code-path` | no       | Workspace file system path for source code                                                 |
+| `--json`             | no       | Inline JSON or `@path/to/file.json` with request body                                      |
+| `--debug`            | no       | Enable debug logging                                                                       |
+| `-o json`            | no       | Output as JSON (default: text)                                                             |
+| `--target`           | no       | Bundle target to use (if applicable)                                                       |
+| `--var`              | no       | Set values for bundle config variables (e.g. `--var="key=value"`)                          |
+| `--profile`          | no       | Databricks CLI profile name                                                                |
 
 The CLI validates configuration, builds the project, uploads it, and starts the app. No `--source-code-path` is needed when deploying from a scaffolded AppKit project.
 
 ### Verify the deployment
 
-Check app status:
+Check that the app deployed successfully:
 
-```bash
-databricks apps get my-app -o json --profile <PROFILE>
+```bash title="Common"
+databricks apps get my-app -o json
 ```
+
+```bash title="All Options"
+databricks apps get $APP_NAME \
+  -o json \
+  --debug \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                                                       |
+| ----------- | -------- | ----------------------------------------------------------------- |
+| `NAME`      | yes      | App name                                                          |
+| `-o json`   | no       | Output as JSON                                                    |
+| `--debug`   | no       | Enable debug logging                                              |
+| `--target`  | no       | Bundle target to use (if applicable)                              |
+| `--var`     | no       | Set values for bundle config variables (e.g. `--var="key=value"`) |
+| `--profile` | no       | Databricks CLI profile name                                       |
 
 <details>
 <summary>Example output</summary>
@@ -84,9 +136,39 @@ databricks apps get my-app -o json --profile <PROFILE>
 
 View logs:
 
-```bash
-databricks apps logs my-app --profile <PROFILE>
+```bash title="Common"
+databricks apps logs my-app
 ```
+
+```bash title="All Options"
+databricks apps logs $APP_NAME \
+  --follow \
+  --tail-lines 200 \
+  --timeout 5m \
+  --source APP \
+  --search "$SEARCH_TERM" \
+  --output-file $LOG_FILE \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option            | Required | Description                                                         |
+| ----------------- | -------- | ------------------------------------------------------------------- |
+| `NAME`            | no       | App name. Omit from project directory (auto-detected)               |
+| `-f` / `--follow` | no       | Stream logs until interrupted                                       |
+| `--tail-lines`    | no       | Recent log lines to show before streaming (default: 200, 0 for all) |
+| `--timeout`       | no       | Max streaming time with `--follow` (0 disables)                     |
+| `--search`        | no       | Search term to filter logs                                          |
+| `--source`        | no       | Filter by source: `APP`, `SYSTEM`, or both                          |
+| `--output-file`   | no       | File path to write logs (in addition to stdout)                     |
+| `--debug`         | no       | Enable debug logging                                                |
+| `-o json`         | no       | Output as JSON (default: text)                                      |
+| `--target`        | no       | Bundle target to use (if applicable)                                |
+| `--var`           | no       | Set values for bundle config variables (e.g. `--var="key=value"`)   |
+| `--profile`       | no       | Databricks CLI profile name                                         |
 
 <details>
 <summary>Example log output</summary>
@@ -109,12 +191,6 @@ databricks apps logs my-app --profile <PROFILE>
 ```
 
 </details>
-
-Use `--tail-lines` to limit output:
-
-```bash
-databricks apps logs my-app --tail-lines 100 --profile <PROFILE>
-```
 
 ## Environment configuration
 
@@ -157,7 +233,7 @@ Before deploying to production:
 
 ## CI/CD
 
-For non-interactive deploys in CI, set `DATABRICKS_HOST` and `DATABRICKS_TOKEN` (or use OAuth with `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET`):
+For automated deploys in CI, set `DATABRICKS_HOST` and `DATABRICKS_TOKEN` (or use OAuth with `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET`):
 
 ```bash
 DATABRICKS_HOST=https://<workspace>.cloud.databricks.com \
@@ -175,13 +251,55 @@ See the [Databricks CLI authentication guide](/docs/tools/databricks-cli#authent
 
 ## Managing apps
 
-Stop, start, or delete apps from the CLI:
-
-```bash
-databricks apps stop my-app --profile <PROFILE>
-databricks apps start my-app --profile <PROFILE>
-databricks apps delete my-app --profile <PROFILE>
+```bash title="Common"
+databricks apps stop my-app
+databricks apps start my-app
+databricks apps delete my-app
 ```
+
+```bash title="All Options"
+databricks apps stop $APP_NAME \
+  --no-wait \
+  --timeout 20m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+
+databricks apps start $APP_NAME \
+  --no-wait \
+  --timeout 20m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+
+databricks apps delete $APP_NAME \
+  --auto-approve \
+  --force-lock \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option           | Required | Description                                                       |
+| ---------------- | -------- | ----------------------------------------------------------------- |
+| `NAME`           | no       | App name. Omit from project directory (auto-detected)             |
+| `--no-wait`      | no       | Return immediately (stop/start only)                              |
+| `--timeout`      | no       | Max time to wait for completion (default: 20m, stop/start only)   |
+| `--auto-approve` | no       | Skip confirmation prompts (delete only)                           |
+| `--force-lock`   | no       | Force acquisition of deployment lock (delete only)                |
+| `--debug`        | no       | Enable debug logging                                              |
+| `-o json`        | no       | Output as JSON (default: text)                                    |
+| `--target`       | no       | Bundle target to use (if applicable)                              |
+| `--var`          | no       | Set values for bundle config variables (e.g. `--var="key=value"`) |
+| `--profile`      | no       | Databricks CLI profile name                                       |
+
+`apps delete` prompts for confirmation. Pass `--auto-approve` in CI to skip the prompt.
 
 ## All app recipes
 

--- a/docs/apps/getting-started.md
+++ b/docs/apps/getting-started.md
@@ -14,30 +14,49 @@ Databricks Apps hosts and operates web applications inside your Databricks works
 
 ## Scaffold an app
 
-Interactive mode lets you select plugins and configure resources:
-
-```bash
-databricks apps init
+```bash title="Common"
+databricks apps init --name my-app
 ```
 
-App names must be lowercase, hyphenated, and 26 characters or fewer.
-
-For non-interactive use (CI, agents), pass `--name` and optional `--features`/`--set` flags:
-
-```bash
-databricks apps init --name my-app --run none --profile <PROFILE>
+```bash title="All Options"
+databricks apps init \
+  --name $APP_NAME \
+  --features lakebase \
+  --set lakebase.postgres.branch=projects/$PROJECT_ID/branches/production \
+  --set lakebase.postgres.database=projects/$PROJECT_ID/branches/production/databases/$DB_NAME \
+  --description "My Databricks App" \
+  --output-dir $OUTPUT_DIR \
+  --template $TEMPLATE_URL \
+  --branch $BRANCH \
+  --deploy \
+  --run none \
+  --version $APPKIT_VERSION \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
 ```
 
-Add plugins with `--features`:
+| Option          | Required | Description                                                                                             |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `--name`        | no       | App name (lowercase, hyphenated, 26 chars max). Suppresses prompts and applies defaults for other flags |
+| `--features`    | no       | Comma-separated plugins to enable (e.g. `lakebase`, `analytics`, `genie`)                               |
+| `--set`         | no       | Resource values: `plugin.resourceKey.field=value`. Multi-field resources require all fields together    |
+| `--description` | no       | App description                                                                                         |
+| `--output-dir`  | no       | Directory to write the project to                                                                       |
+| `--deploy`      | no       | Deploy the app after creation                                                                           |
+| `--run`         | no       | Run after creation: `none`, `dev`, or `dev-remote`                                                      |
+| `--template`    | no       | Template path (local directory or GitHub URL)                                                           |
+| `--branch`      | no       | Git branch or tag (for GitHub templates, mutually exclusive with `--version`)                           |
+| `--version`     | no       | AppKit version to use (default: latest release, `latest` for main branch)                               |
+| `--debug`       | no       | Enable debug logging                                                                                    |
+| `-o json`       | no       | Output as JSON (default: text)                                                                          |
+| `--target`      | no       | Bundle target to use (if applicable)                                                                    |
+| `--var`         | no       | Set values for bundle config variables (e.g. `--var="key=value"`)                                       |
+| `--profile`     | no       | Databricks CLI profile name                                                                             |
 
-```bash
-databricks apps init --name my-app --features=lakebase \
-  --set lakebase.postgres.branch=projects/<project>/branches/production \
-  --set lakebase.postgres.database=projects/<project>/branches/production/databases/<db-name> \
-  --run none --profile <PROFILE>
-```
-
-The CLI derives defaults for unset values. See [Apps Plugins](/docs/apps/plugins) for the full list of built-in plugins and `databricks apps init --help` for all `--set` keys.
+Passing `--name` suppresses prompts and uses defaults for unspecified options. App names must be lowercase, hyphenated, and 26 characters or fewer. See [Apps Plugins](/docs/apps/plugins) for the full list of built-in plugins and `databricks apps init --help` for all `--set` keys.
 
 ## Build an app from a template
 

--- a/docs/apps/plugins.md
+++ b/docs/apps/plugins.md
@@ -10,14 +10,58 @@ AppKit plugins are modular extensions that add capabilities to your app. Built-i
 
 List available plugins:
 
-```bash
-databricks apps manifest --profile <PROFILE>
+```bash title="Common"
+databricks apps manifest
 ```
 
-Select plugins interactively when scaffolding a new app:
+```bash title="All Options"
+databricks apps manifest \
+  --template $TEMPLATE_URL \
+  --branch $BRANCH \
+  --version $APPKIT_VERSION \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
+```
 
-```bash
-databricks apps init
+| Option       | Required | Description                                                             |
+| ------------ | -------- | ----------------------------------------------------------------------- |
+| `--template` | no       | Template path (local directory or GitHub URL). Default: AppKit template |
+| `--branch`   | no       | Git branch or tag (mutually exclusive with `--version`)                 |
+| `--version`  | no       | AppKit version for default template (default: main)                     |
+| `--debug`    | no       | Enable debug logging                                                    |
+| `-o json`    | no       | Output as JSON (default: text)                                          |
+| `--target`   | no       | Bundle target to use (if applicable)                                    |
+| `--var`      | no       | Set values for bundle config variables (e.g. `--var="key=value"`)       |
+| `--profile`  | no       | Databricks CLI profile name                                             |
+
+Use the Common tab for a typical non-interactive scaffold (`--name` suppresses prompts and applies defaults). Use the All Options tab to choose plugins and resource values with flags instead of prompts. For every `databricks apps init` flag, see the option table in [Apps getting started](/docs/apps/getting-started#scaffold-an-app).
+
+```bash title="Common"
+databricks apps init --name my-app
+```
+
+```bash title="All Options"
+databricks apps init \
+  --name $APP_NAME \
+  --features lakebase,analytics \
+  --set lakebase.postgres.branch=projects/$PROJECT_ID/branches/production \
+  --set lakebase.postgres.database=projects/$PROJECT_ID/branches/production/databases/$DB_NAME \
+  --set analytics.sql-warehouse.id=$WAREHOUSE_ID \
+  --description "My App" \
+  --output-dir $OUTPUT_DIR \
+  --template $TEMPLATE_URL \
+  --branch $BRANCH \
+  --deploy \
+  --run none \
+  --version $APPKIT_VERSION \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --var "key=value" \
+  --profile $DATABRICKS_PROFILE
 ```
 
 | Plugin        | What it adds                                                                   |
@@ -27,15 +71,6 @@ databricks apps init
 | **analytics** | SQL query execution against Databricks SQL Warehouses                          |
 | **genie**     | AI/BI Genie space integration for natural language queries                     |
 | **files**     | File operations against Unity Catalog Volumes                                  |
-
-For non-interactive use (CI, agents), pass `--name`, `--features`, and `--set` flags (`databricks apps init --help` for the full reference). An example:
-
-```bash
-databricks apps init --name my-app --features=lakebase \
-  --set lakebase.postgres.branch=projects/inventory/branches/production \
-  --set lakebase.postgres.database=projects/inventory/branches/production/databases/app_db \
-  --run none --profile <PROFILE>
-```
 
 ## Using plugins
 
@@ -63,7 +98,7 @@ Scaffold a custom plugin inside an existing AppKit project:
 npx @databricks/appkit plugin create
 ```
 
-The interactive wizard generates a plugin class, manifest, and resource declarations. See the [AppKit custom plugins guide](/docs/appkit/v0/plugins/custom-plugins) for the full class API, lifecycle hooks, and route injection.
+The CLI wizard generates a plugin class, manifest, and resource declarations. See the [AppKit custom plugins guide](/docs/appkit/v0/plugins/custom-plugins) for the full class API, lifecycle hooks, and route injection.
 
 ## Related pages
 

--- a/docs/lakebase/core-concepts.md
+++ b/docs/lakebase/core-concepts.md
@@ -26,21 +26,43 @@ IDs must be 1-63 characters, start with a lowercase letter, and contain only low
 
 Create a branch from an existing one to copy its schema and data:
 
-```bash
+```bash title="Common"
+databricks postgres create-branch projects/my-project feature
+```
+
+```bash title="All Options"
 databricks postgres create-branch \
   projects/$PROJECT_ID \
-  feature \
+  $BRANCH_ID \
   --json '{
     "spec": {
-      "source_branch": "projects/$PROJECT_ID/branches/$BRANCH_ID",
+      "source_branch": "projects/$PROJECT_ID/branches/$SOURCE_BRANCH_ID",
       "no_expiry": true
     }
-  }'
+  }' \
+  --no-wait \
+  --timeout 10m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
 ```
+
+| Option      | Required | Description                                                                                                                                                                 |
+| ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PARENT`    | yes      | Project resource path: `projects/{project_id}`                                                                                                                              |
+| `BRANCH_ID` | yes      | Unique branch identifier (1-63 chars, lowercase)                                                                                                                            |
+| `--json`    | no       | JSON spec with `source_branch` and expiration policy (`no_expiry`, `ttl`, or `expire_time`). If omitted, branches from the project's default branch with default expiration |
+| `--no-wait` | no       | Return immediately with operation details                                                                                                                                   |
+| `--timeout` | no       | Max time to wait for completion                                                                                                                                             |
+| `--debug`   | no       | Enable debug logging                                                                                                                                                        |
+| `-o json`   | no       | Output as JSON (default: text)                                                                                                                                              |
+| `--target`  | no       | Bundle target to use (if applicable)                                                                                                                                        |
+| `--profile` | no       | Databricks CLI profile name                                                                                                                                                 |
 
 Each new branch automatically gets a `primary` read-write endpoint that inherits the project's `default_endpoint_settings`. Use `create-endpoint` to add read replicas (`ENDPOINT_TYPE_READ_ONLY`).
 
-Delete when done: `databricks postgres delete-branch projects/$PROJECT_ID/branches/feature`
+Delete when done: `databricks postgres delete-branch projects/my-project/branches/feature`
 
 Branches require an expiration policy (`ttl`, `expire_time`, or `no_expiry: true`). See [branch expiration](https://docs.databricks.com/aws/en/oltp/projects/manage-branches#expiration) for details.
 
@@ -48,12 +70,37 @@ Branches require an expiration policy (`ttl`, `expire_time`, or `no_expiry: true
 
 Update commands require an update mask specifying which fields to modify. The `--json` payload contains the new values; only masked fields change.
 
-```bash
+```bash title="Common"
 databricks postgres update-branch \
-  projects/$PROJECT_ID/branches/$BRANCH_ID \
+  projects/my-project/branches/production \
   spec.is_protected \
   --json '{"spec": {"is_protected": true}}'
 ```
+
+```bash title="All Options"
+databricks postgres update-branch \
+  projects/$PROJECT_ID/branches/$BRANCH_ID \
+  $UPDATE_MASK \
+  --json '{"spec": {"is_protected": true}}' \
+  --no-wait \
+  --timeout 10m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option        | Required | Description                                                         |
+| ------------- | -------- | ------------------------------------------------------------------- |
+| `NAME`        | yes      | Branch resource path: `projects/{project_id}/branches/{branch_id}`  |
+| `UPDATE_MASK` | yes      | Comma-separated list of fields to update (e.g. `spec.is_protected`) |
+| `--json`      | yes      | JSON with new field values                                          |
+| `--no-wait`   | no       | Return immediately with operation details                           |
+| `--timeout`   | no       | Max time to wait for completion                                     |
+| `--debug`     | no       | Enable debug logging                                                |
+| `-o json`     | no       | Output as JSON (default: text)                                      |
+| `--target`    | no       | Bundle target to use (if applicable)                                |
+| `--profile`   | no       | Databricks CLI profile name                                         |
 
 For multiple fields, use a comma-separated mask (see autoscaling example below).
 
@@ -68,12 +115,40 @@ Endpoints autoscale between a configured min and max compute unit (CU) range. Ea
 
 The difference between max and min cannot exceed 16 CU (`max - min <= 16`).
 
-```bash
+```bash title="Common"
 databricks postgres update-endpoint \
-  projects/$PROJECT_ID/branches/$BRANCH_ID/endpoints/$ENDPOINT_ID \
+  projects/my-project/branches/production/endpoints/primary \
   "spec.autoscaling_limit_min_cu,spec.autoscaling_limit_max_cu" \
   --json '{"spec": {"autoscaling_limit_min_cu": 1.0, "autoscaling_limit_max_cu": 8.0}}'
 ```
+
+```bash title="All Options"
+databricks postgres update-endpoint \
+  projects/$PROJECT_ID/branches/$BRANCH_ID/endpoints/$ENDPOINT_ID \
+  $UPDATE_MASK \
+  --json '{"spec": {
+    "autoscaling_limit_min_cu": 1.0,
+    "autoscaling_limit_max_cu": 8.0
+  }}' \
+  --no-wait \
+  --timeout 10m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option        | Required | Description                                                                                  |
+| ------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `NAME`        | yes      | Endpoint resource path: `projects/{project_id}/branches/{branch_id}/endpoints/{endpoint_id}` |
+| `UPDATE_MASK` | yes      | Comma-separated fields (e.g. `spec.autoscaling_limit_min_cu,spec.autoscaling_limit_max_cu`)  |
+| `--json`      | yes      | JSON with new field values                                                                   |
+| `--no-wait`   | no       | Return immediately with operation details                                                    |
+| `--timeout`   | no       | Max time to wait for completion                                                              |
+| `--debug`     | no       | Enable debug logging                                                                         |
+| `-o json`     | no       | Output as JSON (default: text)                                                               |
+| `--target`    | no       | Bundle target to use (if applicable)                                                         |
+| `--profile`   | no       | Databricks CLI profile name                                                                  |
 
 Scaling within the configured range happens without connection interruptions. Changing the min/max configuration may cause a brief interruption.
 
@@ -94,10 +169,17 @@ When a compute resumes, session context resets (temporary tables, prepared state
 
 Configure at the project level so new branches inherit the settings:
 
-```bash
+```bash title="Common"
+databricks postgres update-project \
+  projects/my-project \
+  "spec.default_endpoint_settings" \
+  --json '{"spec": {"default_endpoint_settings": {"suspend_timeout_duration": "300s"}}}'
+```
+
+```bash title="All Options"
 databricks postgres update-project \
   projects/$PROJECT_ID \
-  "spec.default_endpoint_settings" \
+  $UPDATE_MASK \
   --json '{
     "spec": {
       "default_endpoint_settings": {
@@ -106,8 +188,26 @@ databricks postgres update-project \
         "suspend_timeout_duration": "300s"
       }
     }
-  }'
+  }' \
+  --no-wait \
+  --timeout 10m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
 ```
+
+| Option        | Required | Description                                              |
+| ------------- | -------- | -------------------------------------------------------- |
+| `NAME`        | yes      | Project resource path: `projects/{project_id}`           |
+| `UPDATE_MASK` | yes      | Fields to update (e.g. `spec.default_endpoint_settings`) |
+| `--json`      | yes      | JSON with new field values                               |
+| `--no-wait`   | no       | Return immediately with operation details                |
+| `--timeout`   | no       | Max time to wait for completion                          |
+| `--debug`     | no       | Enable debug logging                                     |
+| `-o json`     | no       | Output as JSON (default: text)                           |
+| `--target`    | no       | Bundle target to use (if applicable)                     |
+| `--profile`   | no       | Databricks CLI profile name                              |
 
 ## Long-running operations
 

--- a/docs/lakebase/development.md
+++ b/docs/lakebase/development.md
@@ -14,12 +14,28 @@ Key points from the recipe:
 - **Connection**: AppKit's `lakebase()` plugin provides a `pg.Pool` with automatic OAuth token refresh
 - **Deploy first**: the app's Service Principal creates schemas and tables on first deploy. Grant yourself `databricks_superuser` for local development afterward:
 
-```bash
-databricks psql --project <project-name> --branch production --endpoint primary --profile <PROFILE> -- -c "
-  CREATE EXTENSION IF NOT EXISTS databricks_auth;
-  SELECT databricks_create_role('<your-email>', 'USER');
-  GRANT databricks_superuser TO \"<your-email>\";
-"
+```bash title="Common"
+databricks psql --project my-project
+# After connecting, grant yourself superuser for local development:
+# GRANT databricks_superuser TO "<your-email>";
+```
+
+```bash title="All Options"
+databricks psql \
+  --project $PROJECT_ID \
+  --branch production \
+  --endpoint primary \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --autoscaling \
+  --max-retries 3 \
+  --profile $DATABRICKS_PROFILE \
+  -- -c "
+    CREATE EXTENSION IF NOT EXISTS databricks_auth;
+    SELECT databricks_create_role('$USER_EMAIL', 'USER');
+    GRANT databricks_superuser TO \"$USER_EMAIL\";
+  "
 ```
 
 - **Environment**: deployed apps get Postgres connection values injected automatically. Only `LAKEBASE_ENDPOINT` needs explicit configuration in `app.yaml`:
@@ -44,14 +60,51 @@ The [Lakebase Off-Platform Template](/resources/lakebase-off-platform-template) 
 
 Use Lakebase branches to isolate schema changes and test migrations without affecting production:
 
-```bash
-databricks postgres create-branch projects/$PROJECT_ID feature-xyz \
-  --json '{"spec": {"source_branch": "projects/$PROJECT_ID/branches/$BRANCH_ID", "no_expiry": true}}'
+```bash title="Common"
+databricks postgres create-branch projects/my-project feature-xyz
+```
+
+```bash title="All Options"
+databricks postgres create-branch \
+  projects/$PROJECT_ID \
+  $BRANCH_ID \
+  --json '{"spec": {"source_branch": "projects/$PROJECT_ID/branches/$SOURCE_BRANCH_ID", "no_expiry": true}}' \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --no-wait \
+  --timeout 10m \
+  --profile $DATABRICKS_PROFILE
 ```
 
 A `primary` read-write endpoint is created automatically, inheriting the project's `default_endpoint_settings`.
 
-Delete when done: `databricks postgres delete-branch projects/$PROJECT_ID/branches/feature-xyz`
+Delete when done:
+
+```bash title="Common"
+databricks postgres delete-branch projects/my-project/branches/feature-xyz
+```
+
+```bash title="All Options"
+databricks postgres delete-branch \
+  projects/$PROJECT_ID/branches/$BRANCH_ID \
+  --no-wait \
+  --timeout 10m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                                                        |
+| ----------- | -------- | ------------------------------------------------------------------ |
+| `NAME`      | yes      | Branch resource path: `projects/{project_id}/branches/{branch_id}` |
+| `--no-wait` | no       | Return immediately with operation details                          |
+| `--timeout` | no       | Max time to wait for completion                                    |
+| `--debug`   | no       | Enable debug logging                                               |
+| `-o json`   | no       | Output as JSON (default: text)                                     |
+| `--target`  | no       | Bundle target to use (if applicable)                               |
+| `--profile` | no       | Databricks CLI profile name                                        |
 
 ## All Lakebase recipes
 

--- a/docs/lakebase/getting-started.md
+++ b/docs/lakebase/getting-started.md
@@ -14,18 +14,69 @@ title: Getting Started
 
 ## Create a project
 
-```bash
-databricks postgres create-project my-project \
-  --json '{"spec": {"display_name": "My Lakebase Project"}}'
+```bash title="Common"
+databricks postgres create-project my-project
 ```
+
+```bash title="All Options"
+databricks postgres create-project $PROJECT_ID \
+  --json '{"spec": {
+    "display_name": "My Lakebase Project",
+    "pg_version": 17,
+    "history_retention_duration": "172800s",
+    "default_endpoint_settings": {
+      "autoscaling_limit_min_cu": 0.5,
+      "autoscaling_limit_max_cu": 1.0,
+      "suspend_timeout_duration": "300s"
+    }
+  }}' \
+  --no-wait \
+  --timeout 10m \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option       | Required | Description                                                                                                                                     |
+| ------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PROJECT_ID` | yes      | Unique project identifier (1-63 chars, lowercase letter start, lowercase/numbers/hyphens)                                                       |
+| `--json`     | no       | Inline JSON or `@path/to/file.json` with project spec (`display_name`, `pg_version`, `history_retention_duration`, `default_endpoint_settings`) |
+| `--no-wait`  | no       | Return immediately with operation details instead of waiting for completion                                                                     |
+| `--timeout`  | no       | Max time to wait for completion (e.g. `10m`). Ignored with `--no-wait`                                                                          |
+| `--debug`    | no       | Enable debug logging                                                                                                                            |
+| `-o json`    | no       | Output as JSON (default: text)                                                                                                                  |
+| `--target`   | no       | Bundle target to use (if applicable)                                                                                                            |
+| `--profile`  | no       | Databricks CLI profile name                                                                                                                     |
 
 The optional `display_name` sets a human-readable label. This creates a project with a default `production` branch, a `databricks_postgres` database, and a read-write endpoint.
 
 ## Get connection values
 
-```bash
+```bash title="Common"
 databricks postgres list-endpoints projects/my-project/branches/production -o json
 ```
+
+```bash title="All Options"
+databricks postgres list-endpoints \
+  projects/$PROJECT_ID/branches/$BRANCH_ID \
+  -o json \
+  --page-size 100 \
+  --page-token "$PAGE_TOKEN" \
+  --debug \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option         | Required | Description                                                        |
+| -------------- | -------- | ------------------------------------------------------------------ |
+| `PARENT`       | yes      | Branch resource path: `projects/{project_id}/branches/{branch_id}` |
+| `-o json`      | no       | Output as JSON (default: text)                                     |
+| `--page-size`  | no       | Max items per page                                                 |
+| `--page-token` | no       | Pagination token for next page                                     |
+| `--debug`      | no       | Enable debug logging                                               |
+| `--target`     | no       | Bundle target to use (if applicable)                               |
+| `--profile`    | no       | Databricks CLI profile name                                        |
 
 <details>
 <summary>Example response</summary>
@@ -60,9 +111,30 @@ databricks postgres list-endpoints projects/my-project/branches/production -o js
 
 </details>
 
-```bash
+```bash title="Common"
 databricks postgres list-databases projects/my-project/branches/production -o json
 ```
+
+```bash title="All Options"
+databricks postgres list-databases \
+  projects/$PROJECT_ID/branches/$BRANCH_ID \
+  -o json \
+  --page-size 100 \
+  --page-token "$PAGE_TOKEN" \
+  --debug \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option         | Required | Description                                                        |
+| -------------- | -------- | ------------------------------------------------------------------ |
+| `PARENT`       | yes      | Branch resource path: `projects/{project_id}/branches/{branch_id}` |
+| `-o json`      | no       | Output as JSON (default: text)                                     |
+| `--page-size`  | no       | Max items per page                                                 |
+| `--page-token` | no       | Pagination token for next page                                     |
+| `--debug`      | no       | Enable debug logging                                               |
+| `--target`     | no       | Bundle target to use (if applicable)                               |
+| `--profile`    | no       | Databricks CLI profile name                                        |
 
 <details>
 <summary>Example response</summary>
@@ -97,22 +169,65 @@ Key values from the output:
 
 The simplest way to connect is with `databricks psql`:
 
-```bash
+```bash title="Common"
 databricks psql --project my-project
 ```
 
-This auto-selects the branch and endpoint when only one exists. To skip selection (CI, agents), specify all three:
-
-```bash
-databricks psql --project my-project --branch production --endpoint primary
+```bash title="All Options"
+databricks psql \
+  --project $PROJECT_ID \
+  --branch $BRANCH_ID \
+  --endpoint $ENDPOINT_ID \
+  --autoscaling \
+  --max-retries 3 \
+  --debug \
+  -o json \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE \
+  -- -c "SELECT 1"
 ```
+
+| Option          | Required | Description                                                                                       |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `--project`     | no       | Project ID. With a TTY, omit to choose from prompts; in CI or scripts, set explicitly when needed |
+| `--branch`      | no       | Branch ID (default: auto-select when only one exists)                                             |
+| `--endpoint`    | no       | Endpoint ID (default: auto-select when only one exists)                                           |
+| `--autoscaling` | no       | Only show Lakebase Autoscaling projects                                                           |
+| `--provisioned` | no       | Only show Lakebase Provisioned instances                                                          |
+| `--max-retries` | no       | Connection retries; 0 to disable (default: 3)                                                     |
+| `--debug`       | no       | Enable debug logging                                                                              |
+| `-o json`       | no       | Output as JSON (default: text)                                                                    |
+| `--target`      | no       | Bundle target to use (if applicable)                                                              |
+| `--profile`     | no       | Databricks CLI profile name                                                                       |
+| `-- PSQL_ARGS`  | no       | Additional arguments passed through to `psql`                                                     |
+
+Without a TTY (for example in CI), the CLI auto-selects when only one branch or endpoint exists. When multiple exist, specify `--project`, `--branch`, and `--endpoint` explicitly so the command does not block on prompts.
 
 If you don't have a `psql` client installed, generate a short-lived credential and use it with any PostgreSQL client (DBeaver, pgAdmin, DataGrip, or a language driver):
 
-```bash
+```bash title="Common"
 databricks postgres generate-database-credential \
-  projects/my-project/branches/production/endpoints/<endpoint-id>
+  projects/my-project/branches/production/endpoints/primary
 ```
+
+```bash title="All Options"
+databricks postgres generate-database-credential \
+  projects/$PROJECT_ID/branches/$BRANCH_ID/endpoints/$ENDPOINT_ID \
+  --json '{}' \
+  --debug \
+  --target $TARGET \
+  -o json \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option      | Required | Description                                                                                  |
+| ----------- | -------- | -------------------------------------------------------------------------------------------- |
+| `ENDPOINT`  | yes      | Endpoint resource path: `projects/{project_id}/branches/{branch_id}/endpoints/{endpoint_id}` |
+| `--json`    | no       | Inline JSON or `@path/to/file.json` with request body                                        |
+| `--debug`   | no       | Enable debug logging                                                                         |
+| `-o json`   | no       | Output as JSON (default: text)                                                               |
+| `--target`  | no       | Bundle target to use (if applicable)                                                         |
+| `--profile` | no       | Databricks CLI profile name                                                                  |
 
 Use the returned token as the password, with your Databricks email as the username and the endpoint host from `list-endpoints` above.
 

--- a/docs/tools/databricks-cli.md
+++ b/docs/tools/databricks-cli.md
@@ -58,7 +58,7 @@ If the CLI is missing or below `0.295`, install or upgrade before continuing.
 
 ## Authenticate
 
-Interactive OAuth is the default for user-driven workflows:
+Browser-based OAuth (`databricks auth login`) is the default for local and ad-hoc use:
 
 ```bash
 databricks auth login --host <workspace-url>
@@ -131,8 +131,9 @@ databricks schemas list --help
 - prefer OAuth over legacy PAT flows where possible
 - keep credentials out of source control
 - standardize on named profiles per environment
-- use non-interactive auth methods for CI/CD and service automation
+- use token or OAuth client-credential flows for CI/CD and service automation (no browser step)
 - pass `--profile <PROFILE>` on every command in automation and agent workflows
+- DevHub **Common** examples assume a single default workspace profile. For CI, agents, and multi-workspace setups, pass `--profile` explicitly or set `DATABRICKS_CONFIG_PROFILE`
 - verify CLI command shape with `--help` instead of guessing flags
 
 ## Source of truth

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,6 +4,7 @@ import type * as Preset from "@docusaurus/preset-classic";
 import path from "path";
 import contentEntriesPlugin from "./plugins/content-entries";
 import llmsTxtPlugin from "./plugins/llms-txt";
+import remarkCliTabs from "./plugins/remark-cli-tabs";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -45,6 +46,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: "./sidebars.ts",
+          remarkPlugins: [remarkCliTabs],
         },
         blog: false,
         theme: {

--- a/plugins/remark-cli-tabs.ts
+++ b/plugins/remark-cli-tabs.ts
@@ -1,0 +1,151 @@
+import type { Code } from "mdast";
+import type { MdxJsxFlowElement, MdxJsxAttribute } from "mdast-util-mdx";
+import type { Node, Parent } from "unist";
+import type { Transformer } from "unified";
+
+function parseTitle(meta: string | null | undefined): string | null {
+  if (!meta) return null;
+  const match = meta.match(/title="([^"]*)"/);
+  return match ? match[1].trim() : null;
+}
+
+function stripTitle(meta: string | null | undefined): string | null {
+  if (!meta) return null;
+  const stripped = meta.replace(/title="[^"]*"/, "").trim();
+  return stripped || null;
+}
+
+function attr(name: string, value: string): MdxJsxAttribute {
+  return { type: "mdxJsxAttribute", name, value };
+}
+
+function createTabItem(
+  code: Code,
+  label: string,
+  value: string,
+): MdxJsxFlowElement {
+  return {
+    type: "mdxJsxFlowElement",
+    name: "TabItem",
+    attributes: [attr("value", value), attr("label", label)],
+    children: [
+      {
+        type: code.type,
+        lang: code.lang,
+        meta: stripTitle(code.meta),
+        value: code.value,
+      } as Code,
+    ],
+  };
+}
+
+function createImportNode() {
+  return {
+    type: "mdxjsEsm" as const,
+    value:
+      "import Tabs from '@theme/Tabs'\nimport TabItem from '@theme/TabItem'",
+    data: {
+      estree: {
+        type: "Program" as const,
+        body: [
+          {
+            type: "ImportDeclaration" as const,
+            specifiers: [
+              {
+                type: "ImportDefaultSpecifier" as const,
+                local: { type: "Identifier" as const, name: "Tabs" },
+              },
+            ],
+            source: {
+              type: "Literal" as const,
+              value: "@theme/Tabs",
+              raw: "'@theme/Tabs'",
+            },
+          },
+          {
+            type: "ImportDeclaration" as const,
+            specifiers: [
+              {
+                type: "ImportDefaultSpecifier" as const,
+                local: { type: "Identifier" as const, name: "TabItem" },
+              },
+            ],
+            source: {
+              type: "Literal" as const,
+              value: "@theme/TabItem",
+              raw: "'@theme/TabItem'",
+            },
+          },
+        ],
+        sourceType: "module" as const,
+      },
+    },
+  };
+}
+
+const isCode = (node: Node): node is Code => node.type === "code";
+const isParent = (node: Node): node is Parent =>
+  Array.isArray((node as Parent).children);
+
+export default function remarkCliTabs(): Transformer {
+  return async (root) => {
+    const { visit } = await import("unist-util-visit");
+
+    let transformed = false;
+    let alreadyImported = false;
+
+    visit(root, (node: Node) => {
+      if (
+        node.type === "mdxjsEsm" &&
+        (node as { value?: string }).value?.includes("@theme/Tabs")
+      ) {
+        alreadyImported = true;
+      }
+
+      if (!isParent(node)) return;
+
+      let i = 0;
+      while (i < node.children.length - 1) {
+        const first = node.children[i];
+        const second = node.children[i + 1];
+
+        if (!isCode(first) || !isCode(second)) {
+          i++;
+          continue;
+        }
+
+        const firstTitle = parseTitle(first.meta);
+        const secondTitle = parseTitle(second.meta);
+
+        if (
+          firstTitle &&
+          secondTitle &&
+          /^Common$/i.test(firstTitle) &&
+          /^All Options$/i.test(secondTitle)
+        ) {
+          const tabs: MdxJsxFlowElement = {
+            type: "mdxJsxFlowElement",
+            name: "Tabs",
+            attributes: [
+              attr("groupId", "cli-mode"),
+              attr("queryString", "cli"),
+            ],
+            children: [
+              createTabItem(first, firstTitle, "common"),
+              createTabItem(second, secondTitle, "all-options"),
+            ],
+          };
+
+          node.children.splice(i, 2, tabs as unknown as typeof first);
+          transformed = true;
+        }
+
+        i++;
+      }
+    });
+
+    if (transformed && !alreadyImported) {
+      (root as Parent).children.unshift(createImportNode() as unknown as Node);
+    }
+  };
+}

--- a/src/components/DocExample.tsx
+++ b/src/components/DocExample.tsx
@@ -8,7 +8,7 @@ export function DocExample({ name }: DocExampleProps): ReactNode {
   return (
     <div className="my-4 rounded-lg border border-black/10 bg-black/3 p-4 text-sm text-black/60 dark:border-white/10 dark:bg-white/3 dark:text-white/60">
       <p className="m-0">
-        Interactive example for <code>{name}</code> — see the{" "}
+        Example placeholder for <code>{name}</code> — see the{" "}
         <a
           href="https://ui.shadcn.com/docs/components"
           target="_blank"

--- a/tests/docs-verify/cli-options-lakebase.test.ts
+++ b/tests/docs-verify/cli-options-lakebase.test.ts
@@ -1,0 +1,240 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect } from "vitest";
+
+const MUTUALLY_EXCLUSIVE: Record<string, string[]> = {
+  psql: ["--provisioned", "--autoscaling"],
+  manifest: ["--branch", "--version"],
+  init: ["--branch", "--version"],
+};
+
+const SKIP_FLAGS: Record<string, string[]> = {
+  "apps init": ["--name"],
+  "postgres create-project": ["--name"],
+  "postgres create-branch": ["--name"],
+  "postgres update-branch": ["--name"],
+  "postgres update-endpoint": ["--name"],
+  "postgres update-project": ["--name"],
+};
+
+const SHORT_TO_LONG: Record<string, string> = {
+  "-o": "--output",
+  "-f": "--follow",
+  "-p": "--profile",
+  "-t": "--target",
+  "-c": "--cluster-id",
+};
+
+const LONG_TO_SHORT: Record<string, string> = Object.fromEntries(
+  Object.entries(SHORT_TO_LONG).map(([short, long]) => [long, short]),
+);
+
+type CommandSpec = {
+  command: string;
+  doc: string;
+};
+
+const CLI_COMMANDS: CommandSpec[] = [
+  // Lakebase
+  {
+    command: "postgres create-project",
+    doc: "docs/lakebase/getting-started.md",
+  },
+  {
+    command: "postgres list-endpoints",
+    doc: "docs/lakebase/getting-started.md",
+  },
+  {
+    command: "postgres list-databases",
+    doc: "docs/lakebase/getting-started.md",
+  },
+  {
+    command: "postgres generate-database-credential",
+    doc: "docs/lakebase/getting-started.md",
+  },
+  {
+    command: "psql",
+    doc: "docs/lakebase/getting-started.md",
+  },
+  {
+    command: "postgres create-branch",
+    doc: "docs/lakebase/core-concepts.md",
+  },
+  {
+    command: "postgres update-branch",
+    doc: "docs/lakebase/core-concepts.md",
+  },
+  {
+    command: "postgres update-endpoint",
+    doc: "docs/lakebase/core-concepts.md",
+  },
+  {
+    command: "postgres update-project",
+    doc: "docs/lakebase/core-concepts.md",
+  },
+  {
+    command: "postgres delete-branch",
+    doc: "docs/lakebase/development.md",
+  },
+  // Apps
+  {
+    command: "apps init",
+    doc: "docs/apps/getting-started.md",
+  },
+  {
+    command: "apps deploy",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps logs",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps manifest",
+    doc: "docs/apps/plugins.md",
+  },
+  {
+    command: "apps get",
+    doc: "docs/apps/development.md",
+  },
+  // Agents
+  {
+    command: "bundle validate",
+    doc: "docs/agents/getting-started.md",
+  },
+  {
+    command: "apps get",
+    doc: "docs/agents/getting-started.md",
+  },
+  {
+    command: "serving-endpoints list",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "serving-endpoints get",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "serving-endpoints query",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "serving-endpoints create",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "experiments create-experiment",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "experiments create-experiment",
+    doc: "docs/agents/observability.md",
+  },
+];
+
+function getCliFlags(command: string): string[] {
+  const output = execSync(`databricks ${command} --help`, {
+    encoding: "utf-8",
+  });
+  const flags: string[] = [];
+  for (const match of output.matchAll(/(--[\w-]+)/gm)) {
+    const flag = match[1];
+    if (flag !== "--help") {
+      flags.push(flag);
+    }
+  }
+  return [...new Set(flags)];
+}
+
+function getAllOptionsBlocks(docPath: string): string[] {
+  const content = readFileSync(resolve(process.cwd(), docPath), "utf-8");
+  const blocks: string[] = [];
+  const regex = /```\w+\s+title="All Options"\s*\n([\s\S]*?)```/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    blocks.push(match[1]);
+  }
+  return blocks;
+}
+
+function extractFlagsFromBlocks(blocks: string[]): string[] {
+  const flags: string[] = [];
+  for (const block of blocks) {
+    for (const match of block.matchAll(/(--[\w-]+)/g)) {
+      flags.push(match[1]);
+    }
+    for (const match of block.matchAll(/^\s+(-[a-zA-Z])\s/gm)) {
+      flags.push(match[1]);
+    }
+  }
+  return [...new Set(flags)];
+}
+
+function findBlockForCommand(
+  blocks: string[],
+  command: string,
+): string | undefined {
+  const parts = command.split(" ");
+  const cliCommand = `databricks ${parts.join(" ")}`;
+  return blocks.find((b) => b.includes(cliCommand));
+}
+
+function flagInSet(flag: string, flagSet: string[]): boolean {
+  if (flagSet.includes(flag)) return true;
+  const alt = SHORT_TO_LONG[flag] ?? LONG_TO_SHORT[flag];
+  return alt ? flagSet.includes(alt) : false;
+}
+
+describe("CLI options completeness", () => {
+  for (const spec of CLI_COMMANDS) {
+    describe(spec.command, () => {
+      test("all CLI flags appear in docs (no missing)", () => {
+        const cliFlags = getCliFlags(spec.command);
+        const blocks = getAllOptionsBlocks(spec.doc);
+        const block = findBlockForCommand(blocks, spec.command);
+
+        expect(
+          block,
+          `No "All Options" code block found for '${spec.command}' in ${spec.doc}`,
+        ).toBeTruthy();
+
+        const docFlags = extractFlagsFromBlocks([block!]);
+        const subcommand = spec.command.split(" ").pop()!;
+        const exclusiveGroup = MUTUALLY_EXCLUSIVE[subcommand] ?? [];
+        const skipFlags = SKIP_FLAGS[spec.command] ?? [];
+
+        for (const flag of cliFlags) {
+          if (skipFlags.includes(flag)) continue;
+          if (
+            exclusiveGroup.includes(flag) &&
+            exclusiveGroup.some((f) => flagInSet(f, docFlags))
+          ) {
+            continue;
+          }
+          expect(
+            flagInSet(flag, docFlags),
+            `Flag ${flag} from 'databricks ${spec.command} --help' not found in ${spec.doc}`,
+          ).toBe(true);
+        }
+      });
+
+      test("all documented flags exist in CLI (no stale)", () => {
+        const cliFlags = getCliFlags(spec.command);
+        const blocks = getAllOptionsBlocks(spec.doc);
+        const block = findBlockForCommand(blocks, spec.command);
+
+        if (!block) return;
+
+        const docFlags = extractFlagsFromBlocks([block]);
+
+        for (const flag of docFlags) {
+          expect(
+            flagInSet(flag, cliFlags),
+            `Flag ${flag} in ${spec.doc} does not exist in 'databricks ${spec.command} --help'`,
+          ).toBe(true);
+        }
+      });
+    });
+  }
+});

--- a/tests/docs-verify/docs-verify-lakebase.test.ts
+++ b/tests/docs-verify/docs-verify-lakebase.test.ts
@@ -346,7 +346,7 @@ describe("Lakebase workflow", { timeout: 600_000 }, () => {
     );
   });
 
-  test("connect with databricks psql (non-interactive)", () => {
+  test("connect with databricks psql (CI-style flags)", () => {
     const output = retry(
       () =>
         run(


### PR DESCRIPTION
This is an experiment. 

It adds a custom `remark-cli-tabs plugin` that renders consecutive "Common" and "All Options" fenced blocks as Docusaurus tabs. Applied across the lakebase, apps, and agents docs. Option tables were also added for every CLI command.