### PR TITLE
fix: respect sidebar_position in AppKit reference sidebar

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -43,6 +43,21 @@ function toLabel(value: string): string {
   return value.replaceAll(/[-_]/g, " ").replaceAll(/\s+/g, " ").trim();
 }
 
+function readSidebarPosition(filePath: string): number | null {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const posMatch = match[1].match(/^sidebar_position:\s*(\d+)/m);
+  return posMatch ? Number(posMatch[1]) : null;
+}
+
+function readCategoryPosition(dirPath: string): number | null {
+  const categoryFile = path.join(dirPath, "_category_.json");
+  if (!fs.existsSync(categoryFile)) return null;
+  const data = JSON.parse(fs.readFileSync(categoryFile, "utf-8"));
+  return typeof data.position === "number" ? data.position : null;
+}
+
 function readAppKitDocTree(relativeDir: string): AppKitDocTree {
   const absoluteDir = path.resolve(process.cwd(), "docs", relativeDir);
   if (!fs.existsSync(absoluteDir)) {
@@ -51,8 +66,7 @@ function readAppKitDocTree(relativeDir: string): AppKitDocTree {
 
   const entries = fs
     .readdirSync(absoluteDir, { withFileTypes: true })
-    .filter((entry) => !entry.name.startsWith("."))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .filter((entry) => !entry.name.startsWith("."));
 
   const files = entries.filter(
     (entry) =>
@@ -69,11 +83,21 @@ function readAppKitDocTree(relativeDir: string): AppKitDocTree {
     ? toDocId(path.join(relativeDir, indexFile.name))
     : null;
 
-  const fileDocItems: AppKitSidebarItem[] = files
-    .filter((entry) => !["index.md", "index.mdx"].includes(entry.name))
-    .map((entry) => toDocId(path.join(relativeDir, entry.name)));
+  type PositionedItem = {
+    position: number | null;
+    name: string;
+    item: AppKitSidebarItem;
+  };
 
-  const directoryItems: AppKitSidebarItem[] = directories
+  const fileDocItems: PositionedItem[] = files
+    .filter((entry) => !["index.md", "index.mdx"].includes(entry.name))
+    .map((entry) => ({
+      position: readSidebarPosition(path.join(absoluteDir, entry.name)),
+      name: entry.name,
+      item: toDocId(path.join(relativeDir, entry.name)),
+    }));
+
+  const directoryItems: PositionedItem[] = directories
     .map((entry) => {
       const childRelativeDir = path.join(relativeDir, entry.name);
       const childTree = readAppKitDocTree(childRelativeDir);
@@ -83,23 +107,35 @@ function readAppKitDocTree(relativeDir: string): AppKitDocTree {
       }
 
       return {
-        type: "category" as const,
-        label: toLabel(entry.name),
-        link: childTree.indexDocId
-          ? {
-              type: "doc" as const,
-              id: childTree.indexDocId,
-            }
-          : undefined,
-        collapsed: true,
-        items: childTree.items,
+        position: readCategoryPosition(path.join(absoluteDir, entry.name)),
+        name: entry.name,
+        item: {
+          type: "category" as const,
+          label: toLabel(entry.name),
+          link: childTree.indexDocId
+            ? {
+                type: "doc" as const,
+                id: childTree.indexDocId,
+              }
+            : undefined,
+          collapsed: true,
+          items: childTree.items,
+        },
       };
     })
     .filter((item): item is Exclude<typeof item, null> => item !== null);
 
+  const allItems = [...fileDocItems, ...directoryItems].sort((a, b) => {
+    if (a.position != null && b.position != null)
+      return a.position - b.position;
+    if (a.position != null) return -1;
+    if (b.position != null) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
   return {
     indexDocId,
-    items: [...fileDocItems, ...directoryItems],
+    items: allItems.map((entry) => entry.item),
   };
 }
 

--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -267,7 +267,7 @@ function DocSidebarItemCategoryCollapsible({
       <Collapsible
         lazy
         as="ul"
-        className="menu__list !ml-0 !mt-0.5 !space-y-0.5 !border-l-0 !pl-0"
+        className="menu__list !ml-0 !mt-0.5 !space-y-0.5 !border-l-0 !pl-3"
         collapsed={collapsed}
       >
         <DocSidebarItems


### PR DESCRIPTION
The auto-generated AppKit sidebar sorted entries alphabetically by filename, ignoring `sidebar_position` frontmatter and `_category_.json` position values. It now reads position metadata and sorts by it, with alphabetical as a fallback. 
Also we now indent child pages under categories for clearer visual hierarchy.