### PR TITLE
fix: prepend llms.txt reference and strip frontmatter from raw-docs

### DIFF
--- a/api/content-markdown.ts
+++ b/api/content-markdown.ts
@@ -291,8 +291,8 @@ export function getDetailMarkdown(
   }
 }
 
-export function appendLlmsFooter(markdown: string, host: string): string {
+export function prependLlmsReference(markdown: string, host: string): string {
   const protocol = host.startsWith("localhost") ? "http" : "https";
   const llmsUrl = `${protocol}://${host}/llms.txt`;
-  return `${markdown.trimEnd()}\n\n---\nFull documentation: ${llmsUrl}\n`;
+  return `> Full DevHub resource index: ${llmsUrl}\n\n${markdown.trimEnd()}\n`;
 }

--- a/api/markdown.ts
+++ b/api/markdown.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import {
-  appendLlmsFooter,
+  prependLlmsReference,
   getDetailMarkdown,
   type MarkdownSection,
 } from "./content-markdown";
@@ -40,7 +40,7 @@ export default function handler(req: VercelRequest, res: VercelResponse): void {
     const parsed = parseSection(req.query.section);
     const markdown = getDetailMarkdown(parsed, slug);
     const host = req.headers.host ?? "dev.databricks.com";
-    const withFooter = appendLlmsFooter(markdown, host);
+    const withRef = prependLlmsReference(markdown, host);
 
     const filename = slug ? `${slug.replace(/\//g, "-")}.md` : `${parsed}.md`;
     res.setHeader("Content-Type", "text/markdown; charset=utf-8");
@@ -48,7 +48,7 @@ export default function handler(req: VercelRequest, res: VercelResponse): void {
     res.setHeader("Vary", "Accept");
     res.setHeader("X-Robots-Tag", "noindex");
     res.setHeader("Content-Disposition", `inline; filename="${filename}"`);
-    res.status(200).send(withFooter);
+    res.status(200).send(withRef);
   } catch {
     res.setHeader("Content-Type", "text/markdown; charset=utf-8");
     res.setHeader("Vary", "Accept");

--- a/plugins/llms-txt.ts
+++ b/plugins/llms-txt.ts
@@ -255,7 +255,9 @@ function copyRawDocs(docsDir: string, destDir: string): void {
       copyRawDocs(srcPath, dstPath);
     } else if (entry.name.endsWith(".md") || entry.name.endsWith(".mdx")) {
       const raw = fs.readFileSync(srcPath, "utf-8");
-      fs.writeFileSync(dstPath, expandMdxImports(raw, srcPath));
+      const expanded = expandMdxImports(raw, srcPath);
+      const stripped = expanded.replace(/^---\n[\s\S]*?\n---\n*/, "");
+      fs.writeFileSync(dstPath, stripped);
     }
   }
 }

--- a/src/components/ai-export-menu.tsx
+++ b/src/components/ai-export-menu.tsx
@@ -71,10 +71,10 @@ export function AIExportMenu({
     const escapedTitle = title.replace(/"/g, '\\"');
     const escapedDescription = description.replace(/"/g, '\\"');
 
-    let md = `---\ntitle: "${escapedTitle}"\nurl: ${fullUrl}\nsummary: "${escapedDescription}"\n---\n\n`;
+    let md = `> Full DevHub resource index: ${baseUrl}/llms.txt\n\n`;
+    md += `---\ntitle: "${escapedTitle}"\nurl: ${fullUrl}\nsummary: "${escapedDescription}"\n---\n\n`;
     if (rawContent) md += `${rawContent}\n\n`;
     if (additionalMarkdown) md += `${additionalMarkdown}\n\n`;
-    md += `---\nFull documentation: ${baseUrl}/llms.txt\n`;
     return md;
   }, [
     resolveContent,

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { appendLlmsFooter, getDetailMarkdown } from "../api/content-markdown";
+import {
+  prependLlmsReference,
+  getDetailMarkdown,
+} from "../api/content-markdown";
 
 describe("detail markdown resolver", () => {
   test("resolves docs markdown", () => {
@@ -106,70 +109,69 @@ describe("example markdown includes metadata", () => {
   });
 });
 
-describe("appendLlmsFooter appends llms.txt reference", () => {
-  test("appends footer with https for production host", () => {
-    const result = appendLlmsFooter("# Hello", "dev.databricks.com");
+describe("prependLlmsReference prepends llms.txt reference", () => {
+  const LLMS_REF =
+    "> Full DevHub resource index: https://dev.databricks.com/llms.txt";
+
+  test("prepends reference with https for production host", () => {
+    const result = prependLlmsReference("# Hello", "dev.databricks.com");
+    expect(result).toBe(`${LLMS_REF}\n\n# Hello\n`);
+  });
+
+  test("prepends reference with http for localhost", () => {
+    const result = prependLlmsReference("# Hello", "localhost:3001");
     expect(result).toBe(
-      "# Hello\n\n---\nFull documentation: https://dev.databricks.com/llms.txt\n",
+      "> Full DevHub resource index: http://localhost:3001/llms.txt\n\n# Hello\n",
     );
   });
 
-  test("appends footer with http for localhost", () => {
-    const result = appendLlmsFooter("# Hello", "localhost:3001");
-    expect(result).toBe(
-      "# Hello\n\n---\nFull documentation: http://localhost:3001/llms.txt\n",
-    );
+  test("trims trailing whitespace from markdown", () => {
+    const result = prependLlmsReference("content\n\n\n", "dev.databricks.com");
+    expect(result).toMatch(/^> Full DevHub/);
+    expect(result).toMatch(/content\n$/);
+    expect(result).not.toMatch(/\n\n\n$/);
   });
 
-  test("trims trailing whitespace from markdown before appending", () => {
-    const result = appendLlmsFooter("content\n\n\n", "dev.databricks.com");
-    expect(result).toMatch(/^content\n\n---\n/);
-    expect(result).not.toMatch(/content\n\n\n\n/);
-  });
-
-  const LLMS_FOOTER =
-    "---\nFull documentation: https://dev.databricks.com/llms.txt\n";
-
-  test("docs markdown with footer ends with llms.txt link", () => {
+  test("docs markdown starts with llms.txt reference", () => {
     const markdown = getDetailMarkdown("docs", "start-here");
-    const withFooter = appendLlmsFooter(markdown, "dev.databricks.com");
-    expect(withFooter).toContain("title:");
-    expect(withFooter.endsWith(LLMS_FOOTER)).toBe(true);
+    const result = prependLlmsReference(markdown, "dev.databricks.com");
+    expect(result.startsWith(LLMS_REF)).toBe(true);
+    expect(result).toContain("title:");
   });
 
-  test("recipe markdown with footer ends with llms.txt link", () => {
+  test("recipe markdown starts with llms.txt reference", () => {
     const markdown = getDetailMarkdown("recipes", "databricks-local-bootstrap");
-    const withFooter = appendLlmsFooter(markdown, "dev.databricks.com");
-    expect(withFooter).toContain("## Databricks Local Bootstrap");
-    expect(withFooter.endsWith(LLMS_FOOTER)).toBe(true);
+    const result = prependLlmsReference(markdown, "dev.databricks.com");
+    expect(result.startsWith(LLMS_REF)).toBe(true);
+    expect(result).toContain("## Databricks Local Bootstrap");
   });
 
-  test("example markdown with footer ends with llms.txt link", () => {
+  test("example markdown starts with llms.txt reference", () => {
     const markdown = getDetailMarkdown("examples", "agentic-support-console");
-    const withFooter = appendLlmsFooter(markdown, "dev.databricks.com");
-    expect(withFooter).toContain("## Agentic Support Console");
-    expect(withFooter.endsWith(LLMS_FOOTER)).toBe(true);
+    const result = prependLlmsReference(markdown, "dev.databricks.com");
+    expect(result.startsWith(LLMS_REF)).toBe(true);
+    expect(result).toContain("## Agentic Support Console");
   });
 
-  test("template markdown with footer ends with llms.txt link", () => {
+  test("template markdown starts with llms.txt reference", () => {
     const markdown = getDetailMarkdown("templates", "hello-world-app");
-    const withFooter = appendLlmsFooter(markdown, "dev.databricks.com");
-    expect(withFooter).toContain("# Hello World App");
-    expect(withFooter.endsWith(LLMS_FOOTER)).toBe(true);
+    const result = prependLlmsReference(markdown, "dev.databricks.com");
+    expect(result.startsWith(LLMS_REF)).toBe(true);
+    expect(result).toContain("# Hello World App");
   });
 
-  test("solution markdown with footer ends with llms.txt link", () => {
+  test("solution markdown starts with llms.txt reference", () => {
     const markdown = getDetailMarkdown("solutions", "devhub-launch");
-    const withFooter = appendLlmsFooter(markdown, "dev.databricks.com");
-    expect(withFooter).toContain("# Introducing dev.databricks.com");
-    expect(withFooter.endsWith(LLMS_FOOTER)).toBe(true);
+    const result = prependLlmsReference(markdown, "dev.databricks.com");
+    expect(result.startsWith(LLMS_REF)).toBe(true);
+    expect(result).toContain("# Introducing dev.databricks.com");
   });
 
-  test("resources meta-section with footer ends with llms.txt link", () => {
+  test("resources meta-section starts with llms.txt reference", () => {
     const markdown = getDetailMarkdown("resources", "agentic-support-console");
-    const withFooter = appendLlmsFooter(markdown, "dev.databricks.com");
-    expect(withFooter).toContain("## Agentic Support Console");
-    expect(withFooter.endsWith(LLMS_FOOTER)).toBe(true);
+    const result = prependLlmsReference(markdown, "dev.databricks.com");
+    expect(result.startsWith(LLMS_REF)).toBe(true);
+    expect(result).toContain("## Agentic Support Console");
   });
 });
 

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -100,6 +100,12 @@ describe("production build smoke tests", () => {
     }
   });
 
+  test("raw-docs strip Docusaurus frontmatter", () => {
+    const text = readBuildFile("raw-docs/start-here.md");
+    expect(text).not.toMatch(/^---\n/);
+    expect(text).toMatch(/^# Start here/);
+  });
+
   test("raw-docs preserve CLI tab code blocks for markdown export", () => {
     const text = readBuildFile("raw-docs/lakebase/core-concepts.md");
     expect(text).toContain('title="Common"');


### PR DESCRIPTION
- Move the llms.txt reference from a footer to a prepended blockquote and rename "Full documentation" to "Full DevHub resource index" across the markdown API and AI export menu.
- Strip Docusaurus frontmatter in copyRawDocs so /raw-docs/ files served to ai-export-menu don't duplicate frontmatter when wrapped with AI-specific metadata.
- TODO: Unify frontmatter schema between the markdown API and the copy-markdown export, should be the same