### PR TITLE
migrate server({ autoStart: false }) to onPluginsReady

### DIFF
--- a/content/recipes/lakebase-chat-persistence/content.md
+++ b/content/recipes/lakebase-chat-persistence/content.md
@@ -38,7 +38,19 @@ CREATE INDEX IF NOT EXISTS idx_messages_chat_id_created_at
 
 ### 2. Run setup from your server bootstrap
 
-In `server/server.ts`, keep `autoStart: false` and run schema setup before `appkit.server.start()`.
+In `server/server.ts`, run schema setup inside `onPluginsReady` so it completes before AppKit starts the HTTP server:
+
+```typescript
+import { createApp, server, lakebase } from "@databricks/appkit";
+import { setupChatTables } from "./lib/chat-store";
+
+await createApp({
+  plugins: [server(), lakebase()],
+  async onPluginsReady(appkit) {
+    await setupChatTables(appkit);
+  },
+});
+```
 
 ### 3. Add persistence helpers
 

--- a/content/recipes/lakebase-data-persistence/content.md
+++ b/content/recipes/lakebase-data-persistence/content.md
@@ -45,20 +45,18 @@ The code below may be outdated. To get the latest, clone `https://github.com/dat
 
 #### Update `server/server.ts`
 
-Use `autoStart: false` on the server plugin so database setup runs before accepting requests. Import and register the `lakebase` plugin, then call route setup in the `.then()` handler:
+Register the `lakebase` plugin and run route setup inside `onPluginsReady`. AppKit waits for that hook to resolve before the server starts accepting requests, so your schema setup completes before the first call lands:
 
 ```typescript
 import { createApp, server, lakebase } from "@databricks/appkit";
 import { setupRoutes } from "./routes/item-routes";
 
-createApp({
-  plugins: [server({ autoStart: false }), lakebase()],
-})
-  .then(async (appkit) => {
+await createApp({
+  plugins: [server(), lakebase()],
+  async onPluginsReady(appkit) {
     await setupRoutes(appkit);
-    await appkit.server.start();
-  })
-  .catch(console.error);
+  },
+});
 ```
 
 #### Create `server/routes/item-routes.ts`

--- a/examples/agentic-support-console/template/server/server.ts
+++ b/examples/agentic-support-console/template/server/server.ts
@@ -1,11 +1,9 @@
 import { createApp, analytics, genie, lakebase, server } from '@databricks/appkit';
 import { setupSupportRoutes } from './routes/support-routes';
 
-createApp({
-  plugins: [server({ autoStart: false }), analytics(), genie(), lakebase()],
-})
-  .then(async (appkit) => {
+await createApp({
+  plugins: [server(), analytics(), genie(), lakebase()],
+  async onPluginsReady(appkit) {
     await setupSupportRoutes(appkit);
-    await appkit.server.start();
-  })
-  .catch(console.error);
+  },
+});

--- a/examples/content-moderator/template/server/server.ts
+++ b/examples/content-moderator/template/server/server.ts
@@ -7,11 +7,9 @@ import {
 } from "@databricks/appkit";
 import { setupModerationRoutes } from "./routes/moderation-routes";
 
-createApp({
-  plugins: [server({ autoStart: false }), analytics(), genie(), lakebase()],
-})
-  .then(async (appkit) => {
+await createApp({
+  plugins: [server(), analytics(), genie(), lakebase()],
+  async onPluginsReady(appkit) {
     await setupModerationRoutes(appkit);
-    await appkit.server.start();
-  })
-  .catch(console.error);
+  },
+});

--- a/examples/inventory-intelligence/template/server/server.ts
+++ b/examples/inventory-intelligence/template/server/server.ts
@@ -7,16 +7,14 @@ import {
 } from "@databricks/appkit";
 import { setupInventoryRoutes, genieEnabled } from "./routes/inventory-routes";
 
-createApp({
+await createApp({
   plugins: [
-    server({ autoStart: false }),
+    server(),
     analytics(),
     ...(genieEnabled ? [genie()] : []),
     lakebase(),
   ],
-})
-  .then(async (appkit) => {
+  async onPluginsReady(appkit) {
     await setupInventoryRoutes(appkit);
-    await appkit.server.start();
-  })
-  .catch(console.error);
+  },
+});

--- a/examples/rag-chat/template/server/server.ts
+++ b/examples/rag-chat/template/server/server.ts
@@ -6,13 +6,13 @@ import { setupChatTables } from './lib/chat-store';
 import { seedFromWikipedia } from './lib/seed-data';
 import { generateEmbedding } from './lib/embeddings';
 
-const appkit = await createApp({
-  plugins: [server({ autoStart: false }), lakebase()],
+await createApp({
+  plugins: [server(), lakebase()],
+  async onPluginsReady(appkit) {
+    await setupRagTables(appkit);
+    await setupChatTables(appkit);
+    await seedFromWikipedia(appkit, generateEmbedding, insertDocument);
+    setupChatRoutes(appkit);
+    setupChatPersistenceRoutes(appkit);
+  },
 });
-
-await setupRagTables(appkit);
-await setupChatTables(appkit);
-await seedFromWikipedia(appkit, generateEmbedding, insertDocument);
-setupChatRoutes(appkit);
-setupChatPersistenceRoutes(appkit);
-await appkit.server.start();

--- a/examples/saas-tracker/template/server/server.ts
+++ b/examples/saas-tracker/template/server/server.ts
@@ -7,11 +7,9 @@ import {
 } from "@databricks/appkit";
 import { setupSaasRoutes } from "./routes/saas-routes";
 
-createApp({
-  plugins: [server({ autoStart: false }), analytics(), genie(), lakebase()],
-})
-  .then(async (appkit) => {
+await createApp({
+  plugins: [server(), analytics(), genie(), lakebase()],
+  async onPluginsReady(appkit) {
     await setupSaasRoutes(appkit);
-    await appkit.server.start();
-  })
-  .catch(console.error);
+  },
+});

--- a/tests/docs-verify/docs-verify-apps.test.ts
+++ b/tests/docs-verify/docs-verify-apps.test.ts
@@ -184,9 +184,10 @@ describe("Scaffold app with Lakebase feature", { timeout: 120_000 }, () => {
     );
   });
 
-  test("server.ts uses autoStart: false with lakebase", () => {
+  test("server.ts wires lakebase setup through onPluginsReady", () => {
     const serverTs = readFileSync(resolve(appDir, "server/server.ts"), "utf-8");
-    expect(serverTs).toContain("autoStart: false");
+    expect(serverTs).toContain("onPluginsReady");
+    expect(serverTs).not.toContain("autoStart");
     expect(serverTs).toContain("lakebase");
     expect(serverTs).toContain("setupSampleLakebaseRoutes");
     console.log("[apps+lakebase] server.ts:", serverTs.trim());


### PR DESCRIPTION
## Summary

The server plugin's `autoStart: false` option plus a manual `appkit.server.start()` in a `.then()` handler is deprecated. AppKit now exposes `onPluginsReady` on `createApp`, which runs after plugins initialize and before the HTTP server starts accepting requests. This PR migrates every example app and recipe in this repo to the new pattern.

### Before

```ts
createApp({
  plugins: [server({ autoStart: false }), lakebase()],
})
  .then(async (appkit) => {
    await setupRoutes(appkit);
    await appkit.server.start();
  })
  .catch(console.error);
```

### After

```ts
await createApp({
  plugins: [server(), lakebase()],
  async onPluginsReady(appkit) {
    await setupRoutes(appkit);
  },
});
```

## Changes

- **5 example `server.ts` files** migrated to `onPluginsReady`:
  - `examples/saas-tracker/template/server/server.ts`
  - `examples/content-moderator/template/server/server.ts`
  - `examples/rag-chat/template/server/server.ts`
  - `examples/agentic-support-console/template/server/server.ts`
  - `examples/inventory-intelligence/template/server/server.ts`
- **2 recipes** rewritten to teach the new pattern instead of `autoStart: false`:
  - `content/recipes/lakebase-data-persistence/content.md`
  - `content/recipes/lakebase-chat-persistence/content.md`
- **1 test** (`tests/docs-verify/docs-verify-apps.test.ts`) now asserts the new `onPluginsReady` shape and the absence of `autoStart`.

## Out of scope

- `docs/appkit/v0/api/**` and `docs/appkit/v0/plugins/server.md` still reference `autoStart`. Those are auto-generated TypeDoc output from the AppKit SDK and will refresh once the SDK ships the new API.
- The unrelated `autoStart` mentions for `useAnalyticsQuery` / serving hooks (`docs/appkit/v0/plugins/analytics.md`, `docs/appkit/v0/plugins/serving.md`, `.agents/skills/.../appkit-sdk.md`, `.agents/skills/.../overview.md`) are a different option on a different API and were intentionally not touched.

## Test plan

- [x] `npm run fmt` — clean
- [x] `npm run typecheck` — passes
- [x] `npm run build` (run by pre-commit hook) — passes
- [ ] `tests/docs-verify/docs-verify-apps.test.ts` will pass once the `databricks apps init --features=lakebase` template generator emits the new `onPluginsReady` shape (i.e. after the AppKit SDK ships this API). On the current generator output it would fail — this is the intended signal, since the test previously pinned the deprecated pattern.
- [ ] Manual: run any one of the migrated example apps end-to-end against an SDK build that includes `onPluginsReady` and confirm routes are registered before the HTTP server starts accepting requests.

## Notes

Drafting because the smoke / docs-verify path depends on the AppKit SDK release that introduces `onPluginsReady`. Ready to mark for review once that ships (or we can land the docs/example side first if you prefer to lead the migration narrative).