### PR TITLE
docs: goal-oriented restructure with newcomer entry points

### DIFF
--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -1,0 +1,34 @@
+---
+title: What is an AI agent on Databricks?
+sidebar_label: Overview
+description: Databricks agents are LLM-driven apps that plan, use tools, and return structured output. Deployed as Databricks Apps with built-in tracing and model serving.
+---
+
+# What is an AI agent on Databricks?
+
+An AI agent is an application where an LLM does the reasoning. Instead of writing all the logic yourself, you give the model a goal and a set of tools: functions it can call, APIs it can hit, databases it can query. The model decides which tools to use and in what order to accomplish the goal.
+
+On Databricks, agents are Python applications deployed as Databricks Apps. They use hosted model endpoints for LLM inference, get automatic tracing for debugging and evaluation, and share the same auth and data access as any other App.
+
+## Agent versus simple chat app
+
+Use an agent when the response requires multiple steps, tool calls, or conditional logic. For example, to answer a support question, an agent queries Unity Catalog for relevant records, calls a model endpoint for reasoning, and returns a formatted response.
+
+Use a simple LLM call when the response comes from the model's knowledge alone, with no data access or multistep logic needed.
+
+## What you get out of the box
+
+- **Any Python framework**: OpenAI Agents SDK, LangGraph, or your own. The platform requires implementing the `ResponsesAgent` interface, not a specific library.
+- **Model serving**: connect to Databricks-hosted foundation models (Llama, Claude, and others) or bring your own endpoint through AI Gateway.
+- **Automatic tracing**: MLflow traces every invocation without extra code. Evaluate quality, debug failures, and monitor production behavior.
+- **Tool use and MCP**: give your agent Python functions it can call, or connect an MCP server for workspace-level tools including Unity Catalog, Vector Search, and Genie.
+
+## How it fits together
+
+- You deploy agents as **Databricks Apps**, using the same CLI and bundle workflow. The hosting, auth, and fixed URL behavior is identical.
+- Agents access **Lakebase** for persistent memory such as chat history or user context.
+- **AI Gateway** sits in front of model serving endpoints to add rate limits, usage tracking, payload logging, and content safety filtering.
+
+## Next steps
+
+To get started, see the [Quickstart](/docs/agents/quickstart), where you clone the agent template and deploy it to your workspace.

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -57,7 +57,7 @@ uv run quickstart --skip-lakebase
 
 The quickstart script verifies your environment, configures Databricks authentication, creates an MLflow experiment for tracing, and starts the agent server with a built-in chat UI at `http://localhost:8000` (override with `--port`). If port 3000 is in use, set `CHAT_APP_PORT` in `.env` to a free port.
 
-See [Lakebase quickstart](/docs/lakebase/quickstart) for creating or finding projects when you use Lakebase-backed templates.
+For Lakebase-backed templates, see the [Lakebase quickstart](/docs/lakebase/quickstart) to create or find a project first.
 
 For subsequent runs:
 

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -1,0 +1,36 @@
+---
+title: What is Databricks Apps?
+sidebar_label: Overview
+description: Databricks Apps hosts web applications inside your workspace with built-in auth, managed compute, and direct access to your data.
+---
+
+# What is Databricks Apps?
+
+Databricks Apps is a hosting service for web applications that runs inside your Databricks workspace. You deploy with a single CLI command and the app gets a fixed URL, built-in OAuth, and a dedicated service principal. No external hosting service. No separate auth layer.
+
+Apps run as managed workspace resources. The platform handles compute, TLS, and authentication.
+
+## What problem it solves
+
+Normally, an app that reads or writes Databricks data requires a separate server, manual credential management, and cross-network configuration. Apps removes this: your app lives inside the workspace, authenticates through it, and connects to your data the same way your notebooks do.
+
+## When to use it
+
+- You're building a web app, internal tool, or API that reads or writes Databricks data.
+- You want auth handled by the platform, without building login flows, token rotation, or session management.
+- You're deploying an AI agent (agents run as Apps).
+
+## When not to use it
+
+- Your app is a static site with no Databricks data access.
+- You're serving external users who won't have workspace access.
+
+## How it fits together
+
+- **AppKit** is the TypeScript SDK built for Databricks Apps. It provides UI components, a plugin system (Lakebase, analytics, Genie, files, and more), and type-safe data access.
+- **Lakebase** is the Postgres database layer you connect to from an App for persistent OLTP storage.
+- **Agents** are LLM-driven applications deployed as Databricks Apps using the same CLI and bundle workflow.
+
+## Next steps
+
+To get started, see the [Quickstart](/docs/apps/quickstart), where you scaffold and deploy a working app to your workspace.

--- a/docs/apps/quickstart.md
+++ b/docs/apps/quickstart.md
@@ -21,10 +21,10 @@ Whether you copy a guide or scaffold manually, here's what the flow looks like:
 1. The Databricks CLI authenticates against your workspace.
 2. The project is scaffolded with the right dependencies.
 3. Databricks resources are provisioned (Lakebase databases, model serving endpoints, or Genie spaces, depending on the guide).
-4. The coding agent implements your business logic on top of the scaffold.
+4. The coding agent builds your application on top of the scaffold.
 5. `databricks bundle deploy` pushes the app to Databricks Apps.
 
-If something fails during the build, guides include troubleshooting context for each step. Coding agents can usually self-correct.
+If something fails during the build, guides include troubleshooting context for each step. Coding agents can diagnose and fix most errors from the troubleshooting context.
 
 ## Build an app from a guide
 

--- a/docs/lakebase/overview.md
+++ b/docs/lakebase/overview.md
@@ -1,0 +1,37 @@
+---
+title: What is Lakebase?
+sidebar_label: Overview
+description: Lakebase is managed Postgres inside Databricks, co-located with your Lakehouse. OLTP storage with instant branching and autoscaling.
+---
+
+# What is Lakebase?
+
+Lakebase is managed PostgreSQL that runs inside your Databricks workspace. You provision it with the CLI and connect to it like any Postgres database.
+
+Use it for the data your apps actively write and read at low latency: user state, sessions, chat history, and logs stored alongside your analytical data in the Lakehouse.
+
+## What makes it different from running your own Postgres
+
+- **Co-located with your workspace**: no VPC peering, no cross-cloud credential management, no added latency from network boundaries. Your app and your data are in the same place.
+- **Instant branching**: create isolated database copies in seconds using copy-on-write storage, similar to git branches. Branches share unchanged data, so they're cheap to create and maintain.
+- **Scales to zero**: the database pauses when idle and resumes on the next query. No cost for idle compute. Development branches suspend by default after five minutes.
+
+## When to use it
+
+- Your app writes user state, sessions, logs, or any data that needs low-latency reads and writes.
+- You want isolated database branches for feature development or CI testing.
+- You're syncing data between OLTP and your Lakehouse (Lakebase supports change data capture to Unity Catalog).
+
+## When not to use it
+
+- Pure analytics: read-only queries against large datasets belong in Unity Catalog, not Lakebase.
+- Apps hosted entirely outside Databricks with no other workspace usage, where the colocation benefit doesn't apply.
+
+## How it fits together
+
+- Access Lakebase from a Databricks App through the **AppKit Lakebase plugin**, which handles connection strings, credentials, and branch routing automatically.
+- Lakebase tables sync to **Unity Catalog** for analytical workloads via change data feed.
+
+## Next steps
+
+To get started, see the [Quickstart](/docs/lakebase/quickstart), where you provision a Lakebase project and connect it to an app.

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -1,0 +1,48 @@
+---
+title: Platform overview
+description: How Databricks Apps, AppKit, Lakebase, and Agents fit together. Architecture reference for the Databricks developer stack.
+---
+
+# Platform overview
+
+DevHub is a catalog of guides and examples for the Databricks developer stack. Pick a guide, copy it into your coding agent, and it handles scaffolding, auth, database, and deployment.
+
+## How the platform fits together
+
+Apps, AppKit, Lakebase, and Agents are four layers that make up a full-stack Databricks application. Unity Catalog and AI Gateway are workspace services they connect to.
+
+<img src="/img/docs/platform-overview.svg" alt="Architecture diagram showing Apps containing AppKit, Lakebase, and Agents, with Unity Catalog and AI Gateway as workspace services" width="100%" />
+
+| Layer        | What it is                                                                                                                                                                          |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Apps**     | The hosting layer. Your Node.js or Python app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.      |
+| **AppKit**   | The TypeScript SDK. Provides auth, UI components, and a plugin system (server, lakebase, analytics, genie, files, caching, and more) with support for custom plugins.               |
+| **Lakebase** | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments. |
+| **Agents**   | The LLM orchestration layer. Deployed as Apps using any framework that implements the ResponsesAgent interface. Supports tool use, MCP servers, and built-in tracing.               |
+
+**[Unity Catalog](https://docs.databricks.com/aws/en/data-governance/)** and **[AI Gateway](/docs/agents/ai-gateway)** are workspace-level services your app connects to for data governance and model serving.
+
+## Pick a guide or example
+
+Guides are step-by-step instructions for your coding agent. Examples are working apps built on top of guides, with source code. Here are a few common starting points. The [resources catalog](/resources) has the full list.
+
+All guides assume the [Databricks CLI](/docs/tools/databricks-cli) is installed and [authenticated](/docs/tools/databricks-cli#authenticate) against your workspace.
+
+| Resource                                                      | Type    | Best for                                        |
+| ------------------------------------------------------------- | ------- | ----------------------------------------------- |
+| [Hello World App](/resources/hello-world-app)                 | Guide   | Simple apps, static pages, getting started      |
+| [AI Chat App](/resources/ai-chat-app)                         | Guide   | Conversational AI, chatbots, assistants         |
+| [App with Lakebase](/resources/app-with-lakebase)             | Guide   | CRUD apps with persistent storage               |
+| [Agentic Support Console](/resources/agentic-support-console) | Example | Full AI support console with Lakebase and Genie |
+
+More guides and examples are in the [resources catalog](/resources).
+
+## Companion docs
+
+These docs explain the platform layers that guides build on:
+
+- **[Web apps (Databricks Apps)](/docs/apps/quickstart)**: Scaffold and deploy a working app built with AppKit (TypeScript) or Python.
+- **[Postgres database (Lakebase)](/docs/lakebase/quickstart)**: Provision a Lakebase project and connect it to an app.
+- **[AI agents](/docs/agents/quickstart)**: Clone the agent template and deploy it to your workspace.
+- **[Set up your environment](/docs/tools/databricks-cli)**: Databricks CLI, agent skills, and MCP server.
+- **[AppKit Reference](/docs/appkit/v0)**: Component library, plugin API, and TypeScript SDK reference.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,48 +1,33 @@
 ---
 title: Start here
-description: DevHub is a catalog of guides and examples for the Databricks developer stack. Pick a guide, copy it into your coding agent, and start building.
+description: DevHub is the developer platform for Databricks. Build web apps, AI agents, and data-backed applications deployed and hosted inside your Databricks workspace.
 ---
 
 # Start here
 
-DevHub is a catalog of guides and examples for the Databricks developer stack. Pick a guide, copy it into your coding agent, and you get a working app deployed to Databricks with auth, database, and deployment handled.
+Databricks is a data and AI platform. It manages data pipelines, stores and governs data at scale, runs ML workloads, and serves AI models. DevHub is the developer-facing layer: guides, SDKs, and tools for building applications on top of that platform.
+
+## What you can build
+
+- **A web app**: your app runs inside your workspace with built-in auth and direct data access. Build it with AppKit, a TypeScript SDK with UI components and a plugin system, or use Python.
+- **A Postgres database**: provision Lakebase, managed Postgres that runs inside your workspace, with instant branching and scale-to-zero for development and production.
+- **An AI agent**: give an LLM a goal and a set of tools: functions it can call, APIs it can hit, data it can query. Deploy it to your workspace with hosted model endpoints and built-in tracing.
+
+## Guides and examples
+
+DevHub has two types of resources in the [resources catalog](/resources):
+
+- **Guides**: step-by-step build instructions. Copy one into your coding agent and it handles scaffolding, configuration, and deployment.
+- **Examples**: working apps with source code you can clone and customize.
+
+These docs explain the platform in detail when you or your agent needs more context.
+
+## Where to start
+
+1. **Set up your environment**: install the Databricks CLI and authenticate against your workspace. The [Databricks CLI](/docs/tools/databricks-cli) page walks you through both.
+2. **Pick a product**: read the overview for context or go straight to the quickstart. Choose from [Web app](/docs/apps/overview), [Database](/docs/lakebase/overview), or [AI agent](/docs/agents/overview).
+3. **Start building**: copy a guide into your coding agent to scaffold and deploy, or clone an example and customize it. Browse the [resources catalog](/resources).
 
 ## How the platform fits together
 
-<img src="/img/docs/platform-overview.svg" alt="Architecture diagram showing Apps containing AppKit, Lakebase, and Agents, with Unity Catalog and AI Gateway as workspace services" width="100%" />
-
-| Layer        | What it is                                                                                                                                                                          |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Apps**     | The hosting layer. Your Node.js or Python app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.      |
-| **AppKit**   | The TypeScript SDK. Provides auth, UI components, and a plugin system (server, lakebase, analytics, genie, files, caching, and more) with support for custom plugins.               |
-| **Lakebase** | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments. |
-| **Agents**   | The LLM orchestration layer. Deployed as Apps using any framework that implements the ResponsesAgent interface. Supports tool use, MCP servers, and built-in tracing.               |
-
-**[Unity Catalog](https://docs.databricks.com/aws/en/data-governance/)** and **[AI Gateway](/docs/agents/ai-gateway)** are workspace-level services your app connects to for data governance and model serving.
-
-## Pick a guide or example
-
-Guides are step-by-step instructions for your coding agent. Examples are working apps built on top of guides, with source code. A few common starting points are below. Browse the full [resources catalog](/resources) for more.
-
-All guides assume the [Databricks CLI](/docs/tools/databricks-cli) is installed and [authenticated](/docs/tools/databricks-cli#authenticate) against your workspace.
-
-| Resource                                                      | Type    | Best for                                        |
-| ------------------------------------------------------------- | ------- | ----------------------------------------------- |
-| [Hello World App](/resources/hello-world-app)                 | Guide   | Simple apps, static pages, getting started      |
-| [AI Chat App](/resources/ai-chat-app)                         | Guide   | Conversational AI, chatbots, assistants         |
-| [App with Lakebase](/resources/app-with-lakebase)             | Guide   | CRUD apps with persistent storage               |
-| [Agentic Support Console](/resources/agentic-support-console) | Example | Full AI support console with Lakebase and Genie |
-
-## Create your app
-
-Copy the guide into your coding agent and describe what you want to build. The guide handles setup, auth, schemas, and deployment. Your prompt shapes the business logic. A machine-readable index of all guides is at <a href="/llms.txt">llms.txt</a>.
-
-## Companion docs
-
-These docs explain the platform layers that guides build on:
-
-- **[Apps](/docs/apps/quickstart)**: Host web applications as managed Databricks workspace resources.
-- **[Lakebase](/docs/lakebase/quickstart)**: Managed PostgreSQL for application data.
-- **[Agents](/docs/agents/quickstart)**: Build AI agents with tool orchestration, guardrails, and observability.
-- **[Tools](/docs/tools/databricks-cli)**: Databricks CLI, agent skills, and MCP server.
-- **[AppKit Reference](/docs/appkit/v0)**: Component library, plugin API, and TypeScript SDK reference.
+For the full architecture showing how Apps, AppKit, Lakebase, and Agents relate, see [Platform overview](/docs/platform-overview).

--- a/docs/tools/ai-tools/agent-skills.md
+++ b/docs/tools/ai-tools/agent-skills.md
@@ -10,11 +10,19 @@ Skills tell your coding agent how Databricks works, including CLI conventions, a
 
 ## Install
 
-```bash
+```bash title="Common"
 databricks experimental aitools install
 ```
 
-The CLI auto-detects installed coding agents (Claude Code, Cursor, Codex CLI, etc.) and symlinks skills into each agent's config directory from a shared canonical location (`~/.databricks/aitools/skills/`). By default skills install globally. Pass `--project` to scope them to the current project instead.
+```bash title="Specific agents"
+databricks experimental aitools install --agents claude-code,cursor
+```
+
+```bash title="Project scope"
+databricks experimental aitools install --project
+```
+
+The CLI auto-detects installed coding agents and symlinks skills into each agent's config directory from a shared canonical location (`~/.databricks/aitools/skills/`). Skills install globally by default.
 
 | Option           | Description                                    |
 | ---------------- | ---------------------------------------------- |
@@ -26,13 +34,13 @@ The CLI auto-detects installed coding agents (Claude Code, Cursor, Codex CLI, et
 
 ## Manage
 
-```bash
-databricks experimental aitools update
+```bash title="List, update, or remove skills"
 databricks experimental aitools list
+databricks experimental aitools update
 databricks experimental aitools uninstall
 ```
 
-`update` fetches the latest release and auto-installs new skills from the manifest. Pass `--check` for a dry run, `--no-new` to skip new skills, or `--force` to re-download even if versions match. `uninstall` removes all skills, or pass `--skills` to remove specific ones. All three commands accept `--global` (default) and `--project` to control scope.
+`update` fetches the latest release and auto-installs new skills from the manifest. Pass `--check` to preview without downloading. All commands accept `--global` (default) and `--project` to control scope.
 
 ## Other install methods
 
@@ -46,17 +54,15 @@ Cursor also supports `/add-plugin databricks-skills` in chat.
 
 ## Available skills
 
-Most skills declare `databricks-core` as a parent, so agents load it first for CLI and auth context.
+Run `databricks experimental aitools skills list` to see available skills and their install status.
 
-| Skill                      | Description                                                                                                                                                                     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `databricks-core`          | CLI operations, auth, profiles, and data exploration. Base skill for all others.                                                                                                |
-| `databricks-apps`          | Build apps on Databricks Apps using AppKit. Includes references for the AppKit SDK, SQL queries, tRPC, Lakebase, Model Serving, and testing.                                    |
-| `databricks-dabs`          | Create, configure, deploy, and manage Declarative Automation Bundles. References for bundle structure, pipelines, alerts, and permissions.                                      |
-| `databricks-jobs`          | Develop and deploy Lakeflow Jobs with notebooks, Python wheels, or SQL tasks.                                                                                                   |
-| `databricks-lakebase`      | Manage Lakebase Postgres Autoscaling projects, branches, and endpoints.                                                                                                         |
-| `databricks-model-serving` | Manage Model Serving endpoints for LLM inference, custom models, or external models. _(experimental)_                                                                           |
-| `databricks-pipelines`     | Develop Lakeflow Spark Declarative Pipelines (formerly DLT). Large reference set covering streaming tables, materialized views, Auto Loader, Auto CDC, expectations, and sinks. |
+| Skill                  | Description                                                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `databricks`           | CLI operations, auth, profiles, and data exploration. Base skill loaded by all others.                                                                                          |
+| `databricks-apps`      | Build apps on Databricks Apps using AppKit. Includes references for the AppKit SDK, SQL queries, tRPC, Lakebase, Model Serving, and testing.                                    |
+| `databricks-jobs`      | Develop and deploy Lakeflow Jobs with notebooks, Python wheels, or SQL tasks.                                                                                                   |
+| `databricks-lakebase`  | Manage Lakebase Postgres Autoscaling projects, branches, and endpoints.                                                                                                         |
+| `databricks-pipelines` | Develop Lakeflow Spark Declarative Pipelines (formerly DLT). Large reference set covering streaming tables, materialized views, Auto Loader, Auto CDC, expectations, and sinks. |
 
 ## Other skill repositories
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -172,10 +172,17 @@ const latestAppKitDocId = latestAppKitMajorChannel
 const sidebars: SidebarsConfig = {
   tutorialSidebar: [
     "start-here",
+    "platform-overview",
     {
       type: "category",
-      label: "Databricks Apps",
+      label: "Set up your environment",
+      items: ["tools/databricks-cli", "tools/ai-tools/agent-skills"],
+    },
+    {
+      type: "category",
+      label: "Web apps (Databricks Apps)",
       items: [
+        "apps/overview",
         "apps/quickstart",
         "apps/core-concepts",
         "apps/appkit",
@@ -185,8 +192,9 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
-      label: "Lakebase Postgres",
+      label: "Postgres database (Lakebase)",
       items: [
+        "lakebase/overview",
         "lakebase/quickstart",
         "lakebase/core-concepts",
         "lakebase/development",
@@ -196,20 +204,12 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "AI agents",
       items: [
+        "agents/overview",
         "agents/quickstart",
         "agents/core-concepts",
         "agents/development",
         "agents/ai-gateway",
         "agents/observability",
-      ],
-    },
-    {
-      type: "category",
-      label: "Developer tools",
-      items: [
-        "tools/databricks-cli",
-        "tools/ai-tools/agent-skills",
-        "tools/ai-tools/docs-mcp-server",
       ],
     },
     {
@@ -221,6 +221,7 @@ const sidebars: SidebarsConfig = {
           label: "Databricks CLI",
           href: "https://docs.databricks.com/aws/en/dev-tools/cli/commands",
         },
+        "tools/ai-tools/docs-mcp-server",
         {
           type: "category",
           label: "AppKit",

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -189,14 +189,24 @@ function Img({ className, ...props }: ComponentPropsWithoutRef<"img">) {
 function InlineCode({
   className,
   children,
+  title,
+  metastring,
   ...props
-}: ComponentPropsWithoutRef<"code">) {
+}: ComponentPropsWithoutRef<"code"> & { metastring?: string }) {
   const languageMatch = className?.match(/language-(\w+)/);
 
   if (languageMatch) {
     const code =
       typeof children === "string" ? children.replace(/\n$/, "") : children;
-    return <CodeBlock language={languageMatch[1]}>{code}</CodeBlock>;
+    return (
+      <CodeBlock
+        language={languageMatch[1]}
+        title={title}
+        metastring={metastring}
+      >
+        {code}
+      </CodeBlock>
+    );
   }
 
   return (

--- a/tests/e2e/copy-markdown.spec.ts
+++ b/tests/e2e/copy-markdown.spec.ts
@@ -243,7 +243,7 @@ test.describe("copy markdown exports raw markdown on docs pages", () => {
     const copied = await getCopiedText(page);
     expect(copied).toContain("# About DevHub");
     expect(copied).toContain("# Start here");
-    expect(copied).toContain("## Pick a guide");
+    expect(copied).toContain("## Guides and examples");
   });
 
   test("raw-docs static files are served", async ({ request }) => {


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                                                
## Summary

- Restructured sidebar from product-layer to goal-oriented sections (Web apps, Postgres database, AI agents)
- Added overview pages for Apps, Lakebase, and Agents as plain-language introductions before the quickstart for developers new to Databricks
- Rewrote `start-here.md` to explain Databricks and DevHub before assuming any product knowledge; separated architecture detail into `platform-overview.md`
- Fixed code block `title=` attributes not rendering: the custom `InlineCode` component was dropping `metastring`, which Docusaurus uses to pass title through its `codeCompatPlugin`
- A few other changes along the way

Note: PR does not fix pre-existing and unrelated test failures from example pages and resource filters