### PR TITLE
Fix scrollbar on CLI code tabs caused by -mb-px overflow

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -576,7 +576,7 @@
   }
 
   .db-docs-article .theme-doc-markdown .tabs {
-    @apply mb-0 flex flex-wrap items-end gap-0 border-b border-db-border pb-0;
+    @apply mb-0 flex flex-wrap items-end gap-0 overflow-visible border-b border-db-border pb-0;
   }
 
   .db-docs-article .theme-doc-markdown .tabs__item {


### PR DESCRIPTION
Docusaurus defaults .tabs to overflow: auto, so that 1px of overflow triggered a visible scrollbar. Override with overflow: visible.