### PR TITLE
docs: rewrite entry pages and standardize page endings

### DIFF
--- a/docs/agents/ai-gateway.md
+++ b/docs/agents/ai-gateway.md
@@ -6,7 +6,7 @@ description: Call governed LLM endpoints from your AppKit app using the Model Se
 
 # AI Gateway
 
-**AI Gateway** is a Databricks governance layer for LLM endpoints and MCP servers. It tracks usage, enforces rate limits, logs payloads, filters unsafe content and PII, and attributes cost. From your AppKit app, you call a governed endpoint with the Model Serving plugin. This page covers the AppKit wiring, the governance features, and the CLI for inspecting and provisioning endpoints.
+**AI Gateway** is a Databricks governance layer for LLM endpoints and MCP servers. It tracks usage, enforces rate limits, logs payloads, filters unsafe content and PII, and attributes cost. See the [AI Gateway overview](https://docs.databricks.com/aws/en/ai-gateway/) for a full product introduction. From your AppKit app, you call a governed endpoint with the Model Serving plugin. This page covers the AppKit wiring, the governance features, and the CLI for inspecting and provisioning endpoints.
 
 ## Prerequisites
 
@@ -318,7 +318,7 @@ databricks serving-endpoints create $ENDPOINT_NAME \
 
 </details>
 
-Wait for the endpoint to reach `READY` state before querying it.
+Wait for the endpoint to reach `READY` state before querying it. For a step-by-step walkthrough, see the [Create a Model Serving Endpoint](/templates/model-serving-endpoint-creation) template.
 
 ## Coding agent integrations
 
@@ -328,20 +328,6 @@ To set up an integration, open **AI Gateway** in your workspace sidebar, go to t
 
 See [Integrate with coding agents](https://docs.databricks.com/aws/en/ai-gateway/coding-agent-integration-beta) for the full walkthrough and the current list of supported tools.
 
-## Related templates
+## Where to next
 
-| Template                                                                      | Description                           |
-| ----------------------------------------------------------------------------- | ------------------------------------- |
-| [Query AI Gateway Endpoints](/templates/foundation-models-api)                | Access foundation models from AppKit  |
-| [Streaming AI Chat](/templates/ai-chat-model-serving)                         | Streaming chat with the Vercel AI SDK |
-| [Create a Model Serving Endpoint](/templates/model-serving-endpoint-creation) | Provision and test a new endpoint     |
-| [AI Chat App](/templates/ai-chat-app)                                         | Streaming chat with history           |
-
-## Further reading
-
-- [AI Gateway landing](https://docs.databricks.com/aws/en/ai-gateway/)
-- [AI Gateway for LLM endpoints](https://docs.databricks.com/aws/en/ai-gateway/overview-beta)
-- [Configure AI Gateway on serving endpoints](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints)
-- [Integrate with coding agents](https://docs.databricks.com/aws/en/ai-gateway/coding-agent-integration-beta)
-- [AppKit Model Serving plugin reference](/docs/appkit/v0/plugins/serving)
-- [AppKit execution context](/docs/appkit/v0/plugins/execution-context)
+Try the [AI Chat App](/templates/ai-chat-app) to wire a governed endpoint into your app, or explore the other agent capabilities: [Genie spaces](/docs/agents/genie) or [Custom agent endpoints](/docs/agents/custom-agents).

--- a/docs/agents/custom-agents.md
+++ b/docs/agents/custom-agents.md
@@ -34,7 +34,7 @@ See [Knowledge Assistant](https://docs.databricks.com/aws/en/generative-ai/agent
 
 Coordinates subagents (Genie spaces, other agent endpoints, Unity Catalog functions, MCP servers) to complete a task, handling delegation and result synthesis. Good for workflows that span domains, for example searching research reports and querying usage data in the same conversation. Like Knowledge Assistant, the builder produces a single agent endpoint.
 
-See [Agent Bricks Multi-Agent Supervisor](https://docs.databricks.com/aws/en/generative-ai/agent-bricks/multi-agent-supervisor).
+See [Agent Bricks Multi-Agent Supervisor](https://docs.databricks.com/aws/en/generative-ai/agent-bricks/multi-agent-supervisor) and the [Supervisor API](https://docs.databricks.com/aws/en/generative-ai/agent-bricks/supervisor-api) for response shapes and query parameters.
 
 ### Custom Python agent
 
@@ -86,17 +86,6 @@ Serving routes in AppKit run on behalf of the authenticated user by default. If 
 
 For server logic outside the built-in plugin routes (for example, custom Express routes), call `AppKit.serving("assistant").asUser(req).invoke(...)` to keep per-user behavior. For background work without a request (scheduled tasks, workers), omit `asUser` and the call runs as the app's service principal.
 
-## Related templates
+## Where to next
 
-| Template                                                       | Description                           |
-| -------------------------------------------------------------- | ------------------------------------- |
-| [Query AI Gateway Endpoints](/templates/foundation-models-api) | Calling foundation models from AppKit |
-| [Streaming AI Chat](/templates/ai-chat-model-serving)          | Streaming chat with the Vercel AI SDK |
-
-## Further reading
-
-- [Knowledge Assistant](https://docs.databricks.com/aws/en/generative-ai/agent-bricks/knowledge-assistant)
-- [Agent Bricks Multi-Agent Supervisor](https://docs.databricks.com/aws/en/generative-ai/agent-bricks/multi-agent-supervisor)
-- [Create an AI agent](https://docs.databricks.com/aws/en/generative-ai/agent-framework/create-agent)
-- [Supervisor API](https://docs.databricks.com/aws/en/generative-ai/agent-bricks/supervisor-api)
-- [AppKit Model Serving plugin reference](/docs/appkit/v0/plugins/serving)
+Try the [AI Chat App](/templates/ai-chat-app) for a complete AppKit and agent setup, or browse the [templates catalog](/templates) for more patterns.

--- a/docs/agents/genie.md
+++ b/docs/agents/genie.md
@@ -112,7 +112,7 @@ export function CustomChat() {
 }
 ```
 
-`status` cycles through `idle`, `streaming`, `loading-history`, `loading-older`, and `error`. Use it to drive loading states in your UI. The hook also returns `error`, `conversationId`, and pagination helpers (`hasPreviousPage`, `isFetchingPreviousPage`, `fetchPreviousPage`). See the [AppKit Genie plugin reference](/docs/appkit/v0/plugins/genie) for the full return type.
+`status` cycles through `idle`, `streaming`, `loading-history`, `loading-older`, and `error`. Use it to drive loading states in your UI. The hook also returns `error`, `conversationId`, and pagination helpers (`hasPreviousPage`, `isFetchingPreviousPage`, `fetchPreviousPage`). See the [AppKit Genie plugin reference](/docs/appkit/v0/plugins/genie) for the full return type and the [Genie conversation API](https://docs.databricks.com/aws/en/genie/conversation-api) for the underlying REST API.
 
 ## Multiple spaces
 
@@ -136,17 +136,6 @@ The `genie` plugin calls the Genie API on behalf of the signed-in user. Both the
 - **App service principal**: `CAN RUN` on the Genie space, plus `SELECT` on the underlying Unity Catalog tables. Attach the space as a resource in `app.yaml` to provision these automatically. See [Add a Genie space resource to an app](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/genie).
 - **End users**: access to the Genie space (shared with them or via a group) and `SELECT` on the same tables. If the user doesn't have access, the call returns a 403. You don't write the permission check.
 
-## Related templates
+## Where to next
 
-| Template                                                                    | Description                                      |
-| --------------------------------------------------------------------------- | ------------------------------------------------ |
-| [Genie Conversational Analytics](/templates/genie-conversational-analytics) | Scaffold an AppKit app with a single Genie space |
-| [Genie Multi-Space Selector](/templates/genie-multi-space)                  | UI pattern for switching between spaces          |
-| [Genie Analytics App](/templates/genie-analytics-app)                       | Full template with Genie chat                    |
-
-## Further reading
-
-- [What is a Genie space](https://docs.databricks.com/aws/en/genie/)
-- [Genie conversation API](https://docs.databricks.com/aws/en/genie/conversation-api)
-- [Add a Genie space resource to an app](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/genie)
-- [AppKit Genie plugin reference](/docs/appkit/v0/plugins/genie)
+Try the [Genie Analytics App](/templates/genie-analytics-app) for a complete wired setup, or explore [Custom agent endpoints](/docs/agents/custom-agents) for Knowledge Assistants and Supervisor Agents.

--- a/docs/apps/configuration.md
+++ b/docs/apps/configuration.md
@@ -120,4 +120,6 @@ See [Best practices](https://docs.databricks.com/aws/en/dev-tools/databricks-app
 | Crashed   | App failed to start or exited      |
 | Stopped   | App was manually stopped           |
 
-Once your app is configured, [Apps development](/docs/apps/development) covers local setup, deploy flags, and the full AppKit plugin API. [Templates](/templates) cover common patterns including chat apps, CRUD with Lakebase, and Genie integrations.
+## Where to next
+
+See [Apps development](/docs/apps/development) for local setup, deploy flags, and the full plugin API, or browse the [templates catalog](/templates) for complete patterns.

--- a/docs/apps/development.md
+++ b/docs/apps/development.md
@@ -462,3 +462,7 @@ npx @databricks/appkit docs "<query-or-doc-path>"  # view a specific section or 
 ```
 
 Run without arguments to browse the index. Useful when building with an AI coding assistant. Point it here instead of guessing API shapes, or view the [AppKit reference](/docs/appkit/v0) on this site.
+
+## Where to next
+
+Browse the [templates catalog](/templates) to start building, or add capabilities to your app: [Lakebase Postgres](/docs/lakebase/overview) for persistent storage or [Agent Bricks](/docs/agents/overview) for AI features.

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -42,6 +42,6 @@ Every app gets a dedicated service principal. Databricks injects its credentials
 - Your app is a static site with no Databricks data access.
 - You're serving users outside your Databricks account (for example, public-facing apps or customers without Databricks access).
 
-## Next steps
+## Where to next
 
 [Templates](/templates) are agent-ready prompts organized by use case. Find one that fits, or see the [Apps Quickstart](/docs/apps/quickstart) for a step-by-step walkthrough.

--- a/docs/apps/quickstart.md
+++ b/docs/apps/quickstart.md
@@ -49,4 +49,6 @@ databricks apps deploy                                   # deploys to your works
 
 To scaffold with specific plugins, pass `--features` with a comma-separated list. Run `databricks apps manifest` to see all available plugins and their required resource fields.
 
-See [Apps Development](/docs/apps/development) for the full scaffold options, deploy flags, and environment configuration. For `app.yaml`, resource bindings, and env vars, see [App configuration](/docs/apps/configuration).
+## Where to next
+
+For the full local development workflow, deploy flags, and plugin setup, see [Apps development](/docs/apps/development).

--- a/docs/lakebase/configuration.md
+++ b/docs/lakebase/configuration.md
@@ -208,4 +208,6 @@ Setting `no_suspension: false` is not supported and returns an error. To re-enab
 
 </details>
 
-Once your resources are configured, [Lakebase Postgres development](/docs/lakebase/development) walks through connecting locally, adding the AppKit plugin, and branching for development workflows. [Templates](/templates) cover common patterns including CRUD apps, chat persistence, and Unity Catalog sync.
+## Where to next
+
+See [Lakebase Postgres development](/docs/lakebase/development) for local setup, feature branches, and the full plugin API, or browse the [templates catalog](/templates) for complete patterns.

--- a/docs/lakebase/development.md
+++ b/docs/lakebase/development.md
@@ -497,4 +497,6 @@ npx @databricks/appkit docs "lakebase"         # view Lakebase Postgres plugin d
 
 Or view the [AppKit Lakebase Postgres plugin reference](/docs/appkit/v0/plugins/lakebase) on this site.
 
+## Where to next
+
 [Templates](/templates) cover common Lakebase Postgres patterns. Browse them to find a starting point, or copy one into your coding agent to scaffold a working app.

--- a/docs/lakebase/overview.md
+++ b/docs/lakebase/overview.md
@@ -49,6 +49,6 @@ The plugin handles OAuth token refresh and connection pooling automatically. Whe
 - Pure analytics: read-only queries against large datasets belong in Unity Catalog, not Lakebase Postgres.
 - Apps with no other Databricks workspace dependencies. The colocation advantage doesn't apply, and auth is your responsibility.
 
-## Next steps
+## Where to next
 
 [Templates](/templates) are agent-ready prompts organized by use case. Find one that fits, or see the [Lakebase Postgres Quickstart](/docs/lakebase/quickstart) for step-by-step instructions.

--- a/docs/lakebase/quickstart.md
+++ b/docs/lakebase/quickstart.md
@@ -75,6 +75,6 @@ Execute `databricks apps deploy` before `npm run dev`. Deploying sets up a manag
 npm install && npm run dev
 ```
 
-## Next steps
+## Where to next
 
-[Templates](/templates) cover common Lakebase Postgres patterns. If you scaffolded manually, [Lakebase Postgres development](/docs/lakebase/development) covers local setup, feature branches, and the full plugin API. [Lakebase Postgres configuration](/docs/lakebase/configuration) has the reference for `app.yaml`, resource declarations, and connection values.
+For local development workflow, feature branches, and the full plugin API, see [Lakebase Postgres development](/docs/lakebase/development).

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -5,26 +5,22 @@ description: How Databricks Apps, AppKit, Lakebase, and Agent Bricks fit togethe
 
 # Platform overview
 
-DevHub is a catalog of templates for the Databricks developer stack. Pick a template, copy it into your coding agent, and it handles scaffolding, auth, database, and deployment.
-
-## How the platform fits together
-
-Apps, AppKit, Lakebase, and Agent Bricks are four layers that make up a full-stack Databricks application. Unity Catalog and AI Gateway are workspace services they connect to.
+Apps, AppKit, Lakebase Postgres, and Agent Bricks are four layers that make up a full-stack Databricks application. Unity Catalog and AI Gateway are workspace services they connect to.
 
 <img src="/img/docs/platform-overview.svg" alt="Architecture diagram showing Apps containing AppKit, Lakebase, and Agents, with Unity Catalog and AI Gateway as workspace services" width="100%" />
 
-| Layer            | What it is                                                                                                                                                                          |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Apps**         | The hosting layer. Your Node.js or Python app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.      |
-| **AppKit**       | The TypeScript SDK. Provides auth, UI components, and a plugin system (server, lakebase, analytics, genie, files, caching, and more) with support for custom plugins.               |
-| **Lakebase**     | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments. |
-| **Agent Bricks** | The AI layer. Connect Knowledge Assistants, Supervisor Agents, Genie spaces, and governed LLM endpoints to your AppKit app via the Model Serving and Genie plugins.                 |
+| Layer                 | What it is                                                                                                                                                                                      |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Apps**              | The hosting layer. Your app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.                                    |
+| **AppKit**            | The TypeScript SDK for building apps on Databricks Apps. Provides auth, pre-built React UI components (data tables, charts, dialogs), and a plugin system for connecting to workspace services. |
+| **Lakebase Postgres** | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments.             |
+| **Agent Bricks**      | The AI layer. Call Knowledge Assistants, Supervisor Agents, and governed LLM endpoints via the Model Serving plugin. Query Unity Catalog tables in natural language via the Genie plugin.       |
 
 **[Unity Catalog](https://docs.databricks.com/aws/en/data-governance/)** and **[AI Gateway](/docs/agents/ai-gateway)** are workspace-level services your app connects to for data governance and model serving.
 
 ## Pick a template
 
-Templates are step-by-step instructions for your coding agent. Here are a few common starting points. The [templates catalog](/templates) has the full list.
+Templates are agent-ready prompts organized by use case. Here are a few common starting points. The [templates catalog](/templates) has the full list.
 
 All templates assume the [Databricks CLI](/docs/tools/databricks-cli) is installed and [authenticated](/docs/tools/databricks-cli#authenticate) against your workspace.
 
@@ -36,12 +32,12 @@ All templates assume the [Databricks CLI](/docs/tools/databricks-cli) is install
 
 More templates are in the [templates catalog](/templates).
 
-## Companion docs
+## Where to next
 
-These docs explain the platform layers that templates build on:
+These docs go deeper on each platform layer:
 
-- **[Web apps (Databricks Apps)](/docs/apps/quickstart)**: Scaffold and deploy a working app built with AppKit (TypeScript) or Python.
-- **[Postgres database (Lakebase)](/docs/lakebase/quickstart)**: Provision a Lakebase project and connect it to an app.
-- **[Agent Bricks](/docs/agents/overview)**: Connect your AppKit app to Agent Bricks: governed model endpoints, Genie spaces, and Knowledge Assistants.
+- **[Web apps (Databricks Apps)](/docs/apps/quickstart)**: Scaffold and deploy an AppKit app (TypeScript) or a Python app on Databricks Apps.
+- **[Lakebase Postgres](/docs/lakebase/quickstart)**: Provision a Lakebase Postgres project and connect it to an app.
+- **[Agent Bricks](/docs/agents/overview)**: Governed model endpoints ([AI Gateway](/docs/agents/ai-gateway)), natural-language data queries ([Genie](/docs/agents/genie)), and custom agent endpoints ([Custom agents](/docs/agents/custom-agents)).
 - **[Set up your environment](/docs/tools/databricks-cli)**: Databricks CLI, agent skills, and MCP server.
 - **[AppKit Reference](/docs/appkit/v0)**: Component library, plugin API, and TypeScript SDK reference.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,30 +1,26 @@
 ---
 title: Start here
-description: DevHub is the developer platform for Databricks. Build web apps, AI agents, and data-backed applications deployed and hosted inside your Databricks workspace.
+description: Build web apps, databases, and AI agents inside your Databricks workspace with Databricks Apps, Lakebase Postgres, and Agent Bricks.
 ---
 
 # Start here
 
-Databricks is a data and AI platform. It manages data pipelines, stores and governs data at scale, runs ML workloads, and serves AI models. DevHub is the developer-facing layer: templates, SDKs, and tools for building applications on top of that platform.
+Build web apps, databases, and AI agents that run inside your Databricks workspace. DevHub provides the templates, SDKs, and companion docs to do it.
 
 ## What you can build
 
-- **A web app**: your app runs inside your workspace with built-in auth and direct data access. Build it with AppKit, a TypeScript SDK with UI components and a plugin system, or use Python.
-- **A Postgres database**: provision Lakebase, managed Postgres that runs inside your workspace, with instant branching and scale-to-zero for development and production.
-- **An AI agent**: give an LLM a goal and a set of tools: functions it can call, APIs it can hit, data it can query. Deploy it to your workspace with hosted model endpoints and built-in tracing.
+- **Databricks Apps**: host your web app inside your workspace with a fixed URL, built-in auth, and direct data access. Build the frontend and backend with AppKit, an open-source Node.js and React SDK.
+- **Lakebase Postgres**: managed Postgres co-located with your workspace, with instant branching and scale-to-zero for development and production.
+- **Agent Bricks**: Databricks' agent platform. Build with Knowledge Assistants, governed model endpoints, and Genie spaces. Agents are hosted on Databricks Apps.
 
 ## Templates
 
-Templates are step-by-step build instructions for your coding agent. Copy one in and it handles scaffolding, configuration, and deployment. Browse the [templates catalog](/templates).
+Templates are agent-ready prompts organized by use case. Copy a [template](/templates) into your coding agent to scaffold and deploy, or read one as a step-by-step guide if you're building manually.
 
-These docs explain the platform in detail when you or your agent needs more context.
+These companion docs go deeper on each platform layer when you need more context.
 
 ## Where to start
 
-1. **Set up your environment**: install the Databricks CLI and authenticate against your workspace. The [Databricks CLI](/docs/tools/databricks-cli) page walks you through both.
-2. **Pick a product**: read the overview for context or go straight to the quickstart. Choose from [Web app](/docs/apps/overview), [Database](/docs/lakebase/overview), or [AI agent](/docs/agents/overview).
-3. **Start building**: copy a [template](/templates) into your coding agent to scaffold and deploy.
-
-## How the platform fits together
-
-For the full architecture showing how Apps, AppKit, Lakebase, and Agents relate, see [Platform overview](/docs/platform-overview).
+1. **Set up your environment**: [Install the Databricks CLI](/docs/tools/databricks-cli) to authenticate against your workspace, and install [agent skills](/docs/tools/ai-tools/agent-skills) to give your coding agent Databricks context.
+2. **Pick a product**: read the overview for context or go straight to the quickstart. Choose from [Databricks Apps](/docs/apps/overview), [Lakebase Postgres](/docs/lakebase/overview), or [Agent Bricks](/docs/agents/overview).
+3. **Start building**: copy a [template](/templates) into your coding agent. Each template includes scaffolding, auth wiring, and a deployment step. You don't write any of it.

--- a/docs/tools/ai-tools/agent-skills.md
+++ b/docs/tools/ai-tools/agent-skills.md
@@ -67,14 +67,6 @@ Run `databricks experimental aitools skills list` to see available skills and th
 | `databricks-pipelines`            | Develop Lakeflow Spark Declarative Pipelines (formerly DLT). Large reference set covering streaming tables, materialized views, Auto Loader, Auto CDC, expectations, and sinks. |
 | `databricks-serverless-migration` | Migrate Databricks workloads from classic compute to serverless. Covers compatibility checks, configuration, code patterns, networking, and streaming migration.                |
 
-## Other skill repositories
+## Where to next
 
-- [AI Dev Kit skills](https://github.com/databricks-solutions/ai-dev-kit/tree/main/databricks-skills) -- community patterns for SQL analytics, ML evaluation, model serving, streaming, and Unity Catalog
-- [MLflow skills](https://github.com/mlflow/skills) -- tracing, LLM judges, evals, and production traffic analysis
-
-## Further reading
-
-- [Agent skills (Databricks docs)](https://docs.databricks.com/aws/en/agent-skills/)
-- [AI-assisted development](/docs/appkit/v0/development/ai-assisted-development)
-- [Local bootstrap recipe](/templates/databricks-local-bootstrap)
-- [Docs MCP Server](/docs/tools/ai-tools/docs-mcp-server)
+With Databricks agent skills installed, your coding agent has the context it needs to build and deploy. Browse the [templates catalog](/templates) to start building.

--- a/docs/tools/ai-tools/docs-mcp-server.md
+++ b/docs/tools/ai-tools/docs-mcp-server.md
@@ -58,7 +58,6 @@ After installing, confirm the server is working:
 2. Ask your agent to call `list_docs_resources` and verify it returns a docs index.
 3. Ask your agent to fetch a specific page with `get_doc_resource`.
 
-## Further reading
+## Where to next
 
-- [Model Context Protocol (MCP) on Databricks](https://docs.databricks.com/aws/en/generative-ai/mcp)
-- [Use Databricks managed MCP servers](https://docs.databricks.com/aws/en/generative-ai/mcp/managed-mcp)
+With the docs server running, your agent can fetch any page from this site. See [agent skills](/docs/tools/ai-tools/agent-skills) to also install Databricks platform knowledge, or browse the [templates catalog](/templates) to start building.

--- a/docs/tools/databricks-cli.mdx
+++ b/docs/tools/databricks-cli.mdx
@@ -9,9 +9,11 @@ import TabItem from "@theme/TabItem";
 
 The Databricks CLI is required for every guide on this site. Install it and authenticate before starting any guide.
 
-Command-line tool for workspace operations, app deployment, and automation. For the full command reference, see the [official CLI docs](https://docs.databricks.com/aws/en/dev-tools/cli/). If you start from a [guide](/templates), the CLI is already part of that workflow.
+Command-line tool for workspace operations, app deployment, and automation. This page covers installation and authentication. Product-specific commands (`databricks apps`, `databricks postgres`, `databricks serving-endpoints`) are covered in each product's docs.
 
-## Install
+For the full command reference, see the [official CLI docs](https://docs.databricks.com/aws/en/dev-tools/cli/). If you start from a [guide](/templates), the CLI is already part of that workflow.
+
+## Install or upgrade
 
 DevHub guides assume version `0.296+`.
 
@@ -21,6 +23,8 @@ DevHub guides assume version `0.296+`.
 ```bash
 brew tap databricks/tap
 brew install databricks
+
+brew update && brew upgrade databricks
 ```
 
 </TabItem>
@@ -28,6 +32,8 @@ brew install databricks
 
 ```bash
 winget install Databricks.DatabricksCLI
+
+winget upgrade Databricks.DatabricksCLI
 ```
 
 </TabItem>
@@ -37,7 +43,7 @@ winget install Databricks.DatabricksCLI
 curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh
 ```
 
-On Windows, use WSL. If `/usr/local/bin` is not writable, rerun with `sudo`.
+On Windows, use WSL. If `/usr/local/bin` is not writable, rerun with `sudo`. Re-running the script also upgrades an existing install.
 
 </TabItem>
 </Tabs>
@@ -66,22 +72,23 @@ List saved profiles:
 databricks auth profiles
 ```
 
+```text
+Name              Host                                             Valid
+DEFAULT           https://adb-1234567890.12.azuredatabricks.net    YES
+my-prod-workspace https://mycompany.cloud.databricks.com           YES
+```
+
+**Name** is the profile label, **Host** is the workspace URL, and **Valid** is the result of a live authentication check against the workspace. `NO` means the check failed; re-run `databricks auth login --profile <NAME>` to re-authenticate.
+
 For CI/CD, use OAuth client credentials or token-based auth (no browser step). See [CLI authentication](https://docs.databricks.com/aws/en/dev-tools/cli/authentication).
 
-## Data exploration
+## Product commands
 
-The `experimental aitools` commands give AI coding assistants direct access to your workspace, including table discovery and ad-hoc SQL without manual warehouse setup. Some subcommands use positional arguments instead of flags. Check `--help` for the exact syntax.
+Product-specific CLI commands are covered alongside each product:
 
-```bash
-# Schema discovery
-databricks experimental aitools tools discover-schema <CATALOG>.<SCHEMA>.<TABLE> --profile <PROFILE>
-
-# Ad-hoc SQL
-databricks experimental aitools tools query "SELECT * FROM <CATALOG>.<SCHEMA>.<TABLE> LIMIT 10" --profile <PROFILE>
-
-# Warehouse lookup
-databricks experimental aitools tools get-default-warehouse --profile <PROFILE>
-```
+- `databricks apps`: [Apps development](/docs/apps/development)
+- `databricks postgres`: [Lakebase development](/docs/lakebase/development)
+- `databricks serving-endpoints`: [AI Gateway](/docs/agents/ai-gateway)
 
 ## Agent skills
 
@@ -92,3 +99,7 @@ databricks experimental aitools install
 ```
 
 By default, skills install globally. Pass `--project` to install into the current project instead. See the [agent skills page](/docs/tools/ai-tools/agent-skills) for all options.
+
+## Where to next
+
+With the CLI installed and authenticated, pick a [template](/templates) to start building.


### PR DESCRIPTION
Updated the four entry-point pages (Start here, Platform overview, Databricks CLI, Agent skills) to match the tone and structure of the recently updated product sections. 

Standardized doc pages to end with a "Where to next" section with concise next-step pointers.

And other improvements along the way.