### PR TITLE
docs: refine onboarding docs for building internal apps

### DIFF
--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -8,7 +8,7 @@ description: Databricks Apps hosts web applications inside your workspace with b
 
 Databricks Apps hosts your web app inside your workspace. It gets a fixed URL, built-in OAuth, and direct access to your workspace data and services. No separate hosting service, no auth layer to build, no credential rotation to manage.
 
-**AppKit** is the TypeScript SDK for building those apps. It provides pre-built React UI components, type-safe data access, and a plugin system for connecting to Databricks services.
+**[AppKit](/docs/appkit/v0)** is the TypeScript SDK for building those apps. It provides pre-built React UI components, type-safe data access, and a plugin system for connecting to Databricks services.
 
 ## How it works
 
@@ -29,18 +29,19 @@ AppKit uses a three-layer architecture with plugins that register capabilities a
 
 ## How auth works
 
-Every app gets a dedicated service principal. Databricks injects its credentials at runtime, so your app can call workspace APIs without managing tokens. By default, all requests run as this service principal and all users share its permissions. When you need per-user data access, Databricks can forward the signed-in user's token via `x-forwarded-access-token`. AppKit's built-in [Genie](/docs/agents/genie) and [Model Serving](/docs/agents/ai-gateway) plugins handle this automatically.
+Every app gets a dedicated service principal. Databricks injects its credentials at runtime, so your app can call workspace APIs without managing tokens.
+
+By default, all requests run as this service principal and all users share its permissions. When you need per-user data access, Databricks can forward the signed-in user's token via `x-forwarded-access-token`. AppKit's built-in [Genie](/docs/agents/genie) and [Model Serving](/docs/agents/ai-gateway) plugins handle this automatically.
 
 ## When to use it
 
-- You're building a web app, internal tool, or API that reads or writes Databricks data.
-- You want auth handled by the platform, without building login flows, token rotation, or session management.
-- You're deploying an AI agent (agents run as Apps).
+Apps are about **interactivity**, not only analytics. A dashboard is great for read-only views with pre-canned filters; an app does that plus accepts input, runs logic, and persists results. Build an app when your workflow needs any of those, for example a scenario builder that saves user-created cases, or an internal tool replacing a manual spreadsheet process.
 
 ## When not to use it
 
-- Your app is a static site with no Databricks data access.
-- You're serving users outside your Databricks account (for example, public-facing apps or customers without Databricks access).
+- **Static sites with no Databricks data access.** Host these anywhere.
+- **Public-facing or customer-facing apps.** Users have to be authenticated as identities in your Databricks account, so anyone outside your enterprise directory can't sign in.
+- **Pure read-only dashboards** that AI/BI [Dashboards](https://docs.databricks.com/aws/en/dashboards/) already cover. Use a dashboard until you need to persist user input or run custom logic on top of it.
 
 ## Where to next
 

--- a/docs/apps/quickstart.md
+++ b/docs/apps/quickstart.md
@@ -8,13 +8,23 @@ title: Quickstart
 
 - Databricks CLI `v0.296+` with an [authenticated profile](/docs/tools/databricks-cli#authenticate)
 - Node.js 22+ (AppKit apps are Node/TypeScript)
-- Workspace with Apps enabled
+- Databricks workspace with Apps enabled
 
 ## Template path
 
-[Templates](/templates) are agent-ready prompts organized by use case, including templates for [Lakebase Postgres](/docs/lakebase/quickstart), [Genie spaces](/docs/agents/genie), [AI Gateway](/docs/agents/ai-gateway), [Agent Bricks](/docs/agents/overview), and more. Browse them, pick one that fits, and copy it into your AI coding assistant. The assistant handles scaffolding, plugin selection, and deployment.
+[Templates](/templates) are agent-ready prompts organized by use case. Pick one that fits, copy it into your AI coding assistant, and the assistant handles scaffolding, plugin selection, and deployment.
 
-For richer CLI and workspace context, install the Databricks agent skills first:
+Common starting points:
+
+| Template                                          | Best for                                   |
+| ------------------------------------------------- | ------------------------------------------ |
+| [Hello World App](/templates/hello-world-app)     | Simple apps, static pages, getting started |
+| [AI Chat App](/templates/ai-chat-app)             | Conversational AI, chatbots, assistants    |
+| [App with Lakebase](/templates/app-with-lakebase) | CRUD apps with persistent storage          |
+
+The [templates catalog](/templates) has the full list, including [Lakebase Postgres](/docs/lakebase/quickstart), [Genie spaces](/docs/agents/genie), [AI Gateway](/docs/agents/ai-gateway), and [Agent Bricks](/docs/agents/overview).
+
+Give your AI assistant Databricks platform context by installing the [agent skills](/docs/tools/ai-tools/agent-skills) before copying in the template:
 
 ```bash
 databricks experimental aitools install
@@ -22,7 +32,7 @@ databricks experimental aitools install
 
 ## Manual path
 
-When you scaffold without a template, `databricks apps init` generates a working AppKit project. Here is what the output looks like (you don't write this yourself):
+Without a template, `databricks apps init` generates a working AppKit project. Here is what `--features lakebase` produces (you don't write this yourself):
 
 ```typescript
 import { createApp, server, lakebase } from "@databricks/appkit";
@@ -46,6 +56,8 @@ databricks apps init --name my-app --features lakebase   # generates the project
 cd my-app && npm install && npm run dev                  # runs locally
 databricks apps deploy                                   # deploys to your workspace
 ```
+
+After deploy, the CLI prints your app's workspace URL.
 
 To scaffold with specific plugins, pass `--features` with a comma-separated list. Run `databricks apps manifest` to see all available plugins and their required resource fields.
 

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -5,32 +5,22 @@ description: How Databricks Apps, AppKit, Lakebase, and Agent Bricks fit togethe
 
 # Platform overview
 
-Apps, AppKit, Lakebase Postgres, and Agent Bricks are four layers that make up a full-stack Databricks application. Unity Catalog and AI Gateway are workspace services they connect to.
+Apps, AppKit, Lakebase Postgres, and Agent Bricks are layers of a full-stack Databricks application running inside your workspace. New to building on Databricks? See [Start here](/docs/start-here) first.
 
 <img src="/img/docs/platform-overview.svg" alt="Architecture diagram showing Apps containing AppKit, Lakebase, and Agents, with Unity Catalog and AI Gateway as workspace services" width="100%" />
 
-| Layer                 | What it is                                                                                                                                                                                      |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Apps**              | The hosting layer. Your app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.                                    |
-| **AppKit**            | The TypeScript SDK for building apps on Databricks Apps. Provides auth, pre-built React UI components (data tables, charts, dialogs), and a plugin system for connecting to workspace services. |
-| **Lakebase Postgres** | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments.             |
-| **Agent Bricks**      | The AI layer. Call Knowledge Assistants, Supervisor Agents, and governed LLM endpoints via the Model Serving plugin. Query Unity Catalog tables in natural language via the Genie plugin.       |
+| Layer                 | What it is                                                                                                                                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Apps**              | The hosting layer. Your app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.                                                         |
+| **AppKit**            | The TypeScript SDK for building apps on Databricks Apps. Built-in Databricks OAuth handling, pre-built React UI components (data tables, charts, dialogs), and a plugin system for connecting to workspace services. |
+| **Lakebase Postgres** | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments.                                  |
+| **Agent Bricks**      | The AI layer. Call Knowledge Assistants, Supervisor Agents, and governed LLM endpoints via the Model Serving plugin. Query Unity Catalog tables in natural language via the Genie plugin.                            |
 
 **[Unity Catalog](https://docs.databricks.com/aws/en/data-governance/)** and **[AI Gateway](/docs/agents/ai-gateway)** are workspace-level services your app connects to for data governance and model serving.
 
-## Pick a template
+## How a request flows
 
-Templates are agent-ready prompts organized by use case. Here are a few common starting points. The [templates catalog](/templates) has the full list.
-
-All templates assume the [Databricks CLI](/docs/tools/databricks-cli) is installed and [authenticated](/docs/tools/databricks-cli#authenticate) against your workspace.
-
-| Resource                                          | Type     | Best for                                   |
-| ------------------------------------------------- | -------- | ------------------------------------------ |
-| [Hello World App](/templates/hello-world-app)     | Template | Simple apps, static pages, getting started |
-| [AI Chat App](/templates/ai-chat-app)             | Template | Conversational AI, chatbots, assistants    |
-| [App with Lakebase](/templates/app-with-lakebase) | Template | CRUD apps with persistent storage          |
-
-More templates are in the [templates catalog](/templates).
+A user opens the app, and Databricks Apps authenticates them via workspace SSO. The relevant AppKit plugin then queries Lakebase, a Genie space, or a serving endpoint on their behalf, using either the app's service principal or the user's forwarded token.
 
 ## Where to next
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,26 +1,27 @@
 ---
 title: Start here
-description: Build web apps, databases, and AI agents inside your Databricks workspace with Databricks Apps, Lakebase Postgres, and Agent Bricks.
+description: Build internal apps on the Databricks workspace your company already runs on. DevHub provides templates, the AppKit SDK, and companion docs.
 ---
 
 # Start here
 
-Build web apps, databases, and AI agents that run inside your Databricks workspace. DevHub provides the templates, SDKs, and companion docs to do it.
+This site is for building internal apps on Databricks. Pick a template, scaffold with [AppKit](/docs/appkit/v0), deploy, and iterate.
 
-## What you can build
+## Your workspace is the foundation
 
-- **Databricks Apps**: host your web app inside your workspace with a fixed URL, built-in auth, and direct data access. Build the frontend and backend with AppKit, an open-source Node.js and React SDK.
-- **Lakebase Postgres**: managed Postgres co-located with your workspace, with instant branching and scale-to-zero for development and production.
-- **Agent Bricks**: Databricks' agent platform. Build with Knowledge Assistants, governed model endpoints, and Genie spaces. Agents are hosted on Databricks Apps.
+Your company already has a **Databricks workspace**: a URL like `https://<your-org>.cloud.databricks.com` your team signs in to. For the internal app you're about to build, it determines **who** can sign in, **what** data the app can read or write (Unity Catalog tables and Lakebase Postgres), and **where** the app runs. Hosting, auth, and networking are handled for you. From your local machine, you connect to it with the [Databricks CLI](/docs/tools/databricks-cli).
 
-## Templates
+## What you'll build
 
-Templates are agent-ready prompts organized by use case. Copy a [template](/templates) into your coding agent to scaffold and deploy, or read one as a step-by-step guide if you're building manually.
+- **[Databricks Apps](/docs/apps/overview)**: where your internal app runs. Built for interactive internal tools, not static dashboards. Managed hosting and workspace SSO. Build it with [AppKit](/docs/appkit/v0), the open-source TypeScript SDK that wires up auth, plugins, and pre-built React components.
+- **[Lakebase Postgres](/docs/lakebase/overview)**: managed Postgres for OLTP storage co-located with your workspace data. Use it for sessions, app state, conversation history, or any data your app reads and writes at low latency.
+- **[Agent Bricks](/docs/agents/overview)**: Databricks' enterprise agent platform, unifying model access, execution, governance, and context. Use it for AI features in your app: chat with internal docs (Knowledge Assistants), ask-your-data in plain English (Genie), foundation-model calls, or custom Python agents.
 
-These companion docs go deeper on each platform layer when you need more context.
+See [Platform overview](/docs/platform-overview) for how these layers fit together.
 
 ## Where to start
 
-1. **Set up your environment**: [Install the Databricks CLI](/docs/tools/databricks-cli) to authenticate against your workspace, and install [agent skills](/docs/tools/ai-tools/agent-skills) to give your coding agent Databricks context.
-2. **Pick a product**: read the overview for context or go straight to the quickstart. Choose from [Databricks Apps](/docs/apps/overview), [Lakebase Postgres](/docs/lakebase/overview), or [Agent Bricks](/docs/agents/overview).
-3. **Start building**: copy a [template](/templates) into your coding agent. Each template includes scaffolding, auth wiring, and a deployment step. You don't write any of it.
+1. **Note your workspace URL** (looks like `https://<id>.cloud.databricks.com`).
+2. **Install and authenticate the [Databricks CLI](/docs/tools/databricks-cli).** Required for every guide on this site.
+3. **Install [agent skills](/docs/tools/ai-tools/agent-skills)** so your coding agent has Databricks platform context.
+4. **Pick a [template](/templates)** that matches your internal app. Browse [Apps overview](/docs/apps/overview) first if you want the conceptual picture.

--- a/tests/e2e/copy-markdown.spec.ts
+++ b/tests/e2e/copy-markdown.spec.ts
@@ -264,7 +264,7 @@ test.describe("copy markdown exports raw markdown on docs pages", () => {
     expect(copied).not.toContain("# About DevHub");
     expect(copied).not.toContain("/llms.txt");
     expect(copied).toContain("# Start here");
-    expect(copied).toContain("## Templates");
+    expect(copied).toContain("## Where to start");
   });
 
   test("raw-docs static files are served", async ({ request }) => {


### PR DESCRIPTION
Refines the onboarding path for developers new to Databricks who are building their first internal app. Tightens the entry page so the workspace foundation, what you'll build, and the first steps are clear.