### PR TITLE
feat: agent-friendly markdown serving and llms.txt improvements

### DIFF
--- a/api/content-markdown.ts
+++ b/api/content-markdown.ts
@@ -2,7 +2,13 @@ import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 import { hasMarkdownSlug } from "../src/lib/content-markdown";
 import { expandMdxImports } from "../src/lib/expand-mdx";
-import { examples, recipes, templates } from "../src/lib/recipes/recipes";
+import {
+  examples,
+  recipes,
+  recipesInOrder,
+  templates,
+} from "../src/lib/recipes/recipes";
+import { solutions } from "../src/lib/solutions/solutions";
 
 export type MarkdownSection =
   | "docs"
@@ -198,12 +204,73 @@ function readResourceMarkdown(rootDir: string, slug: string): string {
   throw new Error(`Resource page not found: "${slug}"`);
 }
 
+/** Markdown index served at /resources.md — lists all templates, recipes, and examples. */
+function readResourcesIndex(): string {
+  const lines: string[] = [
+    "# Resources",
+    "",
+    "Templates and starter kits for building on Databricks.",
+    "",
+  ];
+
+  if (templates.length > 0) {
+    lines.push("## Templates", "");
+    for (const t of templates) {
+      lines.push(`- [${t.name}](/resources/${t.id}.md): ${t.description}`);
+    }
+    lines.push("");
+  }
+
+  if (recipesInOrder.length > 0) {
+    lines.push("## Recipes", "");
+    for (const r of recipesInOrder) {
+      lines.push(`- [${r.name}](/resources/${r.id}.md): ${r.description}`);
+    }
+    lines.push("");
+  }
+
+  if (examples.length > 0) {
+    lines.push("## Examples", "");
+    for (const e of examples) {
+      lines.push(`- [${e.name}](/resources/${e.id}.md): ${e.description}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/** Markdown index served at /solutions.md — lists all solutions. */
+function readSolutionsIndex(): string {
+  const lines: string[] = [
+    "# Solutions",
+    "",
+    "Databricks use-case solutions built on Lakebase, Agent Bricks, and Databricks Apps.",
+    "",
+  ];
+
+  for (const s of solutions) {
+    lines.push(`- [${s.title}](/solutions/${s.id}.md): ${s.description}`);
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
 export function getDetailMarkdown(
   section: MarkdownSection,
   rawSlug: string,
   rootDir = process.cwd(),
 ): string {
   const slug = normalizeSlug(rawSlug);
+
+  // Empty slug → serve the section index page (e.g., /resources.md, /solutions.md)
+  if (!slug || slug.trim() === "") {
+    if (section === "resources") return readResourcesIndex();
+    if (section === "solutions") return readSolutionsIndex();
+    throw new Error("Missing slug");
+  }
+
   validateSlug(slug);
 
   switch (section) {

--- a/api/markdown.ts
+++ b/api/markdown.ts
@@ -21,25 +21,53 @@ function parseSection(section: unknown): MarkdownSection {
   );
 }
 
+/**
+ * Serves markdown content for any doc/resource/solution/template page.
+ * Reached via .md URL rewrites (vercel.json) or content negotiation (middleware.ts).
+ */
 export default function handler(req: VercelRequest, res: VercelResponse): void {
-  if (req.method !== "GET") {
-    res.setHeader("Allow", "GET");
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.setHeader("Allow", "GET, HEAD");
     res.status(405).json({ error: "Method not allowed" });
     return;
   }
 
+  const section = String(req.query.section || "");
+  const slug = String(req.query.slug || "");
+  const requestedPath = slug ? `/${section}/${slug}.md` : `/${section}.md`;
+
   try {
-    const section = parseSection(req.query.section);
-    const slug = String(req.query.slug || "");
-    const markdown = getDetailMarkdown(section, slug);
+    const parsed = parseSection(req.query.section);
+    const markdown = getDetailMarkdown(parsed, slug);
     const host = req.headers.host ?? "dev.databricks.com";
     const withFooter = appendLlmsFooter(markdown, host);
 
+    const filename = slug ? `${slug.replace(/\//g, "-")}.md` : `${parsed}.md`;
     res.setHeader("Content-Type", "text/markdown; charset=utf-8");
     res.setHeader("Cache-Control", "public, max-age=0, s-maxage=600");
+    res.setHeader("Vary", "Accept");
+    res.setHeader("X-Robots-Tag", "noindex");
+    res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
     res.status(200).send(withFooter);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    res.status(404).json({ error: message });
+  } catch {
+    res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+    res.setHeader("Vary", "Accept");
+    res.setHeader("X-Robots-Tag", "noindex");
+    res.setHeader("Content-Disposition", 'inline; filename="not-found.md"');
+    res
+      .status(404)
+      .send(
+        [
+          "# Page not found",
+          "",
+          `\`${requestedPath}\` does not exist.`,
+          "",
+          "- [Site index](/llms.txt): Table of contents for all documentation, templates, and recipes",
+          "- [All resources](/resources.md): Templates, recipes, and examples",
+          "- [All solutions](/solutions.md): Use-case solutions",
+          "- [Start here](/docs/start-here.md): Site orientation and getting started guide",
+          "",
+        ].join("\n"),
+      );
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,65 @@
+import { rewrite } from "@vercel/functions";
+
+/**
+ * Content negotiation: when a client sends Accept: text/markdown,
+ * transparently rewrite to /api/markdown so it gets markdown instead of HTML.
+ *
+ * Keep in sync with Root.tsx MD_PREFIXES and vercel.json headers/rewrites.
+ * TODO: centralize content section definitions into a shared module.
+ */
+const SECTION_PREFIXES: Record<string, string> = {
+  "/docs/": "docs",
+  "/resources/": "resources",
+  "/solutions/": "solutions",
+  "/templates/": "templates",
+};
+
+// Sections that have an index page (e.g., /resources → /resources.md)
+const BARE_SECTIONS: Record<string, string> = {
+  "/resources": "resources",
+  "/solutions": "solutions",
+};
+
+export default function middleware(request: Request): Response | undefined {
+  const accept = request.headers.get("accept") ?? "";
+  if (!accept.includes("text/markdown")) return undefined;
+
+  const url = new URL(request.url);
+  const path = url.pathname;
+
+  let section: string | undefined;
+  let slug = "";
+
+  for (const [prefix, sec] of Object.entries(SECTION_PREFIXES)) {
+    if (path.startsWith(prefix)) {
+      section = sec;
+      slug = path.slice(prefix.length).replace(/\/$/, "");
+      break;
+    }
+  }
+
+  if (!section) {
+    const bare = BARE_SECTIONS[path] ?? BARE_SECTIONS[path.replace(/\/$/, "")];
+    if (bare) {
+      section = bare;
+      slug = "";
+    }
+  }
+
+  if (!section) return undefined;
+
+  const dest = new URL("/api/markdown", url.origin);
+  dest.searchParams.set("section", section);
+  dest.searchParams.set("slug", slug);
+
+  return rewrite(dest);
+}
+
+export const config = {
+  matcher: [
+    "/docs/:path*",
+    "/resources/:path*",
+    "/solutions/:path*",
+    "/templates/:path*",
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@mdx-js/react": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "@vercel/functions": "^3.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.0.0",
         "cmdk": "^1.1.1",
@@ -8182,6 +8183,26 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vercel/nft": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.1.1.tgz",
@@ -8314,6 +8335,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@vercel/python-analysis": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mdx-js/react": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
+    "@vercel/functions": "^3.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",
     "cmdk": "^1.1.1",

--- a/plugins/llms-txt.ts
+++ b/plugins/llms-txt.ts
@@ -2,6 +2,11 @@ import fs from "fs";
 import path from "path";
 import type { LoadContext, Plugin } from "@docusaurus/types";
 import { solutions } from "../src/lib/solutions/solutions";
+import {
+  templates,
+  recipesInOrder,
+  examples,
+} from "../src/lib/recipes/recipes";
 import { expandMdxImports } from "../src/lib/expand-mdx";
 
 type Section = {
@@ -63,7 +68,7 @@ const SIDEBAR_SECTIONS: Array<{
     title: "AppKit",
     description:
       "TypeScript SDK for building full-stack Databricks Apps with plugin-based architecture, type-safe data access, and pre-built UI components.",
-    slugs: ["apps/appkit", "appkit/v0/index", "appkit/v0/plugins/index"],
+    slugs: ["appkit/v0", "appkit/v0/plugins"],
   },
   {
     title: "Tools",
@@ -131,7 +136,7 @@ function readDoc(
 }
 
 function generateLlmsTxt(baseUrl: string, docsDir: string): string {
-  const sections: Section[] = SIDEBAR_SECTIONS.map((section) => ({
+  const allSections: Section[] = SIDEBAR_SECTIONS.map((section) => ({
     title: section.title,
     description: section.description,
     docs: section.slugs
@@ -146,49 +151,95 @@ function generateLlmsTxt(baseUrl: string, docsDir: string): string {
       ),
   }));
 
+  const startHere = allSections.find((s) => s.title === "Start Here");
+  const refSections = allSections.filter((s) => s.title !== "Start Here");
+
   const lines: string[] = [
-    "# Databricks Developer",
+    "# Databricks Developer Hub",
     "",
-    "> Build intelligent data and AI applications in minutes, not months.",
+    "> Documentation, starter templates, and recipes for building apps and AI agents on Databricks using Lakebase (managed Postgres), Model Serving, and Databricks Apps.",
     "",
-    "Documentation for the Databricks developer platform covering application frameworks, AI agents, managed PostgreSQL (Lakebase), deployment tools, and starter templates.",
+  ];
+
+  // Start Here first — orientation for agents
+  if (startHere) {
+    lines.push(`## ${startHere.title}`, "", startHere.description, "");
+    for (const doc of startHere.docs) {
+      const desc = doc.description ? `: ${doc.description}` : "";
+      lines.push(`- [${doc.title}](${baseUrl}/docs/${doc.slug}.md)${desc}`);
+    }
+    lines.push("");
+  }
+
+  // Reference docs (Agents, Apps, Lakebase, AppKit, Tools)
+  for (const section of refSections) {
+    lines.push(`## ${section.title}`, "", section.description, "");
+    for (const doc of section.docs) {
+      const desc = doc.description ? `: ${doc.description}` : "";
+      lines.push(`- [${doc.title}](${baseUrl}/docs/${doc.slug}.md)${desc}`);
+    }
+    lines.push("");
+  }
+
+  // Resources — grouped by type
+  lines.push(
+    "## Resources",
     "",
+    "Templates, recipes, and examples for building on Databricks.",
+    "",
+    `- [All Resources](${baseUrl}/resources.md): Browse all resources`,
+    "",
+  );
+
+  if (templates.length > 0) {
+    lines.push(
+      "### Templates",
+      "",
+      ...templates.map(
+        (t) =>
+          `- [${t.name}](${baseUrl}/resources/${t.id}.md): ${t.description}`,
+      ),
+      "",
+    );
+  }
+
+  if (recipesInOrder.length > 0) {
+    lines.push(
+      "### Recipes",
+      "",
+      ...recipesInOrder.map(
+        (r) =>
+          `- [${r.name}](${baseUrl}/resources/${r.id}.md): ${r.description}`,
+      ),
+      "",
+    );
+  }
+
+  if (examples.length > 0) {
+    lines.push(
+      "### Examples",
+      "",
+      ...examples.map(
+        (e) =>
+          `- [${e.name}](${baseUrl}/resources/${e.id}.md): ${e.description}`,
+      ),
+      "",
+    );
+  }
+
+  // Solutions last — least actionable
+  lines.push(
     "## Solutions",
     "",
     "Databricks use-case solutions built on Lakebase, Agent Bricks, and Databricks Apps.",
     "",
-    `- [All Solutions](${baseUrl}/solutions): Overview of Databricks developer solutions`,
+    `- [All Solutions](${baseUrl}/solutions.md): Overview of Databricks developer solutions`,
     ...solutions.map(
-      (s) => `- [${s.title}](${baseUrl}/solutions/${s.id}): ${s.description}`,
+      (s) =>
+        `- [${s.title}](${baseUrl}/solutions/${s.id}.md): ${s.description}`,
     ),
     "",
-    "## Resources",
-    "",
-    "Templates and starter kits for building on Databricks.",
-    "",
-    `- [All Resources](${baseUrl}/resources): Browse all templates`,
-    `- [Hello World App](${baseUrl}/resources/hello-world-app): Databricks local bootstrap for CLI, auth, app scaffolding, and agent skill setup`,
-    `- [AI Chat App](${baseUrl}/resources/ai-chat-app): Streaming AI chat powered by Databricks Model Serving (AI Gateway) with AI SDK and AI Elements`,
-    `- [App with Lakebase](${baseUrl}/resources/app-with-lakebase): Bootstrap a Databricks app with Lakebase for persistent data storage, schema setup, and CRUD API routes`,
-    `- [Genie Analytics App](${baseUrl}/resources/genie-analytics-app): Build a minimal Databricks App with AI/BI Genie conversational analytics. Covers CLI setup, Genie space configuration, plugin wiring, and deploy.`,
-    `- [Lakebase Off-Platform](${baseUrl}/resources/lakebase-off-platform): Use Lakebase from apps hosted outside Databricks App Platform with portable env, token, and Drizzle patterns.`,
-    `- [Operational Data Analytics](${baseUrl}/resources/operational-data-analytics): End-to-end setup for analyzing operational database data in the lakehouse with Unity Catalog, Lakebase, Lakehouse Sync CDC, and medallion architecture.`,
-    "",
-  ];
-
-  for (const section of sections) {
-    lines.push(`## ${section.title}`);
-    lines.push("");
-    lines.push(section.description);
-    lines.push("");
-
-    for (const doc of section.docs) {
-      const desc = doc.description ? `: ${doc.description}` : "";
-      lines.push(`- [${doc.title}](${baseUrl}/docs/${doc.slug})${desc}`);
-    }
-
-    lines.push("");
-  }
+  );
 
   return lines.join("\n");
 }
@@ -209,9 +260,17 @@ function copyRawDocs(docsDir: string, destDir: string): void {
   }
 }
 
+/** Use the Vercel preview URL for non-production builds, otherwise the configured site URL. */
+function getBaseUrl(configUrl: string): string {
+  if (process.env.VERCEL_ENV !== "production" && process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return configUrl.replace(/\/$/, "");
+}
+
 export default function llmsTxtPlugin(context: LoadContext): Plugin {
   const docsDir = path.resolve(__dirname, "..", "docs");
-  const baseUrl = context.siteConfig.url.replace(/\/$/, "");
+  const baseUrl = getBaseUrl(context.siteConfig.url);
 
   const staticDir = path.resolve(__dirname, "..", "static");
   fs.writeFileSync(
@@ -224,10 +283,10 @@ export default function llmsTxtPlugin(context: LoadContext): Plugin {
     name: "docusaurus-llms-txt",
 
     async postBuild({ siteConfig, outDir }) {
-      const prodBaseUrl = siteConfig.url.replace(/\/$/, "");
+      const buildBaseUrl = getBaseUrl(siteConfig.url);
       fs.writeFileSync(
         path.join(outDir, "llms.txt"),
-        generateLlmsTxt(prodBaseUrl, docsDir),
+        generateLlmsTxt(buildBaseUrl, docsDir),
       );
       copyRawDocs(docsDir, path.join(outDir, "raw-docs"));
     },

--- a/src/components/examples/example-detail.tsx
+++ b/src/components/examples/example-detail.tsx
@@ -1,5 +1,6 @@
 import Link from "@docusaurus/Link";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import { MDXProvider } from "@mdx-js/react";
 import { useRef, type ReactNode } from "react";
@@ -177,6 +178,7 @@ export function ExampleDetail({
   rawMarkdown,
   children,
 }: ExampleDetailProps): ReactNode {
+  const { siteConfig } = useDocusaurusContext();
   const contentRef = useRef<HTMLDivElement>(null);
   const heroImageUrl = useBaseUrl(example.image);
   const permalink = `/resources/${example.id}`;
@@ -190,20 +192,15 @@ export function ExampleDetail({
     .map((id) => recipes.find((r) => r.id === id))
     .filter(Boolean);
 
-  const additionalMarkdown = buildAdditionalMarkdown(
+  const mdOpts = {
     example,
     githubUrl,
     includedTemplates,
     includedRecipes,
-  );
-
-  const fullPrompt = buildFullPrompt(
-    example,
-    githubUrl,
-    rawMarkdown,
-    includedTemplates,
-    includedRecipes,
-  );
+    baseUrl: siteConfig.url,
+  };
+  const additionalMarkdown = buildAdditionalMarkdown(mdOpts);
+  const fullPrompt = buildFullPrompt({ ...mdOpts, rawMarkdown });
 
   return (
     <Layout title={example.name} description={example.description}>

--- a/src/lib/examples/build-example-markdown.ts
+++ b/src/lib/examples/build-example-markdown.ts
@@ -2,6 +2,14 @@ import type { Example } from "@/lib/recipes/recipes";
 
 type ResourceRef = { id: string; name: string; description: string };
 
+export type ExampleMarkdownOptions = {
+  example: Example;
+  githubUrl: string;
+  includedTemplates: ResourceRef[];
+  includedRecipes: ResourceRef[];
+  baseUrl: string;
+};
+
 /** Outcome bullets shown in the Get started card (agent-first copy). */
 export const EXAMPLE_AGENT_OUTCOME_BULLETS = [
   "Prompt the agent to clone the DevHub repo and open this example's template/README.md",
@@ -17,12 +25,16 @@ export function buildExportGetStartedOutline(): string {
 }
 
 export function buildFullPrompt(
-  example: Example,
-  githubUrl: string,
-  rawMarkdown: string,
-  includedTemplates: ResourceRef[],
-  includedRecipes: ResourceRef[],
+  opts: ExampleMarkdownOptions & { rawMarkdown: string },
 ): string {
+  const {
+    example,
+    githubUrl,
+    rawMarkdown,
+    includedTemplates,
+    includedRecipes,
+    baseUrl,
+  } = opts;
   const cliTemplateUrl = `https://github.com/databricks/devhub/tree/main/${example.githubPath}`;
   const lines: string[] = [
     `# ${example.name}`,
@@ -56,11 +68,11 @@ export function buildFullPrompt(
   const guides = [
     ...includedTemplates.map(
       (t) =>
-        `- [${t.name}](https://dev.databricks.com/resources/${t.id}) - ${t.description}`,
+        `- [${t.name}](${baseUrl}/resources/${t.id}.md) - ${t.description}`,
     ),
     ...includedRecipes.map(
       (r) =>
-        `- [${r.name}](https://dev.databricks.com/resources/${r.id}) - ${r.description}`,
+        `- [${r.name}](${baseUrl}/resources/${r.id}.md) - ${r.description}`,
     ),
   ];
   if (guides.length > 0) {
@@ -70,12 +82,8 @@ export function buildFullPrompt(
   return lines.join("\n");
 }
 
-export function buildAdditionalMarkdown(
-  example: Example,
-  githubUrl: string,
-  includedTemplates: ResourceRef[],
-  includedRecipes: ResourceRef[],
-): string {
+export function buildAdditionalMarkdown(opts: ExampleMarkdownOptions): string {
+  const { githubUrl, includedTemplates, includedRecipes, baseUrl } = opts;
   const sections: string[] = [];
 
   sections.push(`## Get started\n\n${buildExportGetStartedOutline()}`);
@@ -83,10 +91,10 @@ export function buildAdditionalMarkdown(
 
   const links = [
     ...includedTemplates.map(
-      (t) => `- [${t.name}](https://dev.databricks.com/resources/${t.id})`,
+      (t) => `- [${t.name}](${baseUrl}/resources/${t.id}.md)`,
     ),
     ...includedRecipes.map(
-      (r) => `- [${r.name}](https://dev.databricks.com/resources/${r.id})`,
+      (r) => `- [${r.name}](${baseUrl}/resources/${r.id}.md)`,
     ),
   ];
   if (links.length > 0) {

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,6 +1,25 @@
 import type { ReactNode } from "react";
+import Head from "@docusaurus/Head";
+import { useLocation } from "@docusaurus/router";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { Toaster } from "sonner";
+
+// Keep in sync with middleware.ts matcher and vercel.json headers/rewrites
+// TODO: centralize content section definitions into a shared module
+const MD_PREFIXES = ["/docs/", "/resources", "/solutions", "/templates/"];
+
+/** Injects <link rel="alternate" type="text/markdown"> so agents discover the .md variant. */
+function MarkdownAlternate(): ReactNode {
+  const { pathname } = useLocation();
+  const hasMarkdown = MD_PREFIXES.some((p) => pathname.startsWith(p));
+  if (!hasMarkdown) return null;
+  const mdHref = pathname.replace(/\/$/, "") + ".md";
+  return (
+    <Head>
+      <link rel="alternate" type="text/markdown" href={mdHref} />
+    </Head>
+  );
+}
 
 function SonnerToaster() {
   const theme =
@@ -27,6 +46,7 @@ function SonnerToaster() {
 export default function Root({ children }: { children: ReactNode }): ReactNode {
   return (
     <>
+      <MarkdownAlternate />
       {children}
       <BrowserOnly>{() => <SonnerToaster />}</BrowserOnly>
     </>

--- a/tests/build-example-markdown.test.ts
+++ b/tests/build-example-markdown.test.ts
@@ -4,6 +4,7 @@ import {
   buildAdditionalMarkdown,
   buildExportGetStartedOutline,
 } from "../src/lib/examples/build-example-markdown";
+import type { ExampleMarkdownOptions } from "../src/lib/examples/build-example-markdown";
 import type { Example } from "../src/lib/recipes/recipes";
 
 const minimalExample: Example = {
@@ -23,6 +24,8 @@ const minimalExample: Example = {
 const githubUrl =
   "https://github.com/databricks/devhub/tree/main/examples/test-example";
 
+const baseUrl = "https://example.com";
+
 const sampleRawMarkdown = [
   "## Test Example",
   "",
@@ -35,30 +38,30 @@ const sampleRawMarkdown = [
 ].join("\n");
 
 const sampleTemplates = [
-  {
-    id: "tmpl-a",
-    name: "Template A",
-    description: "First template.",
-  },
+  { id: "tmpl-a", name: "Template A", description: "First template." },
 ];
 
 const sampleRecipes = [
-  {
-    id: "recipe-b",
-    name: "Recipe B",
-    description: "First recipe.",
-  },
+  { id: "recipe-b", name: "Recipe B", description: "First recipe." },
 ];
+
+const baseOpts: ExampleMarkdownOptions = {
+  example: minimalExample,
+  githubUrl,
+  includedTemplates: [],
+  includedRecipes: [],
+  baseUrl,
+};
 
 describe("buildFullPrompt", () => {
   test("includes example name and description", () => {
-    const prompt = buildFullPrompt(minimalExample, githubUrl, "", [], []);
+    const prompt = buildFullPrompt({ ...baseOpts, rawMarkdown: "" });
     expect(prompt).toContain("# Test Example");
     expect(prompt).toContain("A test example for unit tests.");
   });
 
   test("includes get started steps", () => {
-    const prompt = buildFullPrompt(minimalExample, githubUrl, "", [], []);
+    const prompt = buildFullPrompt({ ...baseOpts, rawMarkdown: "" });
     expect(prompt).toContain("## Get started");
     expect(prompt).toContain(
       "### 1. Clone locally and follow `template/README.md`",
@@ -75,26 +78,20 @@ describe("buildFullPrompt", () => {
   });
 
   test("includes rawMarkdown content", () => {
-    const prompt = buildFullPrompt(
-      minimalExample,
-      githubUrl,
-      sampleRawMarkdown,
-      [],
-      [],
-    );
+    const prompt = buildFullPrompt({
+      ...baseOpts,
+      rawMarkdown: sampleRawMarkdown,
+    });
     expect(prompt).toContain("This is the example overview");
     expect(prompt).toContain("### Data Flow");
     expect(prompt).toContain("1. Step one");
   });
 
   test("rawMarkdown appears after get started and before source code", () => {
-    const prompt = buildFullPrompt(
-      minimalExample,
-      githubUrl,
-      sampleRawMarkdown,
-      [],
-      [],
-    );
+    const prompt = buildFullPrompt({
+      ...baseOpts,
+      rawMarkdown: sampleRawMarkdown,
+    });
     const getStartedIdx = prompt.indexOf("### 1. Clone locally");
     const rawIdx = prompt.indexOf("This is the example overview");
     const sourceIdx = prompt.indexOf("## Source Code");
@@ -103,35 +100,34 @@ describe("buildFullPrompt", () => {
   });
 
   test("includes github link", () => {
-    const prompt = buildFullPrompt(minimalExample, githubUrl, "", [], []);
+    const prompt = buildFullPrompt({ ...baseOpts, rawMarkdown: "" });
     expect(prompt).toContain("## Source Code");
     expect(prompt).toContain(githubUrl);
   });
 
   test("includes guides from templates and recipes", () => {
-    const prompt = buildFullPrompt(
-      minimalExample,
-      githubUrl,
-      "",
-      sampleTemplates,
-      sampleRecipes,
-    );
+    const prompt = buildFullPrompt({
+      ...baseOpts,
+      rawMarkdown: "",
+      includedTemplates: sampleTemplates,
+      includedRecipes: sampleRecipes,
+    });
     expect(prompt).toContain("## Included Guides");
     expect(prompt).toContain(
-      "[Template A](https://dev.databricks.com/resources/tmpl-a) - First template.",
+      "[Template A](https://example.com/resources/tmpl-a.md) - First template.",
     );
     expect(prompt).toContain(
-      "[Recipe B](https://dev.databricks.com/resources/recipe-b) - First recipe.",
+      "[Recipe B](https://example.com/resources/recipe-b.md) - First recipe.",
     );
   });
 
   test("omits guides section when no templates or recipes", () => {
-    const prompt = buildFullPrompt(minimalExample, githubUrl, "", [], []);
+    const prompt = buildFullPrompt({ ...baseOpts, rawMarkdown: "" });
     expect(prompt).not.toContain("## Included Guides");
   });
 
   test("omits rawMarkdown section when empty string", () => {
-    const prompt = buildFullPrompt(minimalExample, githubUrl, "", [], []);
+    const prompt = buildFullPrompt({ ...baseOpts, rawMarkdown: "" });
     expect(prompt).not.toContain("This is the example overview");
     expect(prompt).toContain("## Source Code");
   });
@@ -139,7 +135,7 @@ describe("buildFullPrompt", () => {
 
 describe("buildAdditionalMarkdown", () => {
   test("includes compact get started outline for exports", () => {
-    const md = buildAdditionalMarkdown(minimalExample, githubUrl, [], []);
+    const md = buildAdditionalMarkdown(baseOpts);
     expect(md).toContain("## Get started");
     expect(md).toContain(
       "1) Clone the repository locally and open examples/<example-id>/template/README.md",
@@ -152,42 +148,40 @@ describe("buildAdditionalMarkdown", () => {
   });
 
   test("includes source code link", () => {
-    const md = buildAdditionalMarkdown(minimalExample, githubUrl, [], []);
+    const md = buildAdditionalMarkdown(baseOpts);
     expect(md).toContain("## Source Code");
     expect(md).toContain(githubUrl);
   });
 
   test("includes resource links", () => {
-    const md = buildAdditionalMarkdown(
-      minimalExample,
-      githubUrl,
-      sampleTemplates,
-      sampleRecipes,
-    );
+    const md = buildAdditionalMarkdown({
+      ...baseOpts,
+      includedTemplates: sampleTemplates,
+      includedRecipes: sampleRecipes,
+    });
     expect(md).toContain("## Included Resources");
     expect(md).toContain(
-      "[Template A](https://dev.databricks.com/resources/tmpl-a)",
+      "[Template A](https://example.com/resources/tmpl-a.md)",
     );
     expect(md).toContain(
-      "[Recipe B](https://dev.databricks.com/resources/recipe-b)",
+      "[Recipe B](https://example.com/resources/recipe-b.md)",
     );
   });
 
   test("omits resources section when no templates or recipes", () => {
-    const md = buildAdditionalMarkdown(minimalExample, githubUrl, [], []);
+    const md = buildAdditionalMarkdown(baseOpts);
     expect(md).not.toContain("## Included Resources");
   });
 });
 
 describe("buildFullPrompt matches Copy as Markdown content", () => {
   test("full prompt includes same rawMarkdown as Copy as Markdown would", () => {
-    const prompt = buildFullPrompt(
-      minimalExample,
-      githubUrl,
-      sampleRawMarkdown,
-      sampleTemplates,
-      sampleRecipes,
-    );
+    const prompt = buildFullPrompt({
+      ...baseOpts,
+      rawMarkdown: sampleRawMarkdown,
+      includedTemplates: sampleTemplates,
+      includedRecipes: sampleRecipes,
+    });
     for (const line of sampleRawMarkdown.split("\n").filter(Boolean)) {
       expect(prompt).toContain(line);
     }
@@ -196,8 +190,8 @@ describe("buildFullPrompt matches Copy as Markdown content", () => {
 
 describe("example Get started: full prompt (Copy prompt) vs export markdown (Copy as Markdown)", () => {
   test("full prompt uses ### substeps and bash fences; export uses compact 1) outline only", () => {
-    const full = buildFullPrompt(minimalExample, githubUrl, "", [], []);
-    const exportMd = buildAdditionalMarkdown(minimalExample, githubUrl, [], []);
+    const full = buildFullPrompt({ ...baseOpts, rawMarkdown: "" });
+    const exportMd = buildAdditionalMarkdown(baseOpts);
 
     expect(full).toContain(
       "### 1. Clone locally and follow `template/README.md`",
@@ -213,12 +207,11 @@ describe("example Get started: full prompt (Copy prompt) vs export markdown (Cop
   });
 
   test("export markdown never embeds full-prompt subheadings in the appended section", () => {
-    const exportMd = buildAdditionalMarkdown(
-      minimalExample,
-      githubUrl,
-      sampleTemplates,
-      sampleRecipes,
-    );
+    const exportMd = buildAdditionalMarkdown({
+      ...baseOpts,
+      includedTemplates: sampleTemplates,
+      includedRecipes: sampleRecipes,
+    });
     expect(exportMd).not.toContain("### 2.");
   });
 });

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -65,6 +65,27 @@ describe("resources meta-section resolves recipes, examples, and templates", () 
   });
 });
 
+describe("empty-slug index pages", () => {
+  test("resources index contains headings and .md links", () => {
+    const markdown = getDetailMarkdown("resources", "");
+    expect(markdown).toContain("# Resources");
+    expect(markdown).toContain("## Templates");
+    expect(markdown).toContain("## Recipes");
+    expect(markdown).toContain("## Examples");
+    expect(markdown).toMatch(/\(\/resources\/[\w-]+\.md\)/);
+  });
+
+  test("solutions index contains heading and .md links", () => {
+    const markdown = getDetailMarkdown("solutions", "");
+    expect(markdown).toContain("# Solutions");
+    expect(markdown).toMatch(/\(\/solutions\/[\w-]+\.md\)/);
+  });
+
+  test("docs with empty slug throws", () => {
+    expect(() => getDetailMarkdown("docs", "")).toThrow("Missing slug");
+  });
+});
+
 describe("example markdown includes metadata", () => {
   test("includes init command for examples with one", () => {
     const markdown = getDetailMarkdown("examples", "agentic-support-console");

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -21,23 +21,48 @@ describe("production build smoke tests", () => {
     expect(text).toContain("Sitemap:");
   });
 
-  test("llms.txt exists", () => {
+  test("llms.txt has correct H1 and description", () => {
     const text = readBuildFile("llms.txt");
-    expect(text).toContain("# Databricks Developer");
+    expect(text).toContain("# Databricks Developer Hub");
+    expect(text).toContain("> Documentation, starter templates, and recipes");
+  });
+
+  test("llms.txt links use .md suffix", () => {
+    const text = readBuildFile("llms.txt");
+    expect(text).toContain("/docs/start-here.md");
+    expect(text).toContain("/resources/hello-world-app.md");
+    expect(text).toContain("/solutions.md");
+  });
+
+  test("llms.txt section order: Start Here before Resources before Solutions", () => {
+    const text = readBuildFile("llms.txt");
+    const startHereIdx = text.indexOf("## Start Here");
+    const resourcesIdx = text.indexOf("## Resources");
+    const solutionsIdx = text.indexOf("## Solutions");
+    expect(startHereIdx).toBeGreaterThan(-1);
+    expect(resourcesIdx).toBeGreaterThan(startHereIdx);
+    expect(solutionsIdx).toBeGreaterThan(resourcesIdx);
+  });
+
+  test("llms.txt resources have subheadings", () => {
+    const text = readBuildFile("llms.txt");
+    expect(text).toContain("### Templates");
+    expect(text).toContain("### Recipes");
+    expect(text).toContain("### Examples");
   });
 
   test("llms.txt links to all resource templates", () => {
     const text = readBuildFile("llms.txt");
 
     const expectedTemplates = [
-      "/solutions",
-      "/resources",
-      "/resources/hello-world-app",
-      "/resources/ai-chat-app",
-      "/resources/app-with-lakebase",
-      "/resources/genie-analytics-app",
-      "/resources/lakebase-off-platform",
-      "/resources/operational-data-analytics",
+      "/solutions.md",
+      "/resources.md",
+      "/resources/hello-world-app.md",
+      "/resources/ai-chat-app.md",
+      "/resources/app-with-lakebase.md",
+      "/resources/genie-analytics-app.md",
+      "/resources/lakebase-off-platform.md",
+      "/resources/operational-data-analytics.md",
     ];
 
     for (const path of expectedTemplates) {
@@ -49,25 +74,25 @@ describe("production build smoke tests", () => {
     const text = readBuildFile("llms.txt");
 
     const expectedDocPaths = [
-      "/docs/start-here",
-      "/docs/agents/getting-started",
-      "/docs/agents/core-concepts",
-      "/docs/agents/development",
-      "/docs/agents/ai-gateway",
-      "/docs/agents/observability",
-      "/docs/apps/getting-started",
-      "/docs/apps/core-concepts",
-      "/docs/apps/plugins",
-      "/docs/apps/development",
-      "/docs/lakebase/getting-started",
-      "/docs/lakebase/core-concepts",
-      "/docs/lakebase/development",
-      "/docs/apps/appkit",
-      "/docs/appkit/v0",
-      "/docs/appkit/v0/plugins",
-      "/docs/tools/databricks-cli",
-      "/docs/tools/ai-tools/agent-skills",
-      "/docs/tools/ai-tools/docs-mcp-server",
+      "/docs/start-here.md",
+      "/docs/agents/getting-started.md",
+      "/docs/agents/core-concepts.md",
+      "/docs/agents/development.md",
+      "/docs/agents/ai-gateway.md",
+      "/docs/agents/observability.md",
+      "/docs/apps/getting-started.md",
+      "/docs/apps/core-concepts.md",
+      "/docs/apps/plugins.md",
+      "/docs/apps/development.md",
+      "/docs/lakebase/getting-started.md",
+      "/docs/lakebase/core-concepts.md",
+      "/docs/lakebase/development.md",
+      "/docs/apps/appkit.md",
+      "/docs/appkit/v0.md",
+      "/docs/appkit/v0/plugins.md",
+      "/docs/tools/databricks-cli.md",
+      "/docs/tools/ai-tools/agent-skills.md",
+      "/docs/tools/ai-tools/docs-mcp-server.md",
     ];
 
     for (const docPath of expectedDocPaths) {

--- a/vercel.json
+++ b/vercel.json
@@ -12,23 +12,46 @@
   },
   "rewrites": [
     {
+      "source": "/docs/llms.txt",
+      "destination": "/llms.txt"
+    },
+    {
       "source": "/docs/(.+)\\.md",
       "destination": "/api/markdown?section=docs&slug=$1"
     },
     {
-      "source": "/solutions/(.+)\\.md",
-      "destination": "/api/markdown?section=solutions&slug=$1"
+      "source": "/resources.md",
+      "destination": "/api/markdown?section=resources&slug="
     },
     {
       "source": "/resources/(.+)\\.md",
       "destination": "/api/markdown?section=resources&slug=$1"
     },
     {
+      "source": "/solutions.md",
+      "destination": "/api/markdown?section=solutions&slug="
+    },
+    {
+      "source": "/solutions/(.+)\\.md",
+      "destination": "/api/markdown?section=solutions&slug=$1"
+    },
+    {
       "source": "/templates/(.+)\\.md",
       "destination": "/api/markdown?section=templates&slug=$1"
+    },
+    {
+      "source": "/(.+)\\.md",
+      "destination": "/api/markdown?section=docs&slug=$1"
     }
   ],
   "headers": [
+    {
+      "source": "/(docs|resources|solutions|templates)(.*)",
+      "headers": [
+        { "key": "Link", "value": "</llms.txt>; rel=\"llms-txt\"" },
+        { "key": "X-LLMs-Txt", "value": "/llms.txt" }
+      ]
+    },
     {
       "source": "/api/(.*)",
       "headers": [


### PR DESCRIPTION
## Summary
- Agents can now request markdown via `Accept: text/markdown` (Edge Middleware) or `.md` URLs (e.g., `/docs/start-here.md`)
- `llms.txt` links now use `.md` URLs with dynamically generated resources (was hardcoded) and deployment-aware URLs for previews
- `llms.txt` content restructured: functional description, agent-friendly section order, resource subheadings, removed duplicates
- HTML pages include `<link rel="alternate" type="text/markdown">`, `Link: rel=llms-txt`, and `X-LLMs-Txt` headers
- Markdown responses include `X-Robots-Tag: noindex`, `Content-Disposition`, and `Vary: Accept`
- `.md` URLs that 404 return a useful markdown error page instead of HTML
- `/docs/llms.txt` now serves the same content as `/llms.txt`


## Test plan
- [x] `npm run fmt && npm run typecheck && npm run build && bun run test` (all pass)
- [x] Verify `curl -H "Accept: text/markdown" <url>/docs/start-here` returns markdown
- [x] Verify `<url>/docs/start-here.md` returns markdown
- [x] Verify `<url>/resources.md` returns an index page
- [x] Verify `<url>/nonexistent.md` returns a markdown 404
- [x] Verify HTML pages have `<link rel="alternate" type="text/markdown">` in source
- [x] Verify HTML pages include `Link: </llms.txt>; rel="llms-txt"` and `X-LLMs-Txt` headers
- [x] Verify markdown responses include `Vary: Accept`, `X-Robots-Tag: noindex`, and `Content-Disposition` headers