### PR TITLE
Redesign landing page around the copy-prompt wizard flow

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -7,3 +7,8 @@ build
 test-results
 playwright-report
 screenshots
+
+# Keep Vercel on npm — bun.lock would make it try bun, which
+# hits registry-proxy issues and hangs/fails the deploy
+bun.lock
+bun.lockb

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from "react";
 import { useCallback, useRef, useState } from "react";
-import { Check, LoaderCircle } from "lucide-react";
+import { ArrowRight, Check, Clipboard, LoaderCircle } from "lucide-react";
+import Link from "@docusaurus/Link";
 import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/code/copy-button";
 import { getBootstrapPromptApiPath } from "@/lib/bootstrap-prompt";
 
 function fallbackCopyTextToClipboard(text: string): boolean {
@@ -88,50 +88,66 @@ export function HeroSection(): ReactNode {
     <section className="relative bg-db-oat-medium text-black dark:bg-black dark:text-white">
       <div className="container px-4 py-20 md:py-28">
         <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
-          <h1 className="text-5xl leading-[1.08] font-medium tracking-tight md:text-7xl">
-            Build agentic applications in minutes, not months.
-          </h1>
-          <p className="mt-6 max-w-xl text-base leading-relaxed text-black/60 dark:text-white/60">
-            Lakebase for your data. Agent Bricks for your AI. Databricks Apps
-            for your deployment. One platform, production-ready.
+          <p className="mb-5 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.14em] uppercase text-black/55 dark:text-white/55">
+            <span className="h-1.5 w-1.5 rounded-full bg-db-lava" />
+            Databricks Developer Hub
           </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-            <div className="inline-flex h-11 items-stretch overflow-hidden rounded-full border border-black/22 bg-white pl-4 font-mono text-sm text-black dark:border-white/24 dark:bg-white/6 dark:text-white">
-              <code className="m-0 flex items-center bg-transparent p-0 pr-2 text-inherit">
-                $ databricks apps init
-              </code>
-              <CopyButton
-                text="databricks apps init"
-                label="Copy command"
-                variant="segment"
-                className="!h-full !w-11 !rounded-none !rounded-r-full !border-l !border-black/16 !bg-transparent !text-black hover:!bg-black/10 hover:!text-black dark:!border-white/18 dark:!bg-transparent dark:!text-white dark:hover:!bg-white/16 dark:hover:!text-white"
-              />
-            </div>
-            <span className="text-sm text-black/35 dark:text-white/35">or</span>
+          <h1 className="text-5xl leading-[1.08] font-medium tracking-tight md:text-7xl">
+            Ship your first Databricks app in&nbsp;minutes, not months.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-relaxed text-black/60 md:text-lg dark:text-white/60">
+            Your company&apos;s data already lives in Databricks. Turn it into
+            production apps and AI agents with{" "}
+            <span className="text-black dark:text-white">Lakebase</span>,{" "}
+            <span className="text-black dark:text-white">Databricks Apps</span>,
+            and <span className="text-black dark:text-white">Agent Bricks</span>{" "}
+            — guided by a wizard prompt you paste into your coding agent.
+          </p>
+          <div className="mt-9 flex flex-col items-center gap-3">
             <Button
-              className="h-11 w-40 rounded-full px-6 font-medium"
+              className="h-12 rounded-full px-7 text-[0.95rem] font-medium shadow-[0_10px_30px_-10px_rgba(255,54,33,0.55)] transition-transform hover:-translate-y-0.5"
               onClick={handleCopyBootstrapPrompt}
               disabled={copyState === "copying"}
-              title="Copies a setup guide you can paste into Cursor, Claude Code, or Codex"
+              title="Copies a guided setup prompt you can paste into Cursor, Claude Code, or Codex"
             >
               {copyState === "copying" ? (
-                <LoaderCircle className="h-4 w-4 animate-spin" />
+                <span className="inline-flex items-center gap-2">
+                  <LoaderCircle className="h-4 w-4 animate-spin" />
+                  Copying…
+                </span>
               ) : copyState === "copied" ? (
-                <span className="inline-flex items-center gap-1.5">
+                <span className="inline-flex items-center gap-2">
                   <Check className="h-4 w-4" />
-                  Copied
+                  Copied — paste it in your coding agent
                 </span>
               ) : copyState === "error" ? (
-                "Failed to copy"
+                "Failed to copy — try again"
               ) : (
-                "Copy Prompt"
+                <span className="inline-flex items-center gap-2">
+                  <Clipboard className="h-4 w-4" />
+                  Copy wizard prompt
+                </span>
               )}
             </Button>
+            <p className="text-xs text-black/45 dark:text-white/45">
+              Works with Cursor, Claude Code, and Codex.{" "}
+              <Link
+                to="/docs/start-here"
+                className="text-black/70 underline decoration-black/20 underline-offset-2 hover:text-black hover:decoration-black/40 dark:text-white/70 dark:decoration-white/20 dark:hover:text-white dark:hover:decoration-white/40"
+              >
+                Prefer the docs?
+              </Link>
+            </p>
           </div>
-          <p className="mt-4 text-xs text-black/40 dark:text-white/40">
-            Scaffold an app with the CLI command, or copy a step-by-step guide
-            for your AI coding agent.
-          </p>
+
+          <a
+            href="#wizard-flow"
+            aria-label="See what happens after you copy the prompt"
+            className="group mt-12 inline-flex flex-col items-center gap-1 text-[11px] font-medium tracking-[0.14em] uppercase text-black/45 no-underline transition-colors hover:text-black dark:text-white/45 dark:hover:text-white"
+          >
+            <span>What happens next</span>
+            <ArrowRight className="h-4 w-4 rotate-90 animate-[bounce_1.6s_ease-in-out_infinite] transition-transform group-hover:translate-y-0.5" />
+          </a>
         </div>
       </div>
       <div className="h-3 w-full bg-db-lava" />

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -88,27 +88,20 @@ export function HeroSection(): ReactNode {
     <section className="relative bg-db-oat-medium text-black dark:bg-black dark:text-white">
       <div className="container px-4 py-20 md:py-28">
         <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
-          <p className="mb-5 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.14em] uppercase text-black/55 dark:text-white/55">
-            <span className="h-1.5 w-1.5 rounded-full bg-db-lava" />
-            Databricks Developer Hub
-          </p>
           <h1 className="text-5xl leading-[1.08] font-medium tracking-tight md:text-7xl">
             Ship your first Databricks app in&nbsp;minutes, not months.
           </h1>
           <p className="mt-6 max-w-2xl text-base leading-relaxed text-black/60 md:text-lg dark:text-white/60">
-            Your company&apos;s data already lives in Databricks. Turn it into
-            production apps and AI agents with{" "}
-            <span className="text-black dark:text-white">Lakebase</span>,{" "}
-            <span className="text-black dark:text-white">Databricks Apps</span>,
-            and <span className="text-black dark:text-white">Agent Bricks</span>{" "}
-            — guided by a wizard prompt you paste into your coding agent.
+            Your company already runs on Databricks. Build full-stack apps and
+            AI agents on top of it. Copy the prompt and your coding agent does
+            the rest.
           </p>
           <div className="mt-9 flex flex-col items-center gap-3">
             <Button
               className="h-12 rounded-full px-7 text-[0.95rem] font-medium shadow-[0_10px_30px_-10px_rgba(255,54,33,0.55)] transition-transform hover:-translate-y-0.5"
               onClick={handleCopyBootstrapPrompt}
               disabled={copyState === "copying"}
-              title="Copies a guided setup prompt you can paste into Cursor, Claude Code, or Codex"
+              title="Copies instructions you can paste into Cursor, Claude Code, Codex, or your favorite coding agent"
             >
               {copyState === "copying" ? (
                 <span className="inline-flex items-center gap-2">
@@ -118,36 +111,43 @@ export function HeroSection(): ReactNode {
               ) : copyState === "copied" ? (
                 <span className="inline-flex items-center gap-2">
                   <Check className="h-4 w-4" />
-                  Copied — paste it in your coding agent
+                  Copied — now paste into your agent
                 </span>
               ) : copyState === "error" ? (
                 "Failed to copy — try again"
               ) : (
                 <span className="inline-flex items-center gap-2">
                   <Clipboard className="h-4 w-4" />
-                  Copy wizard prompt
+                  Copy prompt for your agent
                 </span>
               )}
             </Button>
-            <p className="text-xs text-black/45 dark:text-white/45">
-              Works with Cursor, Claude Code, and Codex.{" "}
-              <Link
-                to="/docs/start-here"
-                className="text-black/70 underline decoration-black/20 underline-offset-2 hover:text-black hover:decoration-black/40 dark:text-white/70 dark:decoration-white/20 dark:hover:text-white dark:hover:decoration-white/40"
-              >
-                Prefer the docs?
-              </Link>
+            <p className="text-sm text-black/45 dark:text-white/45">
+              Open your agent in any folder and paste.
+              <br />
+              Works with Cursor, Claude Code, Codex, or your favorite coding
+              agent.
             </p>
+            <button
+              type="button"
+              onClick={() => {
+                document
+                  .getElementById("wizard-flow")
+                  ?.scrollIntoView({ behavior: "smooth" });
+              }}
+              className="group inline-flex cursor-pointer items-center gap-2 rounded-full border border-black/15 bg-white/70 px-5 py-2 text-sm font-medium text-black/80 backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:border-black/25 hover:text-black dark:border-white/15 dark:bg-white/8 dark:text-white/80 dark:hover:border-white/25 dark:hover:text-white"
+            >
+              How it works
+              <ArrowRight className="h-4 w-4 rotate-90 transition-transform group-hover:translate-y-0.5" />
+            </button>
           </div>
 
-          <a
-            href="#wizard-flow"
-            aria-label="See what happens after you copy the prompt"
-            className="group mt-12 inline-flex flex-col items-center gap-1 text-[11px] font-medium tracking-[0.14em] uppercase text-black/45 no-underline transition-colors hover:text-black dark:text-white/45 dark:hover:text-white"
+          <Link
+            to="/docs/start-here"
+            className="mt-8 text-sm text-black/40 underline decoration-black/15 underline-offset-2 hover:text-black/60 hover:decoration-black/30 dark:text-white/40 dark:decoration-white/15 dark:hover:text-white/60 dark:hover:decoration-white/30"
           >
-            <span>What happens next</span>
-            <ArrowRight className="h-4 w-4 rotate-90 animate-[bounce_1.6s_ease-in-out_infinite] transition-transform group-hover:translate-y-0.5" />
-          </a>
+            Read the docs
+          </Link>
         </div>
       </div>
       <div className="h-3 w-full bg-db-lava" />

--- a/src/components/home/pillar-strip.tsx
+++ b/src/components/home/pillar-strip.tsx
@@ -327,8 +327,30 @@ function PillarRow({
 
 export function PillarStrip(): ReactNode {
   return (
-    <section className="bg-db-oat-medium py-16 dark:bg-black md:py-24">
+    <section className="bg-db-oat-medium py-20 dark:bg-black md:py-28">
       <div className="container px-4">
+        <div className="mx-auto mb-14 max-w-3xl text-center md:mb-20">
+          <p className="mb-4 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.14em] uppercase text-black/55 dark:text-white/55">
+            <span className="h-1.5 w-1.5 rounded-full bg-db-lava" />
+            The building blocks
+          </p>
+          <h2 className="text-3xl leading-[1.1] font-medium tracking-tight text-black md:text-5xl dark:text-white">
+            The wizard wires these up{" "}
+            <span className="text-db-lava">for you</span>.
+          </h2>
+          <p className="mt-5 text-base leading-relaxed text-black/60 md:text-lg dark:text-white/60">
+            Three first-class primitives for operationalizing data on
+            Databricks. Same workspace, same identity, same governance —
+            composed by{" "}
+            <Link
+              to="/docs/apps/appkit"
+              className="font-medium text-black no-underline underline-offset-2 hover:underline dark:text-white"
+            >
+              AppKit
+            </Link>
+            , our open-source TypeScript SDK.
+          </p>
+        </div>
         <div className="mx-auto flex max-w-5xl flex-col gap-16 md:gap-24">
           {pillars.map((pillar, index) => (
             <PillarRow key={pillar.title} pillar={pillar} index={index} />

--- a/src/components/home/template-preview.tsx
+++ b/src/components/home/template-preview.tsx
@@ -104,12 +104,14 @@ export function TemplatePreview(): ReactNode {
         <div className="mx-auto mb-8 max-w-6xl">
           <p className="mb-3 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.12em] text-black/50 uppercase dark:text-white/50">
             <span className="text-db-lava">&#9679;</span>
-            {includeExamples ? "Guides and Examples" : "Guides"}
+            More copy-pasteable prompts
           </p>
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-            <h2 className="max-w-xl text-3xl leading-tight font-medium tracking-tight text-black dark:text-white md:text-4xl">
-              Start with a guide or example to{" "}
-              <span className="text-db-lava">build agentic applications</span>.
+            <h2 className="max-w-2xl text-3xl leading-tight font-medium tracking-tight text-black dark:text-white md:text-4xl">
+              Get inspired by what&apos;s possible.{" "}
+              <span className="text-db-lava">
+                Every guide is a prompt you can paste.
+              </span>
             </h2>
             <Link
               to="/resources"
@@ -118,6 +120,17 @@ export function TemplatePreview(): ReactNode {
               See all resources &rarr;
             </Link>
           </div>
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-black/55 dark:text-white/55">
+            Beyond the wizard prompt, each guide and example on{" "}
+            <Link
+              to="/resources"
+              className="text-black/80 no-underline underline-offset-2 hover:underline dark:text-white/80"
+            >
+              /resources
+            </Link>{" "}
+            is a focused, copy-pasteable prompt for a specific pattern —
+            authentication, RAG, streaming, deployments, and more.
+          </p>
         </div>
 
         <div className="mx-auto max-w-6xl">

--- a/src/components/home/template-preview.tsx
+++ b/src/components/home/template-preview.tsx
@@ -121,7 +121,7 @@ export function TemplatePreview(): ReactNode {
             </Link>
           </div>
           <p className="mt-4 max-w-2xl text-sm leading-relaxed text-black/55 dark:text-white/55">
-            Beyond the wizard prompt, each guide and example on{" "}
+            Beyond the prompt, each guide and example on{" "}
             <Link
               to="/resources"
               className="text-black/80 no-underline underline-offset-2 hover:underline dark:text-white/80"

--- a/src/components/home/wizard-flow.tsx
+++ b/src/components/home/wizard-flow.tsx
@@ -1,12 +1,17 @@
 import Link from "@docusaurus/Link";
 import type { ReactNode } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
+  Check,
   Clipboard,
+  LoaderCircle,
   MessagesSquare,
   Rocket,
   Sparkles,
   type LucideIcon,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getBootstrapPromptApiPath } from "@/lib/bootstrap-prompt";
 
 type WizardStep = {
   number: string;
@@ -15,6 +20,7 @@ type WizardStep = {
   description: string;
   icon: LucideIcon;
   visual: ReactNode;
+  action?: ReactNode;
 };
 
 function ClipboardVisual(): ReactNode {
@@ -25,51 +31,75 @@ function ClipboardVisual(): ReactNode {
       preserveAspectRatio="xMidYMid meet"
       aria-hidden
     >
-      <rect
-        x="48"
-        y="36"
-        width="304"
-        height="188"
-        rx="14"
-        className="text-black/8 dark:text-white/8"
-        fill="currentColor"
-      />
-      <rect
-        x="48"
-        y="36"
-        width="304"
-        height="188"
-        rx="14"
-        className="text-black/18 dark:text-white/18"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-      />
-      <g className="text-black/30 dark:text-white/35" fill="currentColor">
-        <rect x="70" y="60" width="120" height="10" rx="3" opacity="0.85" />
-        <rect x="70" y="82" width="220" height="7" rx="3" opacity="0.4" />
-        <rect x="70" y="96" width="190" height="7" rx="3" opacity="0.35" />
-        <rect x="70" y="110" width="240" height="7" rx="3" opacity="0.35" />
-        <rect x="70" y="124" width="180" height="7" rx="3" opacity="0.3" />
-        <rect x="70" y="146" width="140" height="7" rx="3" opacity="0.3" />
-        <rect x="70" y="160" width="210" height="7" rx="3" opacity="0.25" />
-      </g>
-      <g transform="translate(260 156)">
-        <rect x="0" y="0" width="64" height="44" rx="10" fill="#ff3621" />
-        <g transform="translate(18 10)" fill="#ffffff">
-          <rect x="2" y="0" width="16" height="4" rx="1.5" opacity="0.9" />
+      {/* Red pill button centered */}
+      <g transform="translate(200 110)">
+        {/* Button shadow */}
+        <rect
+          x="-110"
+          y="2"
+          width="220"
+          height="48"
+          rx="24"
+          fill="#ff3621"
+          opacity="0.25"
+        />
+        {/* Button background */}
+        <rect x="-110" y="-20" width="220" height="48" rx="24" fill="#ff3621" />
+        {/* Clipboard icon inside button */}
+        <g
+          transform="translate(-84 -10)"
+          fill="none"
+          stroke="#ffffff"
+          strokeWidth="1.8"
+        >
           <rect
-            x="0"
-            y="4"
-            width="20"
-            height="22"
-            rx="3"
-            fill="none"
-            stroke="#ffffff"
-            strokeWidth="2"
+            x="2"
+            y="0"
+            width="12"
+            height="3"
+            rx="1.5"
+            fill="#ffffff"
+            opacity="0.9"
           />
+          <rect x="0" y="3" width="16" height="18" rx="2.5" />
+        </g>
+        {/* Button text placeholder lines */}
+        <g fill="#ffffff">
+          <rect x="-58" y="-8" width="148" height="8" rx="4" opacity="0.95" />
+          <rect x="-36" y="6" width="104" height="6" rx="3" opacity="0.5" />
         </g>
       </g>
+
+      {/* Mouse cursor clicking the button */}
+      <g transform="translate(268 138)">
+        <path
+          d="M0 0 L0 20 L5.5 15.5 L9.5 24 L13 22.5 L9 14 L15.5 13.5 Z"
+          fill="white"
+          stroke="black"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+      </g>
+
+      {/* Click ripple rings */}
+      <circle
+        cx="268"
+        cy="138"
+        r="8"
+        fill="none"
+        stroke="#ff3621"
+        strokeWidth="1.5"
+        opacity="0.4"
+      />
+      <circle
+        cx="268"
+        cy="138"
+        r="16"
+        fill="none"
+        stroke="#ff3621"
+        strokeWidth="1"
+        opacity="0.2"
+      />
     </svg>
   );
 }
@@ -82,72 +112,160 @@ function ChatVisual(): ReactNode {
       preserveAspectRatio="xMidYMid meet"
       aria-hidden
     >
-      <g transform="translate(30 40)">
-        <path
-          d="M8 0 H240 a16 16 0 0 1 16 16 V64 a16 16 0 0 1 -16 16 H40 L24 94 V80 H8 a8 8 0 0 1 -8 -8 V8 a8 8 0 0 1 8 -8 Z"
-          className="text-black/6 dark:text-white/8"
+      {/* Terminal window background */}
+      <rect
+        x="30"
+        y="20"
+        width="340"
+        height="220"
+        rx="12"
+        className="text-black/[0.03] dark:text-white/[0.03]"
+        fill="currentColor"
+      />
+      <rect
+        x="30"
+        y="20"
+        width="340"
+        height="220"
+        rx="12"
+        className="text-black/15 dark:text-white/15"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+      />
+
+      {/* Title bar dots */}
+      <circle
+        cx="50"
+        cy="36"
+        r="4"
+        className="text-black/15 dark:text-white/15"
+        fill="currentColor"
+      />
+      <circle
+        cx="64"
+        cy="36"
+        r="4"
+        className="text-black/15 dark:text-white/15"
+        fill="currentColor"
+      />
+      <circle
+        cx="78"
+        cy="36"
+        r="4"
+        className="text-black/15 dark:text-white/15"
+        fill="currentColor"
+      />
+
+      {/* Terminal title */}
+      <text
+        x="200"
+        y="39"
+        textAnchor="middle"
+        className="text-black/30 dark:text-white/30"
+        fill="currentColor"
+        fontSize="8"
+        fontFamily="monospace"
+      >
+        Terminal
+      </text>
+
+      {/* Line 1: cd ~/projects */}
+      <g transform="translate(50 70)">
+        <text
+          className="text-black/40 dark:text-white/45"
           fill="currentColor"
-        />
-        <path
-          d="M8 0 H240 a16 16 0 0 1 16 16 V64 a16 16 0 0 1 -16 16 H40 L24 94 V80 H8 a8 8 0 0 1 -8 -8 V8 a8 8 0 0 1 8 -8 Z"
-          className="text-black/18 dark:text-white/20"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.25"
-        />
-        <g className="text-black/40 dark:text-white/55" fill="currentColor">
-          <rect x="20" y="18" width="180" height="8" rx="3" opacity="0.75" />
-          <rect x="20" y="34" width="140" height="7" rx="3" opacity="0.45" />
-          <rect x="20" y="48" width="160" height="7" rx="3" opacity="0.4" />
-        </g>
+          fontSize="10"
+          fontFamily="monospace"
+        >
+          <tspan fill="#ff3621" opacity="0.7">
+            $
+          </tspan>
+          <tspan dx="6">cd ~/projects</tspan>
+        </text>
       </g>
 
-      <g transform="translate(120 150)">
-        <path
-          d="M32 0 H244 a8 8 0 0 1 8 8 V72 a8 8 0 0 1 -8 8 H52 L32 96 V80 a8 8 0 0 1 -8 -8 V8 a8 8 0 0 1 8 -8 Z"
-          fill="#ff3621"
-        />
-        <g fill="#ffffff">
-          <circle cx="46" cy="24" r="3" />
-          <rect
-            x="56"
-            y="20"
-            width="12"
-            height="8"
-            rx="2"
-            fill="none"
-            stroke="#ffffff"
-            strokeWidth="1.5"
-          />
-          <rect x="76" y="22" width="120" height="6" rx="2" opacity="0.95" />
-          <circle cx="46" cy="42" r="3" opacity="0.85" />
-          <rect
-            x="56"
-            y="38"
-            width="12"
-            height="8"
-            rx="2"
-            fill="none"
-            stroke="#ffffff"
-            strokeWidth="1.5"
-            opacity="0.85"
-          />
-          <rect x="76" y="40" width="100" height="6" rx="2" opacity="0.75" />
-          <circle cx="46" cy="60" r="3" opacity="0.75" />
-          <rect
-            x="56"
-            y="56"
-            width="12"
-            height="8"
-            rx="2"
-            fill="none"
-            stroke="#ffffff"
-            strokeWidth="1.5"
-            opacity="0.75"
-          />
-          <rect x="76" y="58" width="84" height="6" rx="2" opacity="0.65" />
-        </g>
+      {/* Line 2: cursor (or code .) to open agent */}
+      <g transform="translate(50 96)">
+        <text
+          className="text-black/40 dark:text-white/45"
+          fill="currentColor"
+          fontSize="10"
+          fontFamily="monospace"
+        >
+          <tspan fill="#ff3621" opacity="0.7">
+            $
+          </tspan>
+          <tspan dx="6">cursor .</tspan>
+        </text>
       </g>
+
+      {/* Divider line */}
+      <line
+        x1="50"
+        y1="116"
+        x2="350"
+        y2="116"
+        className="text-black/8 dark:text-white/8"
+        stroke="currentColor"
+        strokeWidth="1"
+      />
+
+      {/* Agent chat area label */}
+      <text
+        x="50"
+        y="138"
+        className="text-black/25 dark:text-white/25"
+        fill="currentColor"
+        fontSize="8"
+        fontFamily="sans-serif"
+        letterSpacing="0.5"
+      >
+        AGENT CHAT
+      </text>
+
+      {/* Ghost text: paste the prompt */}
+      <rect
+        x="50"
+        y="150"
+        width="300"
+        height="60"
+        rx="8"
+        className="text-black/[0.04] dark:text-white/[0.04]"
+        fill="currentColor"
+      />
+      <rect
+        x="50"
+        y="150"
+        width="300"
+        height="60"
+        rx="8"
+        className="text-black/10 dark:text-white/10"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeDasharray="4 3"
+      />
+      <text
+        x="200"
+        y="177"
+        textAnchor="middle"
+        className="text-black/25 dark:text-white/25"
+        fill="currentColor"
+        fontSize="10"
+        fontFamily="monospace"
+      >
+        Paste the copied prompt here...
+      </text>
+      <rect
+        x="298"
+        y="166"
+        width="8"
+        height="14"
+        rx="1.5"
+        fill="#ff3621"
+        opacity="0.5"
+      />
     </svg>
   );
 }
@@ -452,31 +570,97 @@ function ShipVisual(): ReactNode {
   );
 }
 
+function CopyPromptButton(): ReactNode {
+  const [copyState, setCopyState] = useState<
+    "idle" | "copying" | "copied" | "error"
+  >("idle");
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleCopy = useCallback(async () => {
+    setCopyState("copying");
+    try {
+      const response = await fetch(getBootstrapPromptApiPath());
+      if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+      const text = await response.text();
+      if (!text.trim()) throw new Error("Empty prompt");
+
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.setAttribute("readonly", "");
+        textArea.style.position = "fixed";
+        textArea.style.top = "-9999px";
+        document.body.append(textArea);
+        textArea.select();
+        document.execCommand("copy");
+        textArea.remove();
+      }
+
+      setCopyState("copied");
+    } catch {
+      setCopyState("error");
+    } finally {
+      clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 2500);
+    }
+  }, []);
+
+  return (
+    <Button
+      className="mt-5 h-10 rounded-full px-5 text-sm font-medium shadow-[0_8px_24px_-8px_rgba(255,54,33,0.5)] transition-transform hover:-translate-y-0.5"
+      onClick={handleCopy}
+      disabled={copyState === "copying"}
+    >
+      {copyState === "copying" ? (
+        <span className="inline-flex items-center gap-2">
+          <LoaderCircle className="h-4 w-4 animate-spin" />
+          Copying…
+        </span>
+      ) : copyState === "copied" ? (
+        <span className="inline-flex items-center gap-2">
+          <Check className="h-4 w-4" />
+          Copied — now paste into your agent
+        </span>
+      ) : copyState === "error" ? (
+        "Failed to copy — try again"
+      ) : (
+        <span className="inline-flex items-center gap-2">
+          <Clipboard className="h-4 w-4" />
+          Copy prompt for your agent
+        </span>
+      )}
+    </Button>
+  );
+}
+
 const steps: WizardStep[] = [
   {
     number: "01",
     eyebrow: "Copy",
-    title: "Copy the wizard prompt",
+    title: "Copy the prompt",
     description:
-      "One click copies a guided setup prompt — the full recipe your coding agent needs to build and deploy on Databricks.",
+      "One click copies everything your coding agent needs to build and deploy on Databricks.",
     icon: Clipboard,
     visual: <ClipboardVisual />,
+    action: <CopyPromptButton />,
   },
   {
     number: "02",
     eyebrow: "Paste",
     title: "Paste it into your coding agent",
     description:
-      "Works with Cursor, Claude Code, or Codex. Your agent reads the prompt and starts a conversation: what do you want to build, which data, which workspace?",
+      "Navigate to your projects folder (e.g. ~/projects), open your coding agent, and paste the prompt. It creates a new directory for your app and sets everything up inside it.",
     icon: MessagesSquare,
     visual: <ChatVisual />,
   },
   {
     number: "03",
     eyebrow: "Build",
-    title: "It scaffolds, wires, and iterates",
+    title: "Your agent scaffolds, wires, and iterates",
     description:
-      "The wizard uses AppKit to scaffold the app, provisions Lakebase for data, wires Agent Bricks for AI, and iterates on the UI until it feels right — all guided by your answers.",
+      "Your agent scaffolds the app, provisions whatever it needs, and iterates on the UI — all guided by your answers.",
     icon: Sparkles,
     visual: <BuildVisual />,
   },
@@ -485,7 +669,7 @@ const steps: WizardStep[] = [
     eyebrow: "Ship",
     title: "Deploy to your workspace",
     description:
-      "One command ships it to Databricks Apps. Unity Catalog governs the data, OAuth is built in, and you get a live URL under your workspace.",
+      "Once you're ready, just tell your agent to deploy — it ships your app to Databricks Apps. You get a live URL under your workspace, with data governance and authentication built in.",
     icon: Rocket,
     visual: <ShipVisual />,
   },
@@ -522,7 +706,8 @@ function StepRow({
         <p className="mt-3 max-w-lg text-[0.95rem] leading-relaxed text-black/60 dark:text-white/60">
           {step.description}
         </p>
-        <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/70 px-3 py-1.5 text-[11px] font-medium text-black/70 backdrop-blur-sm dark:border-white/12 dark:bg-white/6 dark:text-white/70">
+        {step.action}
+        <div className="mt-5 flex w-fit items-center gap-2 rounded-full border border-black/10 bg-white/70 px-3 py-1.5 text-[11px] font-medium text-black/70 backdrop-blur-sm dark:border-white/12 dark:bg-white/6 dark:text-white/70">
           <Icon className="h-3.5 w-3.5 text-db-lava" />
           Step {step.number}
         </div>
@@ -547,16 +732,16 @@ export function WizardFlow(): ReactNode {
         <div className="mx-auto mb-14 max-w-3xl text-center md:mb-20">
           <p className="mb-4 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.14em] uppercase text-black/55 dark:text-white/55">
             <span className="h-1.5 w-1.5 rounded-full bg-db-lava" />
-            How the wizard prompt works
+            How the prompt works
           </p>
           <h2 className="text-3xl leading-[1.1] font-medium tracking-tight text-black md:text-5xl dark:text-white">
             Copy. Paste. Build.{" "}
             <span className="text-db-lava">Ship to Databricks.</span>
           </h2>
           <p className="mt-5 text-base leading-relaxed text-black/60 md:text-lg dark:text-white/60">
-            The wizard prompt guides you and your coding agent from an empty
-            folder to a deployed Databricks app — with your data, your
-            workspace, and your agent logic wired together in one conversation.
+            Four steps from an empty folder to a live Databricks app.
+            Here&apos;s what the prompt does when you paste it into your coding
+            agent.
           </p>
         </div>
 
@@ -578,8 +763,8 @@ export function WizardFlow(): ReactNode {
             >
               /resources
             </Link>{" "}
-            is a copy-pasteable prompt. Get inspired by what&apos;s already
-            possible, then hand it to your agent.
+            is a ready-to-paste prompt. Browse what&apos;s already possible,
+            then paste one into your agent to get started.
           </p>
         </div>
       </div>

--- a/src/components/home/wizard-flow.tsx
+++ b/src/components/home/wizard-flow.tsx
@@ -1,0 +1,588 @@
+import Link from "@docusaurus/Link";
+import type { ReactNode } from "react";
+import {
+  Clipboard,
+  MessagesSquare,
+  Rocket,
+  Sparkles,
+  type LucideIcon,
+} from "lucide-react";
+
+type WizardStep = {
+  number: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  visual: ReactNode;
+};
+
+function ClipboardVisual(): ReactNode {
+  return (
+    <svg
+      viewBox="0 0 400 260"
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden
+    >
+      <rect
+        x="48"
+        y="36"
+        width="304"
+        height="188"
+        rx="14"
+        className="text-black/8 dark:text-white/8"
+        fill="currentColor"
+      />
+      <rect
+        x="48"
+        y="36"
+        width="304"
+        height="188"
+        rx="14"
+        className="text-black/18 dark:text-white/18"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+      <g className="text-black/30 dark:text-white/35" fill="currentColor">
+        <rect x="70" y="60" width="120" height="10" rx="3" opacity="0.85" />
+        <rect x="70" y="82" width="220" height="7" rx="3" opacity="0.4" />
+        <rect x="70" y="96" width="190" height="7" rx="3" opacity="0.35" />
+        <rect x="70" y="110" width="240" height="7" rx="3" opacity="0.35" />
+        <rect x="70" y="124" width="180" height="7" rx="3" opacity="0.3" />
+        <rect x="70" y="146" width="140" height="7" rx="3" opacity="0.3" />
+        <rect x="70" y="160" width="210" height="7" rx="3" opacity="0.25" />
+      </g>
+      <g transform="translate(260 156)">
+        <rect x="0" y="0" width="64" height="44" rx="10" fill="#ff3621" />
+        <g transform="translate(18 10)" fill="#ffffff">
+          <rect x="2" y="0" width="16" height="4" rx="1.5" opacity="0.9" />
+          <rect
+            x="0"
+            y="4"
+            width="20"
+            height="22"
+            rx="3"
+            fill="none"
+            stroke="#ffffff"
+            strokeWidth="2"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+function ChatVisual(): ReactNode {
+  return (
+    <svg
+      viewBox="0 0 400 260"
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden
+    >
+      <g transform="translate(30 40)">
+        <path
+          d="M8 0 H240 a16 16 0 0 1 16 16 V64 a16 16 0 0 1 -16 16 H40 L24 94 V80 H8 a8 8 0 0 1 -8 -8 V8 a8 8 0 0 1 8 -8 Z"
+          className="text-black/6 dark:text-white/8"
+          fill="currentColor"
+        />
+        <path
+          d="M8 0 H240 a16 16 0 0 1 16 16 V64 a16 16 0 0 1 -16 16 H40 L24 94 V80 H8 a8 8 0 0 1 -8 -8 V8 a8 8 0 0 1 8 -8 Z"
+          className="text-black/18 dark:text-white/20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.25"
+        />
+        <g className="text-black/40 dark:text-white/55" fill="currentColor">
+          <rect x="20" y="18" width="180" height="8" rx="3" opacity="0.75" />
+          <rect x="20" y="34" width="140" height="7" rx="3" opacity="0.45" />
+          <rect x="20" y="48" width="160" height="7" rx="3" opacity="0.4" />
+        </g>
+      </g>
+
+      <g transform="translate(120 150)">
+        <path
+          d="M32 0 H244 a8 8 0 0 1 8 8 V72 a8 8 0 0 1 -8 8 H52 L32 96 V80 a8 8 0 0 1 -8 -8 V8 a8 8 0 0 1 8 -8 Z"
+          fill="#ff3621"
+        />
+        <g fill="#ffffff">
+          <circle cx="46" cy="24" r="3" />
+          <rect
+            x="56"
+            y="20"
+            width="12"
+            height="8"
+            rx="2"
+            fill="none"
+            stroke="#ffffff"
+            strokeWidth="1.5"
+          />
+          <rect x="76" y="22" width="120" height="6" rx="2" opacity="0.95" />
+          <circle cx="46" cy="42" r="3" opacity="0.85" />
+          <rect
+            x="56"
+            y="38"
+            width="12"
+            height="8"
+            rx="2"
+            fill="none"
+            stroke="#ffffff"
+            strokeWidth="1.5"
+            opacity="0.85"
+          />
+          <rect x="76" y="40" width="100" height="6" rx="2" opacity="0.75" />
+          <circle cx="46" cy="60" r="3" opacity="0.75" />
+          <rect
+            x="56"
+            y="56"
+            width="12"
+            height="8"
+            rx="2"
+            fill="none"
+            stroke="#ffffff"
+            strokeWidth="1.5"
+            opacity="0.75"
+          />
+          <rect x="76" y="58" width="84" height="6" rx="2" opacity="0.65" />
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+function BuildVisual(): ReactNode {
+  return (
+    <svg
+      viewBox="0 0 400 260"
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden
+    >
+      <g
+        className="text-black/16 dark:text-white/18"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        fill="none"
+      >
+        <path d="M80 178 C 140 110, 180 110, 200 130" strokeLinecap="round" />
+        <path d="M320 178 C 260 110, 220 110, 200 130" strokeLinecap="round" />
+      </g>
+
+      <g transform="translate(40 150)">
+        <rect
+          x="0"
+          y="0"
+          width="96"
+          height="76"
+          rx="10"
+          className="text-black/8 dark:text-white/10"
+          fill="currentColor"
+        />
+        <rect
+          x="0"
+          y="0"
+          width="96"
+          height="76"
+          rx="10"
+          className="text-black/18 dark:text-white/20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.25"
+        />
+        <ellipse cx="48" cy="22" rx="28" ry="8" fill="#ff3621" />
+        <rect x="20" y="22" width="56" height="30" fill="#ff3621" />
+        <ellipse cx="48" cy="52" rx="28" ry="8" fill="#ff5542" />
+        <text
+          x="48"
+          y="72"
+          textAnchor="middle"
+          className="fill-black/60 dark:fill-white/70"
+          fontSize="10"
+          fontFamily="DM Mono, monospace"
+        >
+          Lakebase
+        </text>
+      </g>
+
+      <g transform="translate(152 112)">
+        <rect
+          x="0"
+          y="0"
+          width="96"
+          height="76"
+          rx="10"
+          className="text-black/8 dark:text-white/10"
+          fill="currentColor"
+        />
+        <rect
+          x="0"
+          y="0"
+          width="96"
+          height="76"
+          rx="10"
+          className="text-black/18 dark:text-white/20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.25"
+        />
+        <circle cx="48" cy="34" r="18" fill="#ff3621" />
+        <circle cx="40" cy="33" r="2.5" fill="#ffffff" opacity="0.95" />
+        <circle cx="48" cy="33" r="2.5" fill="#ffffff" opacity="0.8" />
+        <circle cx="56" cy="33" r="2.5" fill="#ffffff" opacity="0.65" />
+        <text
+          x="48"
+          y="68"
+          textAnchor="middle"
+          className="fill-black/60 dark:fill-white/70"
+          fontSize="10"
+          fontFamily="DM Mono, monospace"
+        >
+          Agent Bricks
+        </text>
+      </g>
+
+      <g transform="translate(264 150)">
+        <rect
+          x="0"
+          y="0"
+          width="96"
+          height="76"
+          rx="10"
+          className="text-black/8 dark:text-white/10"
+          fill="currentColor"
+        />
+        <rect
+          x="0"
+          y="0"
+          width="96"
+          height="76"
+          rx="10"
+          className="text-black/18 dark:text-white/20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.25"
+        />
+        <rect
+          x="14"
+          y="16"
+          width="68"
+          height="36"
+          rx="6"
+          fill="none"
+          className="text-black/35 dark:text-white/45"
+          stroke="currentColor"
+          strokeWidth="1.25"
+        />
+        <rect x="22" y="24" width="30" height="5" rx="2" fill="#ff3621" />
+        <rect
+          x="22"
+          y="34"
+          width="52"
+          height="4"
+          rx="2"
+          className="text-black/25 dark:text-white/30"
+          fill="currentColor"
+        />
+        <rect
+          x="22"
+          y="42"
+          width="40"
+          height="4"
+          rx="2"
+          className="text-black/20 dark:text-white/25"
+          fill="currentColor"
+        />
+        <text
+          x="48"
+          y="68"
+          textAnchor="middle"
+          className="fill-black/60 dark:fill-white/70"
+          fontSize="10"
+          fontFamily="DM Mono, monospace"
+        >
+          AppKit
+        </text>
+      </g>
+    </svg>
+  );
+}
+
+function ShipVisual(): ReactNode {
+  return (
+    <svg
+      viewBox="0 0 400 260"
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden
+    >
+      <rect
+        x="44"
+        y="54"
+        width="312"
+        height="160"
+        rx="14"
+        className="text-black/6 dark:text-white/8"
+        fill="currentColor"
+      />
+      <rect
+        x="44"
+        y="54"
+        width="312"
+        height="160"
+        rx="14"
+        className="text-black/18 dark:text-white/20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+      />
+      <g className="text-black/28 dark:text-white/35" fill="currentColor">
+        <circle cx="60" cy="70" r="3" />
+        <circle cx="72" cy="70" r="3" />
+        <circle cx="84" cy="70" r="3" />
+      </g>
+      <rect
+        x="106"
+        y="62"
+        width="168"
+        height="16"
+        rx="8"
+        className="text-black/8 dark:text-white/10"
+        fill="currentColor"
+      />
+      <text
+        x="190"
+        y="74"
+        textAnchor="middle"
+        className="fill-black/55 dark:fill-white/65"
+        fontSize="10"
+        fontFamily="DM Mono, monospace"
+      >
+        your-app.databricksapps.com
+      </text>
+      <g>
+        <circle cx="326" cy="70" r="5" fill="#22c55e" />
+        <circle cx="326" cy="70" r="9" fill="#22c55e" opacity="0.25" />
+      </g>
+
+      <g transform="translate(76 108)">
+        <rect
+          x="0"
+          y="0"
+          width="110"
+          height="78"
+          rx="10"
+          fill="#ff3621"
+          opacity="0.92"
+        />
+        <rect
+          x="14"
+          y="14"
+          width="48"
+          height="8"
+          rx="2"
+          fill="#ffffff"
+          opacity="0.9"
+        />
+        <rect
+          x="14"
+          y="28"
+          width="80"
+          height="6"
+          rx="2"
+          fill="#ffffff"
+          opacity="0.55"
+        />
+        <rect
+          x="14"
+          y="40"
+          width="66"
+          height="6"
+          rx="2"
+          fill="#ffffff"
+          opacity="0.5"
+        />
+        <rect
+          x="14"
+          y="54"
+          width="36"
+          height="14"
+          rx="4"
+          fill="#ffffff"
+          opacity="0.85"
+        />
+      </g>
+
+      <g transform="translate(210 108)">
+        <rect
+          x="0"
+          y="0"
+          width="110"
+          height="78"
+          rx="10"
+          className="text-black/8 dark:text-white/12"
+          fill="currentColor"
+        />
+        <rect
+          x="0"
+          y="0"
+          width="110"
+          height="78"
+          rx="10"
+          className="text-black/18 dark:text-white/22"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.25"
+        />
+        <g className="text-black/35 dark:text-white/45" fill="currentColor">
+          <rect x="14" y="14" width="46" height="7" rx="2" opacity="0.9" />
+          <rect x="14" y="28" width="82" height="5" rx="2" opacity="0.5" />
+          <polyline
+            points="14,62 28,52 42,58 56,44 70,50 84,36 96,42"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+}
+
+const steps: WizardStep[] = [
+  {
+    number: "01",
+    eyebrow: "Copy",
+    title: "Copy the wizard prompt",
+    description:
+      "One click copies a guided setup prompt — the full recipe your coding agent needs to build and deploy on Databricks.",
+    icon: Clipboard,
+    visual: <ClipboardVisual />,
+  },
+  {
+    number: "02",
+    eyebrow: "Paste",
+    title: "Paste it into your coding agent",
+    description:
+      "Works with Cursor, Claude Code, or Codex. Your agent reads the prompt and starts a conversation: what do you want to build, which data, which workspace?",
+    icon: MessagesSquare,
+    visual: <ChatVisual />,
+  },
+  {
+    number: "03",
+    eyebrow: "Build",
+    title: "It scaffolds, wires, and iterates",
+    description:
+      "The wizard uses AppKit to scaffold the app, provisions Lakebase for data, wires Agent Bricks for AI, and iterates on the UI until it feels right — all guided by your answers.",
+    icon: Sparkles,
+    visual: <BuildVisual />,
+  },
+  {
+    number: "04",
+    eyebrow: "Ship",
+    title: "Deploy to your workspace",
+    description:
+      "One command ships it to Databricks Apps. Unity Catalog governs the data, OAuth is built in, and you get a live URL under your workspace.",
+    icon: Rocket,
+    visual: <ShipVisual />,
+  },
+];
+
+function StepRow({
+  step,
+  index,
+}: {
+  step: WizardStep;
+  index: number;
+}): ReactNode {
+  const isReversed = index % 2 === 1;
+  const Icon = step.icon;
+
+  return (
+    <div
+      className={[
+        "grid grid-cols-1 items-center gap-8 md:grid-cols-2 md:gap-14",
+        isReversed ? "md:[direction:rtl]" : "",
+      ].join(" ")}
+    >
+      <div className={isReversed ? "md:[direction:ltr]" : ""}>
+        <p className="mb-4 inline-flex items-center gap-2.5 text-[10px] font-semibold tracking-[0.14em] uppercase">
+          <span className="font-mono text-db-lava">{step.number}</span>
+          <span className="h-px w-6 bg-db-lava/60" />
+          <span className="text-black/55 dark:text-white/55">
+            {step.eyebrow}
+          </span>
+        </p>
+        <h3 className="text-2xl leading-snug font-medium tracking-tight text-black md:text-[2rem] md:leading-[1.15] dark:text-white">
+          {step.title}
+        </h3>
+        <p className="mt-3 max-w-lg text-[0.95rem] leading-relaxed text-black/60 dark:text-white/60">
+          {step.description}
+        </p>
+        <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/70 px-3 py-1.5 text-[11px] font-medium text-black/70 backdrop-blur-sm dark:border-white/12 dark:bg-white/6 dark:text-white/70">
+          <Icon className="h-3.5 w-3.5 text-db-lava" />
+          Step {step.number}
+        </div>
+      </div>
+      <div className={isReversed ? "md:[direction:ltr]" : ""}>
+        <div className="relative aspect-[16/10] w-full overflow-hidden rounded-2xl border border-black/10 bg-white shadow-[0_18px_48px_-24px_rgba(11,32,38,0.25)] dark:border-white/10 dark:bg-db-navy-light dark:shadow-[0_18px_48px_-24px_rgba(0,0,0,0.6)]">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_12%_0%,rgba(255,54,33,0.06)_0%,transparent_45%)]" />
+          {step.visual}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WizardFlow(): ReactNode {
+  return (
+    <section
+      id="wizard-flow"
+      className="relative scroll-mt-20 bg-white py-20 dark:bg-db-navy md:py-28"
+    >
+      <div className="container px-4">
+        <div className="mx-auto mb-14 max-w-3xl text-center md:mb-20">
+          <p className="mb-4 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.14em] uppercase text-black/55 dark:text-white/55">
+            <span className="h-1.5 w-1.5 rounded-full bg-db-lava" />
+            How the wizard prompt works
+          </p>
+          <h2 className="text-3xl leading-[1.1] font-medium tracking-tight text-black md:text-5xl dark:text-white">
+            Copy. Paste. Build.{" "}
+            <span className="text-db-lava">Ship to Databricks.</span>
+          </h2>
+          <p className="mt-5 text-base leading-relaxed text-black/60 md:text-lg dark:text-white/60">
+            The wizard prompt guides you and your coding agent from an empty
+            folder to a deployed Databricks app — with your data, your
+            workspace, and your agent logic wired together in one conversation.
+          </p>
+        </div>
+
+        <div className="mx-auto flex max-w-5xl flex-col gap-16 md:gap-24">
+          {steps.map((step, index) => (
+            <StepRow key={step.number} step={step} index={index} />
+          ))}
+        </div>
+
+        <div className="mx-auto mt-16 max-w-3xl rounded-2xl border border-black/10 bg-db-oat-medium/60 p-6 text-center dark:border-white/10 dark:bg-black/40 md:mt-24 md:p-8">
+          <p className="text-sm leading-relaxed text-black/70 dark:text-white/70">
+            <span className="font-medium text-black dark:text-white">
+              Want a more specific starting point?
+            </span>{" "}
+            Every guide and example on{" "}
+            <Link
+              to="/resources"
+              className="font-medium text-db-lava no-underline hover:underline"
+            >
+              /resources
+            </Link>{" "}
+            is a copy-pasteable prompt. Get inspired by what&apos;s already
+            possible, then hand it to your agent.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { DecisionMakerCta } from "@/components/home/decision-maker-cta";
 import { HeroSection } from "@/components/home/hero-section";
 import { PillarStrip } from "@/components/home/pillar-strip";
 import { TemplatePreview } from "@/components/home/template-preview";
+import { WizardFlow } from "@/components/home/wizard-flow";
 
 export default function Home(): ReactNode {
   return (
@@ -34,8 +35,9 @@ export default function Home(): ReactNode {
       </Head>
       <main>
         <HeroSection />
-        <TemplatePreview />
+        <WizardFlow />
         <PillarStrip />
+        <TemplatePreview />
         <DecisionMakerCta />
       </main>
     </Layout>


### PR DESCRIPTION
Closes #55 (this PR builds on top of it)

## Summary

- Reframe the landing page narrative around a single primary action: **copy a prompt, paste it into your coding agent, and ship a Databricks app**. The hero drops the CLI terminal segment and leads with a focused copy-prompt CTA.
- Add a new **four-step wizard-flow section** (Copy → Paste → Build → Ship) with on-brand light/dark SVG illustrations that walk the user through what happens after they paste the prompt.
- Tighten copy throughout — hero subtitle, wizard step descriptions, template-preview section, and pillar-strip header — to be more concise and action-oriented.
- Add an **inline copy-prompt button** to wizard step 1 so users can copy without scrolling back to the hero.
- Reorder homepage sections to Hero → WizardFlow → Pillars → Templates → DecisionMakerCta for a top-to-bottom narrative flow.
- Ignore `bun.lock` in `.vercelignore` to avoid a bun registry-proxy hang during Vercel deploys.

## Test plan

- [ ] Verify the landing page renders correctly in both light and dark mode
- [ ] Confirm the "Copy prompt" button in the hero and in wizard step 1 both copy the bootstrap prompt successfully
- [ ] Check smooth-scroll "How it works" button navigates to the wizard-flow section
- [ ] Verify all four SVG illustrations display properly at various breakpoints (mobile, tablet, desktop)
- [ ] Confirm the "Read the docs" link routes to `/docs/start-here`