### PR TITLE
fix: prevent doc tables from rendering phantom extra columns

### DIFF
--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -256,7 +256,7 @@ function Th({ className, ...props }: ComponentPropsWithoutRef<"th">) {
   return (
     <th
       className={cn(
-        "px-3 py-2 text-left align-top text-xs uppercase tracking-wide text-db-navy/80 dark:text-white/90",
+        "whitespace-nowrap px-3 py-2 text-left align-top text-xs uppercase tracking-wide text-db-navy/80 last:w-full last:whitespace-normal dark:text-white/90",
         className,
       )}
       {...props}
@@ -268,7 +268,7 @@ function Td({ className, ...props }: ComponentPropsWithoutRef<"td">) {
   return (
     <td
       className={cn(
-        "px-3 py-2.5 align-top text-db-navy/85 dark:text-white/85",
+        "whitespace-nowrap px-3 py-2.5 align-top last:w-full last:whitespace-normal text-db-navy/85 dark:text-white/85",
         className,
       )}
       {...props}


### PR DESCRIPTION
Thanks Atila for spotting this!