### PR TITLE
recipe: align bootstrap recipe with CLI and agent-skills docs

### DIFF
--- a/content/recipes/databricks-local-bootstrap.md
+++ b/content/recipes/databricks-local-bootstrap.md
@@ -4,7 +4,7 @@ Prepare a local Databricks app workspace: install CLI, authenticate, scaffold, a
 
 ### 1. Verify Databricks CLI version
 
-Use Databricks CLI 0.294+ before running setup and app scaffolding commands.
+Use Databricks CLI 0.296+ before running setup and app scaffolding commands.
 
 ```bash
 databricks -v
@@ -12,9 +12,7 @@ databricks -v
 
 ### 2. Install or upgrade Databricks CLI (if needed)
 
-If the Databricks CLI is not installed or below `0.294`, install it using the appropriate method for your OS. If installed, upgrade it to the latest version using the install method used to install it.
-
-Recommended installation methods below. Find all the installation methods [here](https://docs.databricks.com/aws/en/dev-tools/cli/install).
+If the Databricks CLI is not installed or below `0.296`, install it using the appropriate method for your OS. If installed, upgrade it to the latest version using the install method used to install it. See the [Databricks CLI](/docs/tools/databricks-cli) docs for full details.
 
 #### macOS
 
@@ -30,7 +28,6 @@ brew install databricks
 **WinGet**
 
 ```bash
-winget search databricks
 winget install Databricks.DatabricksCLI
 ```
 
@@ -46,19 +43,19 @@ curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.s
 
 ### 3. Authenticate to your Databricks workspace
 
+This opens a browser window for OAuth. The user must complete authentication in the browser before the CLI returns.
+
 ```bash
-databricks auth login --host <workspace-url>
+databricks auth login --host <workspace-url> --profile <PROFILE>
 ```
 
-### 4. List and select profile
-
-Always run workspace commands with `--profile <PROFILE>`.
+Pass `--profile <PROFILE>` on subsequent commands when using named profiles. Otherwise the DEFAULT profile is used, if set. List saved profiles:
 
 ```bash
 databricks auth profiles
 ```
 
-### 5. Scaffold a new Databricks app
+### 4. Scaffold a new Databricks app
 
 Run this from the directory where you want the project created. The CLI creates a new folder named after `--name` inside the current directory. Use `--version latest` to get the latest AppKit template. Add `--features` to enable specific plugins (e.g., `--features=lakebase` for database persistence).
 
@@ -78,23 +75,21 @@ cd <app-name>
 npm install
 ```
 
-### 6. Install Databricks agent skills
+### 5. Install Databricks agent skills
 
-Install the agent skills for the agents and editors you actively use.
-
-```bash
-npx skills add databricks/databricks-agent-skills -y -a claude-code -a cursor -a codex
-```
-
-Use `-y` for noninteractive installs and add one or more `-a <agent-name>` flags for your specific agents.
-
-### 7. Verify installed skills
+Install [agent skills](/docs/tools/ai-tools/agent-skills) for detected coding agents. The CLI auto-detects installed agents and installs skills globally (`--global`, the default). Pass `--project` to scope skills to the current directory instead.
 
 ```bash
-npx skills list
+databricks experimental aitools install
 ```
 
-### 8. Deploy your app
+Verify by listing installed and available skills:
+
+```bash
+databricks experimental aitools list
+```
+
+### 6. Deploy your app
 
 Deploy the scaffolded app to your Databricks workspace:
 
@@ -104,13 +99,13 @@ databricks apps deploy --profile <PROFILE>
 
 The CLI validates, builds, uploads, and starts your app. Once deployed, it prints the app URL.
 
-### 9. Verify deployed app
+### 7. Verify deployed app
 
 ```bash
 databricks apps list --profile <PROFILE>
 ```
 
-### 10. Verify deployed app logs
+### 8. Verify deployed app logs
 
 ```bash
 databricks apps logs <app-name> --profile <PROFILE>
@@ -119,8 +114,3 @@ databricks apps logs <app-name> --profile <PROFILE>
 Open the app URL from the deploy output (or `databricks apps list`) in your browser while signed in to Databricks to verify the app is running.
 
 From there, edit the source and redeploy to iterate.
-
-#### References
-
-- [Databricks CLI install](https://docs.databricks.com/en/dev-tools/cli/install)
-- [Databricks CLI authentication](https://docs.databricks.com/en/dev-tools/cli/authentication.html)


### PR DESCRIPTION
Switch agent-skills install from npx to `databricks experimental aitools`, merge auth + profile steps, add `--profile` to auth login, note OAuth browser requirement, bump CLI version to 0.296+ (which adds `--project`), and link inline to CLI and agent-skills doc pages.