### PR TITLE
Add embeddings-generation and lakebase-pgvector recipes

### DIFF
--- a/content/recipes/embeddings-generation.md
+++ b/content/recipes/embeddings-generation.md
@@ -1,0 +1,63 @@
+## Generate Embeddings with AI Gateway
+
+Generate text embeddings from a Databricks AI Gateway endpoint using the Databricks SDK.
+
+### 1. Find an embedding endpoint
+
+```bash
+databricks serving-endpoints list --profile <PROFILE>
+```
+
+Common embedding endpoints: `databricks-gte-large-en` (1024d), `databricks-bge-large-en` (1024d).
+
+### 2. Configure environment
+
+`.env`:
+
+```bash
+DATABRICKS_EMBEDDING_ENDPOINT=databricks-gte-large-en
+```
+
+`app.yaml`:
+
+```yaml
+env:
+  - name: DATABRICKS_EMBEDDING_ENDPOINT
+    value: "databricks-gte-large-en"
+```
+
+### 3. Embedding helper
+
+Create `server/lib/embeddings.ts`:
+
+```typescript
+import { getWorkspaceClient } from "@databricks/appkit";
+
+const workspaceClient = getWorkspaceClient({});
+
+export async function generateEmbedding(text: string): Promise<number[]> {
+  const endpoint =
+    process.env.DATABRICKS_EMBEDDING_ENDPOINT || "databricks-gte-large-en";
+  const result = await workspaceClient.servingEndpoints.query({
+    name: endpoint,
+    input: text,
+  });
+  return result.data![0].embedding!;
+}
+```
+
+No additional dependencies — uses `@databricks/appkit` already in your project.
+
+### 4. Verify
+
+```bash
+databricks serving-endpoints query <embedding-endpoint> \
+  --json '{"input": "Hello, world!"}' \
+  --profile <PROFILE>
+```
+
+Response includes a `data` array with `embedding` (float array).
+
+#### References
+
+- [Query embedding models](https://docs.databricks.com/aws/en/machine-learning/model-serving/query-embedding-models)

--- a/content/recipes/lakebase-pgvector.md
+++ b/content/recipes/lakebase-pgvector.md
@@ -1,0 +1,137 @@
+## Lakebase pgvector
+
+Enable vector similarity search in Lakebase using the pgvector extension.
+
+This recipe assumes you have already completed the [Create a Lakebase Instance](/resources/lakebase-create-instance) recipe and have a Lakebase project provisioned.
+
+### 1. Enable pgvector
+
+```bash
+databricks psql --project <project-name> --profile <PROFILE> -- -c "
+  CREATE EXTENSION IF NOT EXISTS vector;
+"
+```
+
+### 2. Create embedding table
+
+```sql
+CREATE SCHEMA IF NOT EXISTS vectors;
+
+CREATE TABLE IF NOT EXISTS vectors.documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  content TEXT NOT NULL,
+  embedding VECTOR(1024),
+  metadata JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+> **Vector dimensions**: `VECTOR(1024)` must match your embedding model's output dimension. `databricks-gte-large-en` and `databricks-bge-large-en` both produce 1024 dimensions. If you use a different model (for example, a 768- or 1536-dimension model), change `VECTOR(1024)` to match.
+
+### 3. Server-side vector store module
+
+Create `server/lib/vector-store.ts` with table setup, insert, and similarity search. Call `setupVectorTables(appkit)` from `server.ts` before starting the server.
+
+`server/lib/vector-store.ts`:
+
+```typescript
+import type { Application } from "express";
+
+interface AppKitWithLakebase {
+  lakebase: {
+    query(
+      text: string,
+      params?: unknown[],
+    ): Promise<{ rows: Record<string, unknown>[] }>;
+  };
+  server: {
+    extend(fn: (app: Application) => void): void;
+  };
+}
+
+export async function setupVectorTables(appkit: AppKitWithLakebase) {
+  try {
+    await appkit.lakebase.query("CREATE EXTENSION IF NOT EXISTS vector");
+  } catch (err: unknown) {
+    const code = (err as { code?: string }).code;
+    if (code === "42501") {
+      console.log(
+        "[vectors] Skipping extension creation — insufficient privileges (likely already exists)",
+      );
+    } else {
+      throw err;
+    }
+  }
+  const { rows } = await appkit.lakebase.query(
+    `SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'vectors' AND table_name = 'documents'`,
+  );
+  if (rows.length > 0) return;
+  await appkit.lakebase.query(`CREATE SCHEMA IF NOT EXISTS vectors`);
+  await appkit.lakebase.query(`
+    CREATE TABLE IF NOT EXISTS vectors.documents (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      content TEXT NOT NULL,
+      embedding VECTOR(1024),
+      metadata JSONB NOT NULL DEFAULT '{}',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+export async function insertDocument(
+  appkit: AppKitWithLakebase,
+  input: {
+    content: string;
+    embedding: number[];
+    metadata?: Record<string, unknown>;
+  },
+) {
+  const result = await appkit.lakebase.query(
+    `INSERT INTO vectors.documents (content, embedding, metadata)
+     VALUES ($1, $2::vector, $3)
+     RETURNING id, content, metadata, created_at`,
+    [
+      input.content,
+      JSON.stringify(input.embedding),
+      JSON.stringify(input.metadata ?? {}),
+    ],
+  );
+  return result.rows[0];
+}
+
+export async function retrieveSimilar(
+  appkit: AppKitWithLakebase,
+  queryEmbedding: number[],
+  limit = 5,
+) {
+  const result = await appkit.lakebase.query(
+    `SELECT id, content, metadata, 1 - (embedding <=> $1::vector) AS similarity
+     FROM vectors.documents
+     WHERE embedding IS NOT NULL
+     ORDER BY embedding <=> $1::vector
+     LIMIT $2`,
+    [JSON.stringify(queryEmbedding), limit],
+  );
+  return result.rows;
+}
+```
+
+> **Distance operators**: `<=>` cosine (default for text), `<->` L2, `<#>` inner product.
+
+### 4. Create an index
+
+Add after inserting initial data (IVFFlat needs representative data to build):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_documents_embedding
+  ON vectors.documents USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+ANALYZE vectors.documents;
+```
+
+> For higher recall without tuning, use `USING hnsw (embedding vector_cosine_ops)` instead.
+
+#### References
+
+- [pgvector](https://github.com/pgvector/pgvector)
+- [Lakebase extensions](https://docs.databricks.com/aws/en/oltp/projects/extensions)

--- a/src/lib/recipes/recipes.ts
+++ b/src/lib/recipes/recipes.ts
@@ -70,6 +70,15 @@ export const recipes: Recipe[] = [
     prerequisites: ["databricks-local-bootstrap"],
   },
   {
+    id: "embeddings-generation",
+    name: "Generate Embeddings with AI Gateway",
+    description:
+      "Generate text embeddings from a Databricks AI Gateway endpoint using the Databricks SDK.",
+    tags: ["AI", "AI Gateway", "Embeddings"],
+    services: ["AI Gateway"],
+    prerequisites: ["databricks-local-bootstrap"],
+  },
+  {
     id: "model-serving-endpoint-creation",
     name: "Create a Databricks Model Serving endpoint",
     description:
@@ -103,6 +112,15 @@ export const recipes: Recipe[] = [
       "Add a managed Postgres database to your Databricks app using the Lakebase plugin. Covers schema setup, table creation, and full CRUD REST API routes.",
     tags: ["Lakebase", "Postgres", "CRUD", "Data"],
     services: ["Lakebase", "Databricks Apps"],
+    prerequisites: ["databricks-local-bootstrap", "lakebase-create-instance"],
+  },
+  {
+    id: "lakebase-pgvector",
+    name: "Lakebase pgvector",
+    description:
+      "Enable vector similarity search in Lakebase using the pgvector extension. Covers extension setup, vector table design, insert and cosine retrieval helpers, and IVFFlat/HNSW index options.",
+    tags: ["Lakebase", "Postgres", "pgvector", "Vector Search", "Embeddings"],
+    services: ["Lakebase"],
     prerequisites: ["databricks-local-bootstrap", "lakebase-create-instance"],
   },
   {
@@ -218,7 +236,9 @@ export const recipesInOrder: Recipe[] = [
   "databricks-local-bootstrap",
   "lakebase-create-instance",
   "lakebase-data-persistence",
+  "lakebase-pgvector",
   "foundation-models-api",
+  "embeddings-generation",
   "model-serving-endpoint-creation",
   "ai-chat-model-serving",
   "lakebase-chat-persistence",


### PR DESCRIPTION
## Summary

Adds two standalone recipes salvaged from the stalled RAG chat cookbook effort in #23. Both stand on their own merits independent of RAG.

- **`embeddings-generation`** — call a Databricks AI Gateway embedding endpoint via the Databricks SDK. Applies to RAG, semantic search, classification, clustering, and recommendations. 65 lines, no cleanup needed.
- **`lakebase-pgvector`** — enable pgvector in Lakebase and run cosine similarity search. Generalized from the RAG-flavored original in #23:
  - schema renamed `rag` → `vectors`
  - helper renamed `setupRagTables` → `setupVectorTables`
  - module path renamed `server/lib/rag-store.ts` → `server/lib/vector-store.ts`
  - step numbering bug fixed (was `### 1, 2, 3, 6` → now `### 1, 2, 3, 4`)
  - vector dimension note expanded to cover non-1024-d models
  - added a prerequisite callout linking to `lakebase-create-instance`, matching the pattern used in `lakebase-data-persistence`

## Context

This is a deliberate salvage from #23 (the WIP RAG chat cookbook branch) rather than a rebase. That branch diverged from main by 100+ commits, conflicts with cookbook renames (`*-template.tsx` → `*.tsx`) and the new Examples tier, and had already pivoted mid-flight to a marker-based cookbook format that was never pushed. Rather than fight the rebase, this PR pulls out the two pieces that are genuinely reusable and atomic — the core recipe content — and lands them against current `main`.

## Registry changes

- Added both recipes to `recipes` in `src/lib/recipes/recipes.ts`.
- Inserted into `recipesInOrder` next to thematically adjacent recipes:
  - `embeddings-generation` after `foundation-models-api` (both AI Gateway)
  - `lakebase-pgvector` after `lakebase-data-persistence` (Lakebase storage recipes grouped)
- Prerequisites:
  - `embeddings-generation`: `databricks-local-bootstrap`
  - `lakebase-pgvector`: `databricks-local-bootstrap`, `lakebase-create-instance`

## Test plan

- [x] `npm run fmt` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` generates `/resources/embeddings-generation` and `/resources/lakebase-pgvector`
- [x] `bun run test` — all 82 vitest + 102 Playwright tests pass
- [x] Visually verified the rendered recipe pages match existing recipe styling against `lakebase-data-persistence` and `foundation-models-api` as references