### PR TITLE
docs: add lakebase bundle doc and test, rename DAB

### DIFF
--- a/docs/agents/core-concepts.md
+++ b/docs/agents/core-concepts.md
@@ -55,7 +55,7 @@ The [`agent-openai-agents-sdk`](https://github.com/databricks/app-templates/tree
 
 ## Deployment targets
 
-**Databricks Apps** (recommended): full control over code, server, and deployment. Uses Databricks Asset Bundles (`databricks bundle deploy` + `databricks bundle run`). The `agent-openai-agents-sdk` template targets this path.
+**Databricks Apps** (recommended): full control over code, server, and deployment. Uses Declarative Automation Bundles (`databricks bundle deploy` + `databricks bundle run`). The `agent-openai-agents-sdk` template targets this path.
 
 **Model Serving** (alternate): register your agent in Unity Catalog and deploy with the Python API (`from databricks.agents import deploy`). Creates a managed serving endpoint. For new use cases, Databricks recommends Apps instead. See [Deploy an agent for generative AI](https://docs.databricks.com/aws/en/generative-ai/agent-framework/deploy-agent) for the Model Serving workflow.
 

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -138,7 +138,7 @@ Customize evaluation by editing `agent_server/evaluate_agent.py` to adjust the d
 
 ## Deploy
 
-The template uses [Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/):
+The template uses [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/):
 
 ```bash title="Common"
 databricks bundle validate
@@ -299,4 +299,4 @@ See [Apps development](/docs/apps/development) for option tables covering `get`,
 - [Deploy an agent (Model Serving)](https://docs.databricks.com/aws/en/generative-ai/agent-framework/deploy-agent)
 - [Query an agent](https://docs.databricks.com/aws/en/generative-ai/agent-framework/query-agent)
 - [Agent template README](https://github.com/databricks/app-templates/tree/main/agent-openai-agents-sdk)
-- [Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/)
+- [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/)

--- a/docs/agents/getting-started.md
+++ b/docs/agents/getting-started.md
@@ -63,7 +63,7 @@ The agent server serves both the API (`/invocations`, `/responses`) and the chat
 
 ## Deploy
 
-The template uses [Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/) for deployment. The `databricks.yml` in the template defines the app, resources, and permissions.
+The template uses [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/) for deployment. The `databricks.yml` in the template defines the app, resources, and permissions.
 
 Validate the configuration:
 
@@ -202,4 +202,4 @@ curl -X POST <app-url>/responses \
 
 - [Author an AI agent and deploy it on Databricks Apps](https://docs.databricks.com/aws/en/generative-ai/agent-framework/author-agent)
 - [Agent template repository](https://github.com/databricks/app-templates/tree/main/agent-openai-agents-sdk)
-- [Databricks Asset Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/)
+- [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/)

--- a/docs/lakebase/core-concepts.md
+++ b/docs/lakebase/core-concepts.md
@@ -209,6 +209,10 @@ databricks postgres update-project \
 | `--target`    | no       | Bundle target to use (if applicable)                     |
 | `--profile`   | no       | Databricks CLI profile name                              |
 
+## Pagination
+
+`databricks postgres list-endpoints` accepts `--page-size` and `--page-token`. When you pass `--page-size`, the workspace API requires it to be **at least 10** (smaller values return an error). Omit the flag to use default paging behavior. Other `postgres list-*` commands document their own rules; see the [`postgres` command reference](https://docs.databricks.com/aws/en/dev-tools/cli/reference/postgres-commands).
+
 ## Long-running operations
 
 Create, update, and delete commands block until complete by default. Use `--no-wait` to return immediately and poll status:

--- a/docs/lakebase/development.md
+++ b/docs/lakebase/development.md
@@ -106,6 +106,90 @@ databricks postgres delete-branch \
 | `--target`  | no       | Bundle target to use (if applicable)                               |
 | `--profile` | no       | Databricks CLI profile name                                        |
 
+## Declarative Automation Bundles
+
+Define Lakebase infrastructure as code in a `databricks.yml` file using [Databricks Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/). This lets you version-control projects, branches, and endpoints alongside your application code.
+
+A bundle defines `postgres_projects`, `postgres_branches`, and `postgres_endpoints` under `resources`. Resources reference each other with `${resources.<type>.<key>.id}`, which resolves to the full resource name (e.g. `projects/my-lakebase-app`). Branches and their auto-created `primary` endpoint inherit `default_endpoint_settings` from the project.
+
+<details>
+<summary>Example <code>databricks.yml</code> with a project, dev branch, and read-only replica</summary>
+
+```yaml
+bundle:
+  name: my-lakebase-app
+
+resources:
+  postgres_projects:
+    my_app:
+      project_id: "my-lakebase-app"
+      display_name: "My Lakebase App"
+      pg_version: 17
+      history_retention_duration: "172800s"
+      default_endpoint_settings:
+        autoscaling_limit_min_cu: 0.5
+        autoscaling_limit_max_cu: 1.0
+        suspend_timeout_duration: "300s"
+        pg_settings:
+          log_min_duration_statement: "1000"
+
+  postgres_branches:
+    dev_branch:
+      parent: ${resources.postgres_projects.my_app.id}
+      branch_id: "dev"
+      no_expiry: true
+      is_protected: false
+
+  postgres_endpoints:
+    read_replica:
+      parent: ${resources.postgres_branches.dev_branch.id}
+      endpoint_id: "replica"
+      endpoint_type: "ENDPOINT_TYPE_READ_ONLY"
+      autoscaling_limit_min_cu: 0.5
+      autoscaling_limit_max_cu: 0.5
+```
+
+</details>
+
+### Validate and deploy
+
+```bash title="Common"
+databricks bundle validate
+databricks bundle deploy
+```
+
+```bash title="All Options"
+databricks bundle validate \
+  --strict \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+
+databricks bundle deploy \
+  --auto-approve \
+  --force-lock \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
+
+| Option           | Required | Description                                                       |
+| ---------------- | -------- | ----------------------------------------------------------------- |
+| `--strict`       | no       | Treat warnings as errors (validate only)                          |
+| `--auto-approve` | no       | Skip confirmation prompts (deploy only)                           |
+| `--force-lock`   | no       | Force acquisition of deployment lock (deploy only)                |
+| `--debug`        | no       | Enable debug logging                                              |
+| `-o json`        | no       | Output as JSON (default: text)                                    |
+| `--var`          | no       | Set values for bundle config variables (e.g. `--var="key=value"`) |
+| `--target`       | no       | Bundle target (e.g. `dev`, `prod`)                                |
+| `--profile`      | no       | Databricks CLI profile name                                       |
+
+`bundle deploy` is idempotent -- it creates new resources and updates existing ones to match the configuration. Unlike agents or apps, there is no `bundle run` step; Lakebase resources are active once deployed.
+
 ## All Lakebase recipes
 
 | Recipe                                                                                         | Description                                    |
@@ -122,3 +206,4 @@ databricks postgres delete-branch \
 - [AppKit Lakebase plugin](/docs/appkit/v0/plugins/lakebase)
 - [AppKit `@databricks/lakebase` README](https://github.com/databricks/appkit/blob/main/packages/lakebase/README.md)
 - [Lakebase Autoscaling](https://docs.databricks.com/aws/en/oltp/projects/)
+- [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/)

--- a/docs/lakebase/getting-started.md
+++ b/docs/lakebase/getting-started.md
@@ -72,7 +72,7 @@ databricks postgres list-endpoints \
 | -------------- | -------- | ------------------------------------------------------------------ |
 | `PARENT`       | yes      | Branch resource path: `projects/{project_id}/branches/{branch_id}` |
 | `-o json`      | no       | Output as JSON (default: text)                                     |
-| `--page-size`  | no       | Max items per page                                                 |
+| `--page-size`  | no       | Max items per page; if set, must be at least `10`                  |
 | `--page-token` | no       | Pagination token for next page                                     |
 | `--debug`      | no       | Enable debug logging                                               |
 | `--target`     | no       | Bundle target to use (if applicable)                               |

--- a/docs/tools/ai-tools/agent-skills.md
+++ b/docs/tools/ai-tools/agent-skills.md
@@ -37,7 +37,7 @@ The Databricks agent skills bundle includes:
 
 - `databricks`: core CLI/auth/profile and data exploration guidance
 - `databricks-apps`: Databricks Apps + AppKit development workflow
-- `databricks-jobs`: Lakeflow Jobs with Databricks Asset Bundles
+- `databricks-jobs`: Lakeflow Jobs with Declarative Automation Bundles
 - `databricks-pipelines`: Lakeflow Spark Declarative Pipelines patterns
 - `databricks-lakebase`: Lakebase Postgres project/branch/endpoint management
 

--- a/tests/docs-verify/docs-verify-lakebase-bundle.test.ts
+++ b/tests/docs-verify/docs-verify-lakebase-bundle.test.ts
@@ -1,0 +1,238 @@
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { run, cliJson } from "../helpers/scaffold-app";
+
+const sleepSync = (ms: number) =>
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+const PROFILE = process.env.DATABRICKS_PROFILE;
+if (!PROFILE) {
+  throw new Error(
+    "DATABRICKS_PROFILE env var is required. Set it to a configured CLI profile name.",
+  );
+}
+
+const TEST_PREFIX = "devhub-bundle";
+const TEST_RUN_ID = Date.now().toString(36);
+const PROJECT_ID = `${TEST_PREFIX}-${TEST_RUN_ID}`;
+const FIXTURE_DIR = resolve(__dirname, "../fixtures/lakebase-bundle");
+const SKIP_CLEANUP = Boolean(process.env.SKIP_CLEANUP);
+
+function pollOperation(operationName: string, maxAttempts = 60, delayS = 5) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const op = cliJson<{ done: boolean; name: string }>(
+      `postgres get-operation ${operationName}`,
+      PROFILE!,
+    );
+    if (op.done) {
+      console.log(
+        `[bundle] operation done after ~${i * delayS}s: ${operationName}`,
+      );
+      return op;
+    }
+    sleepSync(delayS * 1000);
+  }
+  throw new Error(
+    `Operation ${operationName} did not complete in ${maxAttempts * delayS}s`,
+  );
+}
+
+describe("Lakebase bundle workflow", { timeout: 600_000 }, () => {
+  let bundleDir: string;
+
+  beforeAll(() => {
+    bundleDir = mkdtempSync(join(tmpdir(), "devhub-lakebase-bundle-"));
+    cpSync(FIXTURE_DIR, bundleDir, { recursive: true });
+
+    const ymlPath = join(bundleDir, "databricks.yml");
+    const content = readFileSync(ymlPath, "utf-8");
+    writeFileSync(
+      ymlPath,
+      content
+        .replace("BUNDLE_NAME_PLACEHOLDER", PROJECT_ID)
+        .replace("PLACEHOLDER", PROJECT_ID),
+    );
+
+    console.log("[bundle] fixture copied to:", bundleDir);
+    console.log("[bundle] project ID:", PROJECT_ID);
+  });
+
+  afterAll(() => {
+    if (SKIP_CLEANUP) {
+      console.log(`[cleanup] SKIP_CLEANUP set, keeping project ${PROJECT_ID}`);
+      return;
+    }
+
+    const maxRetries = 6;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        console.log(
+          `[cleanup] Deleting project ${PROJECT_ID} (attempt ${attempt + 1})`,
+        );
+        const deleteOutput = cliJson<{ done: boolean; name: string }>(
+          `postgres delete-project projects/${PROJECT_ID} --no-wait`,
+          PROFILE!,
+        );
+        if (!deleteOutput.done) {
+          pollOperation(deleteOutput.name);
+        }
+        console.log(`[cleanup] Project ${PROJECT_ID} deleted`);
+        break;
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (msg.includes("reconciliation") && attempt < maxRetries - 1) {
+          console.warn(
+            `[cleanup] reconciliation in progress, retrying in 10s...`,
+          );
+          sleepSync(10_000);
+          continue;
+        }
+        console.warn("[cleanup] failed:", msg);
+        break;
+      }
+    }
+
+    try {
+      rmSync(bundleDir, { recursive: true, force: true });
+    } catch {
+      // best-effort temp dir cleanup
+    }
+  }, 600_000);
+
+  test("bundle validate succeeds", () => {
+    const output = run(`databricks bundle validate --profile ${PROFILE}`, {
+      cwd: bundleDir,
+      timeoutMs: 60_000,
+    });
+    expect(output).toBeTruthy();
+    console.log("[bundle] validate passed");
+  });
+
+  // Retry guard: we've occasionally seen Lakebase ACL propagation lag after
+  // project creation, causing the branch create to fail with:
+  //   "… not authorized … assign the user … 'Can Manage' for Database project …"
+  // A retry is safe — Terraform picks up where it left off. This doesn't
+  // always reproduce; the retry is here as a precaution.
+  test("bundle deploy creates resources", () => {
+    const maxRetries = 3;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const output = run(`databricks bundle deploy --profile ${PROFILE}`, {
+          cwd: bundleDir,
+          timeoutMs: 480_000,
+        });
+        expect(output).toBeDefined();
+        console.log("[bundle] deploy completed");
+        return;
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (attempt < maxRetries && msg.includes("not authorized")) {
+          console.warn(
+            `[bundle] deploy attempt ${attempt} hit permissions race, retrying in 15s...`,
+          );
+          sleepSync(15_000);
+          continue;
+        }
+        throw e;
+      }
+    }
+  });
+
+  test("verify project settings", () => {
+    const project = cliJson<{
+      status: {
+        display_name: string;
+        pg_version: number;
+        history_retention_duration: string;
+        default_endpoint_settings: {
+          autoscaling_limit_min_cu: number;
+          autoscaling_limit_max_cu: number;
+          suspend_timeout_duration: string;
+          pg_settings?: Record<string, string>;
+        };
+      };
+    }>(`postgres get-project projects/${PROJECT_ID}`, PROFILE!);
+
+    expect(project.status.display_name).toBe("DevHub Bundle Test");
+    expect(project.status.pg_version).toBe(17);
+    expect(project.status.history_retention_duration).toBe("172800s");
+    expect(
+      project.status.default_endpoint_settings.autoscaling_limit_min_cu,
+    ).toBe(0.5);
+    expect(
+      project.status.default_endpoint_settings.autoscaling_limit_max_cu,
+    ).toBe(1.0);
+    expect(
+      project.status.default_endpoint_settings.suspend_timeout_duration,
+    ).toBe("300s");
+    expect(
+      project.status.default_endpoint_settings.pg_settings
+        ?.log_min_duration_statement,
+    ).toBe("1000");
+    console.log("[bundle] project settings verified");
+  });
+
+  test("verify dev branch exists", () => {
+    const branches = cliJson<
+      Array<{ name: string; status: { is_protected: boolean } }>
+    >(`postgres list-branches projects/${PROJECT_ID}`, PROFILE!);
+
+    const devBranch = branches.find((b) => b.name.includes("/branches/dev"));
+    expect(devBranch, "dev branch should exist").toBeTruthy();
+    expect(devBranch!.status.is_protected).toBe(false);
+    console.log("[bundle] dev branch verified:", devBranch!.name);
+  });
+
+  test("verify dev endpoint inherits project defaults", () => {
+    const endpoints = cliJson<
+      Array<{
+        name: string;
+        status: {
+          endpoint_type: string;
+          autoscaling_limit_min_cu: number;
+          autoscaling_limit_max_cu: number;
+          suspend_timeout_duration?: string;
+        };
+      }>
+    >(`postgres list-endpoints projects/${PROJECT_ID}/branches/dev`, PROFILE!);
+
+    expect(endpoints.length).toBeGreaterThan(0);
+    const rw = endpoints.find((e) => e.name.includes("/endpoints/primary"));
+    expect(rw, "auto-created read-write endpoint should exist").toBeTruthy();
+    expect(rw!.status.endpoint_type).toBe("ENDPOINT_TYPE_READ_WRITE");
+    expect(rw!.status.autoscaling_limit_min_cu).toBe(0.5);
+    expect(rw!.status.autoscaling_limit_max_cu).toBe(1.0);
+    expect(rw!.status.suspend_timeout_duration).toBe("300s");
+    console.log("[bundle] read-write endpoint inherited defaults:", rw!.name);
+  });
+
+  test("verify read-only endpoint was created by bundle", () => {
+    const endpoints = cliJson<
+      Array<{
+        name: string;
+        status: {
+          endpoint_type: string;
+          autoscaling_limit_min_cu: number;
+          autoscaling_limit_max_cu: number;
+        };
+      }>
+    >(`postgres list-endpoints projects/${PROJECT_ID}/branches/dev`, PROFILE!);
+
+    const replica = endpoints.find((e) =>
+      e.name.includes("/endpoints/replica"),
+    );
+    expect(replica, "read-only replica endpoint should exist").toBeTruthy();
+    expect(replica!.status.endpoint_type).toBe("ENDPOINT_TYPE_READ_ONLY");
+    expect(replica!.status.autoscaling_limit_min_cu).toBe(0.5);
+    expect(replica!.status.autoscaling_limit_max_cu).toBe(0.5);
+    console.log("[bundle] read-only endpoint verified:", replica!.name);
+  });
+});

--- a/tests/docs-verify/docs-verify-lakebase.test.ts
+++ b/tests/docs-verify/docs-verify-lakebase.test.ts
@@ -5,7 +5,7 @@ import { run, cli, cliJson } from "../helpers/scaffold-app";
 const sleepSync = (ms: number) =>
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 
-const PROFILE = process.env.DATABRICKS_PROFILE;
+const PROFILE = process.env.DATABRICKS_PROFILE as string;
 if (!PROFILE) {
   throw new Error(
     "DATABRICKS_PROFILE env var is required. Set it to a configured CLI profile name.",
@@ -194,6 +194,33 @@ describe("Lakebase workflow", { timeout: 600_000 }, () => {
       "[lakebase] postgres database name:",
       databases[0].status.postgres_database,
     );
+  });
+
+  test("list-branches with --page-size 1", () => {
+    const output = run(
+      `databricks postgres list-branches projects/${PROJECT_ID} --page-size 1 -o json --profile ${PROFILE}`,
+      { timeoutMs: 30_000 },
+    );
+    const parsed = JSON.parse(output);
+    expect(parsed.length).toBeLessThanOrEqual(1);
+  });
+
+  test("list-endpoints with --page-size 1", () => {
+    const output = run(
+      `databricks postgres list-endpoints ${branchName} --page-size 1 -o json --profile ${PROFILE}`,
+      { timeoutMs: 30_000 },
+    );
+    const parsed = JSON.parse(output);
+    expect(parsed.length).toBeLessThanOrEqual(1);
+  });
+
+  test("list-databases with --page-size 1", () => {
+    const output = run(
+      `databricks postgres list-databases ${branchName} --page-size 1 -o json --profile ${PROFILE}`,
+      { timeoutMs: 30_000 },
+    );
+    const parsed = JSON.parse(output);
+    expect(parsed.length).toBeLessThanOrEqual(1);
   });
 
   test("update endpoint: set pg_settings (log slow queries)", () => {

--- a/tests/docs-verify/docs-verify-lakebase.test.ts
+++ b/tests/docs-verify/docs-verify-lakebase.test.ts
@@ -196,31 +196,31 @@ describe("Lakebase workflow", { timeout: 600_000 }, () => {
     );
   });
 
-  test("list-branches with --page-size 1", () => {
+  test("list-branches with --page-size 10", () => {
     const output = run(
-      `databricks postgres list-branches projects/${PROJECT_ID} --page-size 1 -o json --profile ${PROFILE}`,
+      `databricks postgres list-branches projects/${PROJECT_ID} --page-size 10 -o json --profile ${PROFILE}`,
       { timeoutMs: 30_000 },
     );
     const parsed = JSON.parse(output);
-    expect(parsed.length).toBeLessThanOrEqual(1);
+    expect(parsed.length).toBeLessThanOrEqual(10);
   });
 
-  test("list-endpoints with --page-size 1", () => {
+  test("list-endpoints with --page-size 10", () => {
     const output = run(
-      `databricks postgres list-endpoints ${branchName} --page-size 1 -o json --profile ${PROFILE}`,
+      `databricks postgres list-endpoints ${branchName} --page-size 10 -o json --profile ${PROFILE}`,
       { timeoutMs: 30_000 },
     );
     const parsed = JSON.parse(output);
-    expect(parsed.length).toBeLessThanOrEqual(1);
+    expect(parsed.length).toBeLessThanOrEqual(10);
   });
 
-  test("list-databases with --page-size 1", () => {
+  test("list-databases with --page-size 10", () => {
     const output = run(
-      `databricks postgres list-databases ${branchName} --page-size 1 -o json --profile ${PROFILE}`,
+      `databricks postgres list-databases ${branchName} --page-size 10 -o json --profile ${PROFILE}`,
       { timeoutMs: 30_000 },
     );
     const parsed = JSON.parse(output);
-    expect(parsed.length).toBeLessThanOrEqual(1);
+    expect(parsed.length).toBeLessThanOrEqual(10);
   });
 
   test("update endpoint: set pg_settings (log slow queries)", () => {

--- a/tests/fixtures/lakebase-bundle/databricks.yml
+++ b/tests/fixtures/lakebase-bundle/databricks.yml
@@ -1,0 +1,36 @@
+bundle:
+  name: BUNDLE_NAME_PLACEHOLDER
+
+resources:
+  postgres_projects:
+    my_app:
+      project_id: "PLACEHOLDER"
+      display_name: "DevHub Bundle Test"
+      pg_version: 17
+      history_retention_duration: "172800s"
+      custom_tags:
+        - key: "env"
+          value: "test"
+        - key: "managed_by"
+          value: "devhub-ci"
+      default_endpoint_settings:
+        autoscaling_limit_min_cu: 0.5
+        autoscaling_limit_max_cu: 1.0
+        suspend_timeout_duration: "300s"
+        pg_settings:
+          log_min_duration_statement: "1000"
+
+  postgres_branches:
+    dev_branch:
+      parent: ${resources.postgres_projects.my_app.id}
+      branch_id: "dev"
+      no_expiry: true
+      is_protected: false
+
+  postgres_endpoints:
+    read_replica:
+      parent: ${resources.postgres_branches.dev_branch.id}
+      endpoint_id: "replica"
+      endpoint_type: "ENDPOINT_TYPE_READ_ONLY"
+      autoscaling_limit_min_cu: 0.5
+      autoscaling_limit_max_cu: 0.5


### PR DESCRIPTION
Add a "Declarative Automation Bundles" section to `docs/lakebase/development.md` with a `databricks.yml` example covering `postgres_projects`, `postgres_branches`, and `postgres_endpoints`, plus the validate/deploy workflow.

Rename "Databricks Asset Bundles" to "Declarative Automation Bundles" across the docs to reflect the current product name.

Tests pass: `npm run fmt`, `npm run typecheck`, `npm run build`, and `bun run test`. The verify-docs integration tests are WiP. 