### PR TITLE
tests: expand docs-verify cli --help tests

### DIFF
--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -116,6 +116,12 @@ databricks bundle deploy
 databricks bundle run agent_openai_agents_sdk
 ```
 
+### Upload and configure
+
+```bash title="Common"
+databricks bundle deploy
+```
+
 ```bash title="All Options"
 databricks bundle deploy \
   --auto-approve \
@@ -129,18 +135,7 @@ databricks bundle deploy \
   --var "key=value" \
   --target $TARGET \
   --profile $DATABRICKS_PROFILE
-
-databricks bundle run agent_openai_agents_sdk \
-  --no-wait \
-  --restart \
-  --debug \
-  -o json \
-  --var "key=value" \
-  --target $TARGET \
-  --profile $DATABRICKS_PROFILE
 ```
-
-### `databricks bundle deploy`
 
 <details>
 <summary>Options</summary>
@@ -161,7 +156,22 @@ databricks bundle run agent_openai_agents_sdk \
 
 </details>
 
-### `databricks bundle run`
+### Start the app
+
+```bash title="Common"
+databricks bundle run agent_openai_agents_sdk
+```
+
+```bash title="All Options"
+databricks bundle run agent_openai_agents_sdk \
+  --no-wait \
+  --restart \
+  --debug \
+  -o json \
+  --var "key=value" \
+  --target $TARGET \
+  --profile $DATABRICKS_PROFILE
+```
 
 <details>
 <summary>Options</summary>
@@ -176,6 +186,8 @@ databricks bundle run agent_openai_agents_sdk \
 | `--var`     | no       | Set values for bundle config variables (for example, `--var="key=value"`)          |
 | `--target`  | no       | Bundle target (for example, `dev`, `prod`)                                         |
 | `--profile` | no       | Databricks CLI profile name                                                        |
+
+Job, pipeline, and task-specific flags are omitted. Run `databricks bundle run --help` for the full list.
 
 </details>
 
@@ -200,6 +212,9 @@ databricks apps get $APP_NAME \
   --profile $DATABRICKS_PROFILE
 ```
 
+<details>
+<summary>Options</summary>
+
 | Option      | Required | Description                                                               |
 | ----------- | -------- | ------------------------------------------------------------------------- |
 | `NAME`      | yes      | App name                                                                  |
@@ -208,6 +223,8 @@ databricks apps get $APP_NAME \
 | `--target`  | no       | Bundle target to use (if applicable)                                      |
 | `--var`     | no       | Set values for bundle config variables (for example, `--var="key=value"`) |
 | `--profile` | no       | Databricks CLI profile name                                               |
+
+</details>
 
 Query the deployed agent using the `url` field from the `apps get` output (OAuth required, PATs are not supported):
 

--- a/tests/docs-verify/cli-commands.ts
+++ b/tests/docs-verify/cli-commands.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type CommandSpec = {
+  command: string;
+  doc: string;
+};
+
+export const MUTUALLY_EXCLUSIVE: Record<string, string[]> = {
+  psql: ["--provisioned", "--autoscaling"],
+  manifest: ["--branch", "--version"],
+  init: ["--branch", "--version"],
+};
+
+export const SKIP_FLAGS: Record<string, string[]> = {
+  "apps init": ["--name"],
+  "postgres create-project": ["--name"],
+  "postgres create-branch": ["--name"],
+  "postgres update-branch": ["--name"],
+  "postgres update-endpoint": ["--name"],
+  "postgres update-project": ["--name"],
+  // Job, pipeline, and task-specific flags are intentionally omitted from the
+  // agents docs since bundle run is only used here to start apps.
+  "bundle run": [
+    "--only",
+    "--params",
+    "--dbt-commands",
+    "--jar-params",
+    "--notebook-params",
+    "--pipeline-params",
+    "--python-named-params",
+    "--python-params",
+    "--spark-submit-params",
+    "--sql-params",
+    "--full-refresh",
+    "--full-refresh-all",
+    "--refresh",
+    "--refresh-all",
+    "--validate-only",
+    // These appear in help examples ("-- --key1 value1") or notes, not as real flags.
+    "--key1",
+    "--key2",
+    "--param",
+  ],
+};
+
+export const SHORT_TO_LONG: Record<string, string> = {
+  "-o": "--output",
+  "-f": "--follow",
+  "-p": "--profile",
+  "-t": "--target",
+  "-c": "--cluster-id",
+};
+
+export function getAllOptionsBlocks(docPath: string): string[] {
+  const content = readFileSync(resolve(process.cwd(), docPath), "utf-8");
+  const blocks: string[] = [];
+  const regex = /```\w+\s+title="All Options"\s*\n([\s\S]*?)```/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    blocks.push(match[1]);
+  }
+  return blocks;
+}
+
+export const CLI_COMMANDS: CommandSpec[] = [
+  // Lakebase
+  {
+    command: "postgres create-project",
+    doc: "docs/lakebase/quickstart.md",
+  },
+  {
+    command: "postgres list-endpoints",
+    doc: "docs/lakebase/quickstart.md",
+  },
+  {
+    command: "postgres list-databases",
+    doc: "docs/lakebase/quickstart.md",
+  },
+  {
+    command: "postgres generate-database-credential",
+    doc: "docs/lakebase/quickstart.md",
+  },
+  {
+    command: "psql",
+    doc: "docs/lakebase/quickstart.md",
+  },
+  {
+    command: "postgres create-branch",
+    doc: "docs/lakebase/development.md",
+  },
+  {
+    command: "postgres update-branch",
+    doc: "docs/lakebase/development.md",
+  },
+  {
+    command: "postgres update-endpoint",
+    doc: "docs/lakebase/core-concepts.md",
+  },
+  {
+    command: "postgres update-project",
+    doc: "docs/lakebase/core-concepts.md",
+  },
+  {
+    command: "postgres delete-branch",
+    doc: "docs/lakebase/development.md",
+  },
+  {
+    command: "psql",
+    doc: "docs/lakebase/development.md",
+  },
+  // Apps
+  {
+    command: "apps init",
+    doc: "docs/apps/quickstart.md",
+  },
+  {
+    command: "apps deploy",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps logs",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps init",
+    doc: "docs/apps/plugins.md",
+  },
+  {
+    command: "apps manifest",
+    doc: "docs/apps/plugins.md",
+  },
+  {
+    command: "apps get",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps stop",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps start",
+    doc: "docs/apps/development.md",
+  },
+  {
+    command: "apps delete",
+    doc: "docs/apps/development.md",
+  },
+  // Agents
+  {
+    command: "bundle validate",
+    doc: "docs/agents/quickstart.md",
+  },
+  {
+    command: "bundle deploy",
+    doc: "docs/agents/quickstart.md",
+  },
+  {
+    command: "bundle run",
+    doc: "docs/agents/quickstart.md",
+  },
+  // agents/development.md cross-documents the same deploy and app management
+  // commands; testing them here catches drift in that page independently.
+  {
+    command: "bundle validate",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "bundle deploy",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "bundle run",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "apps get",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "apps logs",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "apps stop",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "apps start",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "apps delete",
+    doc: "docs/agents/development.md",
+  },
+  {
+    command: "apps get",
+    doc: "docs/agents/quickstart.md",
+  },
+  {
+    command: "serving-endpoints list",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "serving-endpoints get",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "serving-endpoints query",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "serving-endpoints create",
+    doc: "docs/agents/ai-gateway.md",
+  },
+  {
+    command: "experiments create-experiment",
+    doc: "docs/agents/observability.md",
+  },
+];

--- a/tests/docs-verify/cli-options-coverage.test.ts
+++ b/tests/docs-verify/cli-options-coverage.test.ts
@@ -1,0 +1,51 @@
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect } from "vitest";
+import { CLI_COMMANDS, getAllOptionsBlocks } from "./cli-commands";
+
+// Extract all databricks subcommands from a block. Combined blocks (multiple
+// commands in one "All Options" fence) are split at lines beginning with
+// "databricks" so each command is detected independently.
+function getCommandsFromBlock(block: string): string[] {
+  const sections = block.split(/\n(?=databricks\s)/);
+  const commands: string[] = [];
+  for (const section of sections) {
+    // (?=\s|$) prevents partial matches like "agent" from "agent_openai_agents_sdk"
+    const match = section.match(
+      /^databricks\s+((?:[a-z][a-z0-9-]*\s+)*[a-z][a-z0-9-]*)(?=\s|$)/m,
+    );
+    if (match) commands.push(match[1].trimEnd());
+  }
+  return commands;
+}
+
+describe("All 'All Options' blocks are covered by CLI_COMMANDS", () => {
+  test("every databricks 'All Options' block in docs has a CLI_COMMANDS entry", () => {
+    const docsDir = resolve(process.cwd(), "docs");
+    const mdFiles = (
+      readdirSync(docsDir, { recursive: true, encoding: "utf-8" }) as string[]
+    )
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => `docs/${f}`);
+
+    const missing: string[] = [];
+
+    for (const docPath of mdFiles) {
+      const blocks = getAllOptionsBlocks(docPath);
+      for (const block of blocks) {
+        for (const command of getCommandsFromBlock(block)) {
+          const covered = CLI_COMMANDS.some(
+            (s) => s.command === command && s.doc === docPath,
+          );
+          if (!covered)
+            missing.push(`  { command: "${command}", doc: "${docPath}" }`);
+        }
+      }
+    }
+
+    expect(
+      missing,
+      `These "All Options" blocks in docs have no CLI_COMMANDS entry:\n${missing.join("\n")}`,
+    ).toHaveLength(0);
+  });
+});

--- a/tests/docs-verify/cli-options-lakebase.test.ts
+++ b/tests/docs-verify/cli-options-lakebase.test.ts
@@ -1,161 +1,29 @@
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { describe, test, expect } from "vitest";
-
-const MUTUALLY_EXCLUSIVE: Record<string, string[]> = {
-  psql: ["--provisioned", "--autoscaling"],
-  manifest: ["--branch", "--version"],
-  init: ["--branch", "--version"],
-};
-
-const SKIP_FLAGS: Record<string, string[]> = {
-  "apps init": ["--name"],
-  "postgres create-project": ["--name"],
-  "postgres create-branch": ["--name"],
-  "postgres update-branch": ["--name"],
-  "postgres update-endpoint": ["--name"],
-  "postgres update-project": ["--name"],
-};
-
-const SHORT_TO_LONG: Record<string, string> = {
-  "-o": "--output",
-  "-f": "--follow",
-  "-p": "--profile",
-  "-t": "--target",
-  "-c": "--cluster-id",
-};
+import {
+  CLI_COMMANDS,
+  MUTUALLY_EXCLUSIVE,
+  SKIP_FLAGS,
+  SHORT_TO_LONG,
+  getAllOptionsBlocks,
+} from "./cli-commands";
 
 const LONG_TO_SHORT: Record<string, string> = Object.fromEntries(
   Object.entries(SHORT_TO_LONG).map(([short, long]) => [long, short]),
 );
-
-type CommandSpec = {
-  command: string;
-  doc: string;
-};
-
-const CLI_COMMANDS: CommandSpec[] = [
-  // Lakebase
-  {
-    command: "postgres create-project",
-    doc: "docs/lakebase/quickstart.md",
-  },
-  {
-    command: "postgres list-endpoints",
-    doc: "docs/lakebase/quickstart.md",
-  },
-  {
-    command: "postgres list-databases",
-    doc: "docs/lakebase/quickstart.md",
-  },
-  {
-    command: "postgres generate-database-credential",
-    doc: "docs/lakebase/quickstart.md",
-  },
-  {
-    command: "psql",
-    doc: "docs/lakebase/quickstart.md",
-  },
-  {
-    command: "postgres create-branch",
-    doc: "docs/lakebase/core-concepts.md",
-  },
-  {
-    command: "postgres update-branch",
-    doc: "docs/lakebase/core-concepts.md",
-  },
-  {
-    command: "postgres update-endpoint",
-    doc: "docs/lakebase/core-concepts.md",
-  },
-  {
-    command: "postgres update-project",
-    doc: "docs/lakebase/core-concepts.md",
-  },
-  {
-    command: "postgres delete-branch",
-    doc: "docs/lakebase/development.md",
-  },
-  // Apps
-  {
-    command: "apps init",
-    doc: "docs/apps/quickstart.md",
-  },
-  {
-    command: "apps deploy",
-    doc: "docs/apps/development.md",
-  },
-  {
-    command: "apps logs",
-    doc: "docs/apps/development.md",
-  },
-  {
-    command: "apps manifest",
-    doc: "docs/apps/plugins.md",
-  },
-  {
-    command: "apps get",
-    doc: "docs/apps/development.md",
-  },
-  // Agents
-  {
-    command: "bundle validate",
-    doc: "docs/agents/quickstart.md",
-  },
-  {
-    command: "apps get",
-    doc: "docs/agents/quickstart.md",
-  },
-  {
-    command: "serving-endpoints list",
-    doc: "docs/agents/ai-gateway.md",
-  },
-  {
-    command: "serving-endpoints get",
-    doc: "docs/agents/ai-gateway.md",
-  },
-  {
-    command: "serving-endpoints query",
-    doc: "docs/agents/ai-gateway.md",
-  },
-  {
-    command: "serving-endpoints create",
-    doc: "docs/agents/ai-gateway.md",
-  },
-  {
-    command: "experiments create-experiment",
-    doc: "docs/agents/development.md",
-  },
-  {
-    command: "experiments create-experiment",
-    doc: "docs/agents/observability.md",
-  },
-];
 
 function getCliFlags(command: string): string[] {
   const output = execSync(`databricks ${command} --help`, {
     encoding: "utf-8",
   });
   const flags: string[] = [];
-  for (const match of output.matchAll(/(--[\w-]+)/gm)) {
+  for (const match of output.matchAll(/(--[a-zA-Z][a-zA-Z0-9-]*)/gm)) {
     const flag = match[1];
     if (flag !== "--help") {
       flags.push(flag);
     }
   }
   return [...new Set(flags)];
-}
-
-function getAllOptionsBlocks(docPath: string): string[] {
-  const content = readFileSync(resolve(process.cwd(), docPath), "utf-8");
-  const blocks: string[] = [];
-  const regex = /```\w+\s+title="All Options"\s*\n([\s\S]*?)```/g;
-  let match;
-  while ((match = regex.exec(content)) !== null) {
-    blocks.push(match[1]);
-  }
-  return blocks;
 }
 
 function extractFlagsFromBlocks(blocks: string[]): string[] {
@@ -180,6 +48,19 @@ function findBlockForCommand(
   return blocks.find((b) => b.includes(cliCommand));
 }
 
+// When a single "All Options" block documents multiple commands, split it into
+// per-command sections (split at lines that start a new `databricks` command)
+// and return flags only for the relevant section.
+function extractFlagsForCommand(block: string, command: string): string[] {
+  const cliCommand = `databricks ${command}`;
+  const sections = block.split(/\n(?=databricks\s)/);
+  const section =
+    sections.length > 1
+      ? (sections.find((s) => s.includes(cliCommand)) ?? block)
+      : block;
+  return extractFlagsFromBlocks([section]);
+}
+
 function flagInSet(flag: string, flagSet: string[]): boolean {
   if (flagSet.includes(flag)) return true;
   const alt = SHORT_TO_LONG[flag] ?? LONG_TO_SHORT[flag];
@@ -199,7 +80,7 @@ describe("CLI options completeness", () => {
           `No "All Options" code block found for '${spec.command}' in ${spec.doc}`,
         ).toBeTruthy();
 
-        const docFlags = extractFlagsFromBlocks([block!]);
+        const docFlags = extractFlagsForCommand(block!, spec.command);
         const subcommand = spec.command.split(" ").pop()!;
         const exclusiveGroup = MUTUALLY_EXCLUSIVE[subcommand] ?? [];
         const skipFlags = SKIP_FLAGS[spec.command] ?? [];
@@ -226,7 +107,7 @@ describe("CLI options completeness", () => {
 
         if (!block) return;
 
-        const docFlags = extractFlagsFromBlocks([block]);
+        const docFlags = extractFlagsForCommand(block, spec.command);
 
         for (const flag of docFlags) {
           expect(

--- a/tests/docs-verify/docs-verify-agents.test.ts
+++ b/tests/docs-verify/docs-verify-agents.test.ts
@@ -188,72 +188,7 @@ describe("Bundle validation", { timeout: 180_000 }, () => {
   });
 });
 
-describe("CLI reference", () => {
-  test("serving-endpoints subcommands match what we document", () => {
-    const output = execSync("databricks serving-endpoints --help", {
-      encoding: "utf-8",
-    });
-    const expectedCommands = [
-      "list",
-      "get",
-      "query",
-      "create",
-      "delete",
-      "update-config",
-    ];
-    for (const cmd of expectedCommands) {
-      expect(output).toContain(cmd);
-    }
-  });
-
-  test("serving-endpoints create takes NAME and --json", () => {
-    const output = execSync("databricks serving-endpoints create --help", {
-      encoding: "utf-8",
-    });
-    expect(output).toContain("NAME");
-    expect(output).toContain("--json");
-  });
-
-  test("serving-endpoints query takes NAME and --json", () => {
-    const output = execSync("databricks serving-endpoints query --help", {
-      encoding: "utf-8",
-    });
-    expect(output).toContain("NAME");
-    expect(output).toContain("--json");
-  });
-
-  test("experiments subcommands match what we document", () => {
-    const output = execSync("databricks experiments --help", {
-      encoding: "utf-8",
-    });
-    const expectedCommands = [
-      "create-experiment",
-      "get-experiment",
-      "delete-experiment",
-      "list-experiments",
-    ];
-    for (const cmd of expectedCommands) {
-      expect(output).toContain(cmd);
-    }
-  });
-
-  test("experiments create-experiment takes NAME as positional arg", () => {
-    const output = execSync("databricks experiments create-experiment --help", {
-      encoding: "utf-8",
-    });
-    expect(output).toContain("NAME");
-  });
-
-  test("bundle subcommands match what we document", () => {
-    const output = execSync("databricks bundle --help", {
-      encoding: "utf-8",
-    });
-    const expectedCommands = ["validate", "deploy", "run", "destroy"];
-    for (const cmd of expectedCommands) {
-      expect(output).toContain(cmd);
-    }
-  });
-
+describe("CLI integration checks", () => {
   test("bundle deployment bind subcommand exists", () => {
     const output = execSync("databricks bundle deployment bind --help", {
       encoding: "utf-8",
@@ -277,16 +212,6 @@ describe("CLI reference", () => {
     expect(parsed.access_token).toBeTruthy();
     expect(typeof parsed.access_token).toBe("string");
     console.log("[agents] auth token length:", parsed.access_token.length);
-  });
-
-  test("apps management subcommands match what we document", () => {
-    const output = execSync("databricks apps --help", {
-      encoding: "utf-8",
-    });
-    const expectedCommands = ["get", "logs", "stop", "start", "delete"];
-    for (const cmd of expectedCommands) {
-      expect(output).toContain(cmd);
-    }
   });
 });
 


### PR DESCRIPTION
More commands tested, smarter parsing, self-policing coverage check, shared module. Removes shallow subcommand-existence tests. Fixes formatting in `agents/quickstart.md` discovered during update. All tests pass `DATABRICKS_PROFILE=myprofile npm run test:docs-verify`