### PR TITLE
fix(docs): allow long content in table cells to wrap

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1216,3 +1216,15 @@
     }
   }
 }
+
+/* Override Infima's `table { display: block }` so columns fill the container.
+ * Unlayered to beat Infima's @layer docusaurus.infima rule. */
+.db-docs-article .theme-doc-markdown table {
+  display: table;
+}
+
+/* Let long paths/URLs in cells break when they'd overflow the column. */
+.db-docs-article .theme-doc-markdown td code,
+.db-docs-article .theme-doc-markdown th code {
+  overflow-wrap: break-word;
+}

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -266,7 +266,7 @@ function Th({ className, ...props }: ComponentPropsWithoutRef<"th">) {
   return (
     <th
       className={cn(
-        "whitespace-nowrap px-3 py-2 text-left align-top text-xs uppercase tracking-wide text-db-navy/80 last:w-full last:whitespace-normal dark:text-white/90",
+        "px-3 py-2 text-left align-top text-xs uppercase tracking-wide text-db-navy/80 dark:text-white/90",
         className,
       )}
       {...props}
@@ -278,7 +278,7 @@ function Td({ className, ...props }: ComponentPropsWithoutRef<"td">) {
   return (
     <td
       className={cn(
-        "whitespace-nowrap px-3 py-2.5 align-top last:w-full last:whitespace-normal text-db-navy/85 dark:text-white/85",
+        "px-3 py-2.5 align-top text-db-navy/85 dark:text-white/85",
         className,
       )}
       {...props}


### PR DESCRIPTION
Long content in a non-last cell (e.g. a resource path in a Description column) couldn't wrap, forcing the column to its full unbreakable width and pushing later columns past the container edge. This cut off content in the trailing column (e.g. "Sourc" instead of "Source").
- Drop `whitespace-nowrap` and the `last:w-full last:whitespace-normal` workaround from `Td`/`Th` so all cells wrap, not just the last one.
- Set `display: table` (unlayered, to beat Infima's @layer docusaurus.infima `display: block`) so width is distributed naturally across columns once they can wrap.
- Add `overflow-wrap: break-word` to inline code in cells so unbreakable strings like paths or URLs can break at character boundaries when they'd otherwise overflow their column.