### PR TITLE
feat(analytics): add Vercel Analytics with copy-prompt event tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@mdx-js/react": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "@vercel/analytics": "^2.0.1",
         "@vercel/functions": "^3.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.0.0",
@@ -8774,6 +8775,48 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/build-utils": {
       "version": "13.8.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mdx-js/react": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",

--- a/src/components/home/hero-section.tsx
+++ b/src/components/home/hero-section.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useCallback, useRef, useState } from "react";
 import { ArrowRight, Check, Clipboard, LoaderCircle } from "lucide-react";
 import Link from "@docusaurus/Link";
+import { track } from "@vercel/analytics";
 import { Button } from "@/components/ui/button";
 import { getBootstrapPromptApiPath } from "@/lib/bootstrap-prompt";
 
@@ -76,6 +77,7 @@ export function HeroSection(): ReactNode {
       }
 
       setCopyState("copied");
+      track("copy_bootstrap_prompt", { source: "hero" });
     } catch {
       setCopyState("error");
     } finally {

--- a/src/components/home/wizard-flow.tsx
+++ b/src/components/home/wizard-flow.tsx
@@ -10,6 +10,7 @@ import {
   Sparkles,
   type LucideIcon,
 } from "lucide-react";
+import { track } from "@vercel/analytics";
 import { Button } from "@/components/ui/button";
 import { getBootstrapPromptApiPath } from "@/lib/bootstrap-prompt";
 
@@ -599,6 +600,7 @@ function CopyPromptButton(): ReactNode {
       }
 
       setCopyState("copied");
+      track("copy_bootstrap_prompt", { source: "wizard" });
     } catch {
       setCopyState("error");
     } finally {

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import Head from "@docusaurus/Head";
 import { useLocation } from "@docusaurus/router";
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "sonner";
 
 // Keep in sync with middleware.ts matcher and vercel.json headers/rewrites
@@ -46,6 +47,7 @@ function SonnerToaster() {
 export default function Root({ children }: { children: ReactNode }): ReactNode {
   return (
     <>
+      <Analytics />
       <MarkdownAlternate />
       {children}
       <BrowserOnly>{() => <SonnerToaster />}</BrowserOnly>


### PR DESCRIPTION
## Summary
- Adds `@vercel/analytics` with the `<Analytics />` provider in the Docusaurus Root for automatic pageview tracking site-wide.
- Fires a `copy_bootstrap_prompt` custom event (with `source: "hero"` or `source: "wizard"`) on successful copy from both CTA buttons.
- Rewrites the lockfile private registry URL to `registry.npmjs.org` to avoid Vercel deploy hangs.

## Test plan
- [x] Pre-commit hooks pass (Prettier, typecheck, content validation, image verification, production build)
- [x] Preview deploy succeeded: https://comdatabricks-mc4ay24cf-databricks-web.vercel.app