### PR TITLE
test: enable EXAMPLES_FEATURE in build and fix genie result count

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "npm run emit-about-devhub && tsc",
     "fmt": "npx prettier -w .",
-    "test": "npm run build && vitest run && npx playwright test",
+    "test": "EXAMPLES_FEATURE=true npm run build && vitest run && npx playwright test",
     "test:smoke": "npm run emit-about-devhub && vitest run",
     "test:e2e": "npx playwright test",
     "test:docs-verify": "vitest run --config vitest.docs-verify.config.ts",

--- a/tests/e2e/resources-filters.spec.ts
+++ b/tests/e2e/resources-filters.spec.ts
@@ -37,7 +37,10 @@ test.describe("resources page search", () => {
 
     await page.getByRole("searchbox").fill("genie");
     await expect(
-      page.getByText(`6 of ${RESOURCE_COUNT} resources`),
+      page.getByText(`7 of ${RESOURCE_COUNT} resources`),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Inventory Intelligence" }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "Agentic Support Console" }),


### PR DESCRIPTION
Examples were gated behind `EXAMPLES_FEATURE=true` but the test build never set it, so no example routes were generated and the resources page hid all example cards. This caused 19 E2E failures.

- Pass `EXAMPLES_FEATURE=true` to `npm run build` in the test script
- Update genie search count (6->7) to account for the Inventory Intelligence example

Tests now pass: `npm run fmt && npm run typecheck && npm run test`