### PR TITLE
fix(solutions): open external linked solutions in a new tab

### DIFF
--- a/src/pages/solutions/index.tsx
+++ b/src/pages/solutions/index.tsx
@@ -92,9 +92,10 @@ function LinkedSolutionCard({
   return (
     <a
       href={solution.url}
+      target="_blank"
       rel="noopener noreferrer"
       className="no-underline"
-      aria-label={`${solution.title} on ${solution.source}`}
+      aria-label={`${solution.title} on ${solution.source} (opens in new tab)`}
     >
       <Card className={cardClasses}>
         <div className="relative aspect-[1.91/1] overflow-hidden border-b border-black/10 bg-[#f1ede4] dark:border-white/10 dark:bg-[#0f1c22]">


### PR DESCRIPTION
## Summary

- Linked solutions on `/solutions` point to off-site articles (e.g. the Databricks Blog). Opening them in the same tab made users navigate away from DevHub and lose their place.
- Add `target="_blank"` (alongside the existing `rel="noopener noreferrer"`) to the linked solution card so external solutions open in a new tab.
- Update the `aria-label` to announce "(opens in new tab)" for screen reader users.
- Native solutions (which live on DevHub) are unchanged and still open in the same tab.

## Test plan

- [x] `npm run fmt`
- [x] `npm run typecheck`
- [x] `npm run build` (via pre-commit hook)
- [x] `npx vitest run tests/solutions.test.ts`
- [ ] Visually verify on `/solutions` that linked cards open in a new tab and native cards still open in the same tab