### PR TITLE
docs: add Data Lakehouse docs section

### DIFF
--- a/content/recipes/medallion-architecture-from-cdc/content.md
+++ b/content/recipes/medallion-architecture-from-cdc/content.md
@@ -202,3 +202,4 @@ For implementing each layer, the following Databricks agent skills provide detai
 - [Lakeflow Declarative Pipelines](https://docs.databricks.com/aws/en/delta-live-tables/)
 - [Materialized views](https://docs.databricks.com/aws/en/delta-live-tables/materialized-views)
 - [Lakehouse Sync](https://docs.databricks.com/aws/en/oltp/projects/lakehouse-sync)
+- [DevHub: Pipelines and freshness](/docs/lakehouse/pipelines)

--- a/content/recipes/sync-tables-autoscaling/content.md
+++ b/content/recipes/sync-tables-autoscaling/content.md
@@ -147,3 +147,4 @@ Example costs (181M rows, 1 CU, $2.80/hr DLT rate):
 - [Synced tables (Autoscaling)](https://docs.databricks.com/aws/en/oltp/projects/sync-tables)
 - [Change Data Feed](https://docs.databricks.com/aws/en/delta/delta-change-data-feed)
 - [Lakebase Autoscaling](https://docs.databricks.com/aws/en/oltp/projects/)
+- [DevHub: Data Lakehouse overview](/docs/lakehouse/overview)

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -18,14 +18,14 @@ AppKit uses a three-layer architecture with plugins that register capabilities a
 - **Server**: Express HTTP server with Databricks OAuth built in. Plugins attach routes and middleware at this layer.
 - **Data**: Plugin-based access to Databricks resources. Each plugin wraps a resource type and exposes a typed API on the `AppKit` object.
 
-| Plugin                                             | What it adds                                                                                                                 |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| [**server**](/docs/appkit/v0/plugins/server)       | Express HTTP server, static file serving, Vite dev mode (always included)                                                    |
-| [**lakebase**](/docs/appkit/v0/plugins/lakebase)   | Postgres connection pool for [Lakebase Postgres](/docs/lakebase/quickstart) with automatic OAuth token refresh               |
-| [**analytics**](/docs/appkit/v0/plugins/analytics) | SQL query execution against [Databricks SQL Warehouses](https://docs.databricks.com/aws/en/compute/sql-warehouse/index.html) |
-| [**genie**](/docs/appkit/v0/plugins/genie)         | [Genie space](/docs/agents/genie) integration for natural-language data queries                                              |
-| [**serving**](/docs/appkit/v0/plugins/serving)     | Authenticated proxy to [Model Serving](/docs/agents/ai-gateway) endpoints with streaming support                             |
-| [**files**](/docs/appkit/v0/plugins/files)         | File operations against [Unity Catalog Volumes](https://docs.databricks.com/aws/en/files/index.html)                         |
+| Plugin                                             | What it adds                                                                                                                                                                            |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**server**](/docs/appkit/v0/plugins/server)       | Express HTTP server, static file serving, Vite dev mode (always included)                                                                                                               |
+| [**lakebase**](/docs/appkit/v0/plugins/lakebase)   | Postgres connection pool for [Lakebase Postgres](/docs/lakebase/quickstart) with automatic OAuth token refresh                                                                          |
+| [**analytics**](/docs/appkit/v0/plugins/analytics) | SQL query execution against [Databricks SQL Warehouses](https://docs.databricks.com/aws/en/compute/sql-warehouse/index.html). See [Analytical reads](/docs/lakehouse/analytical-reads). |
+| [**genie**](/docs/appkit/v0/plugins/genie)         | [Genie space](/docs/agents/genie) integration for natural-language data queries                                                                                                         |
+| [**serving**](/docs/appkit/v0/plugins/serving)     | Authenticated proxy to [Model Serving](/docs/agents/ai-gateway) endpoints with streaming support                                                                                        |
+| [**files**](/docs/appkit/v0/plugins/files)         | File operations against [Unity Catalog Volumes](https://docs.databricks.com/aws/en/files/index.html)                                                                                    |
 
 ## How auth works
 

--- a/docs/lakebase/overview.md
+++ b/docs/lakebase/overview.md
@@ -42,7 +42,7 @@ The plugin handles OAuth token refresh and connection pooling automatically. Whe
 - Your app needs low-latency reads and writes: user state, sessions, conversation history, or transactional records.
 - You're building AI agents that need persistent memory: conversation history, workflow state, or tool results across requests.
 - You want isolated database branches for feature development or CI testing.
-- You're syncing data between your OLTP workload and the Lakehouse via change data capture.
+- You're syncing data between your OLTP workload and the [Data Lakehouse](/docs/lakehouse/overview) via change data capture.
 
 ## When not to use it
 

--- a/docs/lakehouse/analytical-reads.md
+++ b/docs/lakehouse/analytical-reads.md
@@ -1,0 +1,134 @@
+---
+title: Read Unity Catalog tables
+sidebar_label: Analytical reads
+description: Read governed Unity Catalog tables from your AppKit app with the Analytics plugin. SQL files, on-behalf-of-user queries, SQL warehouse resource binding.
+---
+
+# Read Unity Catalog tables
+
+To run analytical queries against tables in Databricks from your AppKit app, you need a SQL warehouse (Databricks's SQL compute). The [Analytics plugin](/docs/appkit/v0/plugins/analytics) wires your handler to one: SQL files go in `config/queries/`, the warehouse executes them, and typed rows come back. Your handler does not check permissions.
+
+The tables the warehouse queries are governed by Unity Catalog (UC). UC owns the three-level namespace (`catalog.schema.object`) and applies grants, row filters, column masks, and ABAC (attribute-based access control) policies on every access. Beyond tables, UC also governs views, materialized views, volumes, models, vector search indexes, and registered functions.
+
+## Prerequisites
+
+- Databricks CLI `v0.296+` with an [authenticated profile](/docs/tools/databricks-cli#authenticate).
+- A running AppKit app. See [Apps quickstart](/docs/apps/quickstart).
+- A SQL warehouse declared as an app resource in `databricks.yml`. Your app's service principal gets `CAN_USE` automatically when you bind the resource. End-user permissions are covered [below](#where-403s-come-from).
+
+## What the Analytics plugin reads
+
+All UC objects sit in a `catalog.schema.object` namespace. The objects this plugin queries:
+
+- **Tables** (Delta and Iceberg).
+- **Views** and **materialized views**.
+- **Streaming tables**.
+- **Functions** called as `SELECT my_catalog.my_schema.my_function(...)`.
+
+Other UC objects use other plugins. Volumes (file storage) go through the [Files plugin](/docs/appkit/v0/plugins/files). The full UC object list lives in [Securable objects](https://docs.databricks.com/aws/en/data-governance/unity-catalog/securable-objects).
+
+## Wire the Analytics plugin
+
+Register the plugin in `createApp`. It exposes Analytics endpoints and reads queries from `config/queries/` against the SQL warehouse you bind in `app.yaml`.
+
+```typescript title="server/server.ts"
+import { createApp, server, analytics } from "@databricks/appkit";
+
+await createApp({
+  plugins: [server(), analytics({})],
+});
+```
+
+Bind the SQL warehouse in `app.yaml` so the platform sets `DATABRICKS_WAREHOUSE_ID` at startup:
+
+```yaml title="app.yaml"
+env:
+  - name: DATABRICKS_WAREHOUSE_ID
+    valueFrom: sql-warehouse
+```
+
+The matching resource lives in `databricks.yml`. See [App configuration](/docs/apps/configuration#resources) for the full resource list and `valueFrom` keys.
+
+## Author SQL files
+
+Put `.sql` files in `config/queries/`. The filename without `.sql` becomes the query key.
+
+```sql title="config/queries/spend_summary.sql"
+-- @param startDate DATE
+-- @param endDate DATE
+SELECT date_trunc('day', usage_date) AS day, SUM(usage_quantity) AS qty
+FROM system.billing.usage
+WHERE usage_date BETWEEN :startDate AND :endDate
+GROUP BY 1
+ORDER BY 1;
+```
+
+The execution context is set by the filename:
+
+- `spend_summary.sql` runs as the **app service principal**. The cache is shared across users.
+- `spend_summary.obo.sql` runs as the **signed-in user**. The cache is per-user. Unity Catalog applies that user's grants, row filters, column masks, and ABAC policies.
+
+For the full plugin API, including parameter types and Arrow streaming, see the [Analytics plugin reference](/docs/appkit/v0/plugins/analytics).
+
+## Render in React with `useAnalyticsQuery`
+
+```tsx title="client/src/SpendTable.tsx"
+import { useMemo } from "react";
+import { useAnalyticsQuery } from "@databricks/appkit-ui/react";
+import { sql } from "@databricks/appkit-ui/js";
+
+export function SpendTable() {
+  const params = useMemo(
+    () => ({
+      startDate: sql.date("2025-01-01"),
+      endDate: sql.date("2025-12-31"),
+    }),
+    [],
+  );
+
+  const { data, loading, error } = useAnalyticsQuery("spend_summary", params);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>{error}</p>;
+  return (
+    <ul>
+      {data?.map((row) => (
+        <li key={row.day}>
+          {row.day}: {row.qty}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+:::important[Wrap parameters in useMemo]
+
+`useAnalyticsQuery` refetches whenever its parameters reference changes. An inline object creates a new reference on every render, which loops forever. Wrap parameters in `useMemo`.
+
+:::
+
+## Where 403s come from
+
+The identity attached to each query is set by the filename:
+
+- **Service principal queries** (`*.sql`) use the app's service principal. The SP needs `SELECT` on the underlying tables. Permission errors return `403` from the warehouse.
+- **On-behalf-of-user queries** (`*.obo.sql`) use the signed-in user. UC applies their grants automatically. If the user lacks `SELECT`, or if a row filter or column mask hides the data, the call returns a `403` or fewer rows. You don't write the permission check.
+
+:::note[OBO is in Public Preview]
+
+On-behalf-of-user authorization is in Public Preview. A workspace admin must enable it before scopes can be added to your app. See [App authorization](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/auth) for the platform details.
+
+:::
+
+## Lakehouse Federation
+
+Lakehouse Federation makes foreign sources (Snowflake, BigQuery, Oracle, Redshift) appear as UC catalogs. Once registered, they look like any other UC table to the Analytics plugin: same `catalog.schema.table` reference, same SQL file, same OBO. The warehouse pushes filters and aggregates down to the foreign source where possible, and reads remaining data at query time without persisting it in UC. See [Lakehouse Federation](https://docs.databricks.com/aws/en/query-federation/) for the source list, setup, and per-source pushdown coverage.
+
+## Natural-language queries
+
+For natural-language Q&A over UC tables (curated datasets plus a knowledge store plus a compound AI system that turns questions into SQL), use [Genie](/docs/agents/genie). For a working setup, see the [Genie Conversational Analytics](/templates/genie-conversational-analytics) template. The Genie plugin lives in the Agent Bricks section because it is an agent integration, not a SQL one.
+
+## Where to next
+
+Try [Set Up Unity Catalog with External Storage](/templates/unity-catalog-setup) to provision a catalog, or [Volume File Manager](/templates/volume-file-upload) to add UC Volumes to your app. Then explore [Lakeflow Jobs](/docs/lakehouse/jobs) for triggering work, or [Pipelines and freshness](/docs/lakehouse/pipelines) for "last updated" signals.

--- a/docs/lakehouse/jobs.md
+++ b/docs/lakehouse/jobs.md
@@ -1,0 +1,151 @@
+---
+title: Lakeflow Jobs
+sidebar_label: Lakeflow Jobs
+description: Trigger and monitor Lakeflow Jobs from your AppKit app with the Jobs plugin. Permissions, `runNow` versus `runAndWait`, polling versus webhooks.
+---
+
+# Lakeflow Jobs
+
+To offload work that's too slow or too heavy for a request handler, you need a Lakeflow Job, which is Databricks's managed runner for notebooks, SQL, dbt, and Python wheel tasks. Typical work triggered by a user action: model retraining, multi-task ETL, or a long SQL backfill. The [Jobs plugin](/docs/appkit/v0/plugins/jobs) wires your handler to a job: declare it in `databricks.yml`, then call `AppKit.jobs("etl").runNow(params)` to trigger a run or iterate `runAndWait` for streaming progress.
+
+Authoring jobs is a workspace task done in Databricks or with [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/). From an AppKit app, you only trigger them. The plugin handles run polling, SSE (Server-Sent Events) streaming, and parameter validation with Zod.
+
+## Prerequisites
+
+- Databricks CLI `v0.296+` with an [authenticated profile](/docs/tools/databricks-cli#authenticate).
+- A running AppKit app. See [Apps quickstart](/docs/apps/quickstart).
+- A Lakeflow Job defined in your workspace. See [Create your first job](https://docs.databricks.com/aws/en/jobs/) for setup.
+
+## Wire the Jobs plugin
+
+Register the plugin in `createApp`. It exposes `AppKit.jobs(...)` to your handlers and reads job IDs from env vars you bind in `app.yaml`.
+
+```typescript title="server/server.ts"
+import { createApp, server, jobs } from "@databricks/appkit";
+
+await createApp({
+  plugins: [server(), jobs()],
+});
+```
+
+With no explicit `jobs` config, the plugin reads `DATABRICKS_JOB_ID` from the environment and registers it under the `default` key. For multiple jobs in one app, pass a `jobs` config to the plugin (as part of `createApp`'s `plugins` array):
+
+```typescript
+jobs({
+  jobs: {
+    etl: { taskType: "notebook" },
+    refresh: { taskType: "sql" },
+  },
+}),
+```
+
+## Bind the job
+
+Declare the job as a resource in `databricks.yml`. The Apps platform grants your service principal `CAN_MANAGE_RUN` automatically when you deploy:
+
+```yaml title="databricks.yml"
+resources:
+  apps:
+    my-app:
+      resources:
+        - name: etl-job
+          job:
+            id: ${var.etl_job_id}
+            permission: CAN_MANAGE_RUN
+```
+
+Inject the job ID into `app.yaml`:
+
+```yaml title="app.yaml"
+env:
+  - name: DATABRICKS_JOB_ETL
+    valueFrom: etl-job
+```
+
+Single-job apps can use the default env var name `DATABRICKS_JOB_ID`. The plugin uppercases env var names and lowercases job keys. See [App configuration](/docs/apps/configuration#resources) for the full resource list and the [Jobs plugin reference](/docs/appkit/v0/plugins/jobs) for the multi-job lookup rules.
+
+## Trigger from a route handler
+
+Use `runNow` for a one-shot trigger. Wrap the parameters in a Zod schema and the plugin rejects invalid input with a `400` before the SDK call.
+
+```typescript title="server/server.ts"
+import { createApp, server, jobs } from "@databricks/appkit";
+import { z } from "zod";
+
+const AppKit = await createApp({
+  plugins: [
+    server(),
+    jobs({
+      jobs: {
+        etl: {
+          taskType: "notebook",
+          params: z.object({
+            startDate: z.string(),
+            endDate: z.string(),
+          }),
+        },
+      },
+    }),
+  ],
+});
+
+AppKit.server.extend((app) => {
+  app.post("/api/etl/run", async (req, res) => {
+    const result = await AppKit.jobs("etl").runNow({
+      startDate: req.body.startDate,
+      endDate: req.body.endDate,
+    });
+    if (!result.ok) return res.status(500).json({ error: result.error });
+    res.json({ runId: result.data.run_id });
+  });
+});
+```
+
+All Jobs plugin methods return [`ExecutionResult<T>`](/docs/appkit/v0/api/appkit/TypeAlias.ExecutionResult). Check `result.ok` before reading `result.data`.
+
+For per-user execution, call `.asUser(req)` explicitly. OBO requires the appropriate user API scope in the app's `databricks.yml` (see the [Jobs plugin reference](/docs/appkit/v0/plugins/jobs)) and the user's own `CAN_MANAGE_RUN` grant on the job:
+
+```typescript
+const result = await AppKit.jobs("etl")
+  .asUser(req)
+  .runNow({ startDate, endDate });
+```
+
+## Stream live progress
+
+The plugin exposes a built-in SSE endpoint at `POST /api/jobs/:jobKey/run?stream=true`. Each event delivers `{ status, timestamp, run }` until the run terminates.
+
+For server logic, iterate `runAndWait` directly. It is an async iterator, not a promise:
+
+```typescript
+for await (const status of AppKit.jobs("etl").runAndWait({
+  startDate,
+  endDate,
+})) {
+  // status.status cycles through PENDING, RUNNING, TERMINATED, etc.
+}
+```
+
+The full hook API and pagination helpers live in the [Jobs plugin reference](/docs/appkit/v0/plugins/jobs).
+
+## Permissions
+
+| Permission       | What it lets your principal do                      |
+| ---------------- | --------------------------------------------------- |
+| `CAN_VIEW`       | Read the job definition and run history.            |
+| `CAN_MANAGE_RUN` | Trigger runs, cancel runs, view run output.         |
+| `CAN_MANAGE`     | Modify the job definition. Not used by AppKit apps. |
+
+Set `permission: CAN_MANAGE_RUN` on the job resource binding. That is the least-privilege grant for an app that only triggers existing jobs and reads their state.
+
+## Polling versus webhooks versus system tables
+
+Pick the pattern that fits the run length and your UI:
+
+- **The plugin's built-in run-and-wait endpoint** works well when the user is willing to wait at the page. The browser holds an SSE connection while the plugin polls the SDK every few seconds (default 5s, up to a 10-minute timeout).
+- **Webhook notifications** are a good fit when the user closes the tab and you need the result later. Configure `webhook_notifications.on_success` / `on_failure` destinations, write the run state somewhere durable (Lakebase is convenient if your app already uses it), and stream updates to the client when they reload.
+- **`system.lakeflow.job_run_timeline`** is queryable through the [Analytics plugin](/docs/appkit/v0/plugins/analytics) once your service principal has `SELECT` on it. Useful for run-history dashboards or cross-job analytics.
+
+## Where to next
+
+See [Pipelines and freshness](/docs/lakehouse/pipelines) for the read side: showing "last updated" timestamps next to data a job populated, or browse the [templates catalog](/templates) for related starting points.

--- a/docs/lakehouse/overview.md
+++ b/docs/lakehouse/overview.md
@@ -1,0 +1,40 @@
+---
+title: What is the Data Lakehouse?
+sidebar_label: Overview
+description: The data tier of the Databricks Data Intelligence Platform. Governed analytical tables in Unity Catalog, populated by Lakeflow. Companion docs for AppKit apps.
+---
+
+# What is the Data Lakehouse?
+
+The Data Lakehouse is the analytical tier of your Databricks workspace: tables and views governed by Unity Catalog and populated by Lakeflow. Lakeflow is Databricks's data engineering family, covering ingestion, pipelines, and jobs. From an AppKit app, you read its tables, trigger Lakeflow Jobs, and show "last updated" timestamps from the pipelines that populated them.
+
+The [Analytics plugin](/docs/appkit/v0/plugins/analytics) handles SQL warehouse reads (see [Analytical reads](/docs/lakehouse/analytical-reads) and [Pipelines and freshness](/docs/lakehouse/pipelines)). The [Jobs plugin](/docs/appkit/v0/plugins/jobs) handles run triggering and progress (see [Lakeflow Jobs](/docs/lakehouse/jobs)).
+
+## When to use the Data Lakehouse
+
+- You need to read curated analytical data: revenue, customers, events, model outputs.
+- You display dashboard-style aggregates or list views over millions of rows.
+- You trigger model retraining, ETL, or a long backfill asynchronously from a user action.
+
+## When not to use it
+
+- **Sub-second reads on a user request**, like typeahead or autocomplete. Use [Lakebase Postgres](/docs/lakebase/overview) directly, or replicate a UC table to Lakebase as a synced table.
+- **Transactional writes from your app** (orders, sessions, audit logs). Use [Lakebase Postgres](/docs/lakebase/overview).
+- **Natural-language Q&A over governed tables**. Use [Genie](/docs/agents/genie).
+
+You also don't author pipelines, configure Spark, or size clusters. Those are data engineering tasks that happen in the Databricks workspace or through [Declarative Automation Bundles](https://docs.databricks.com/aws/en/dev-tools/bundles/).
+
+## Pick a template to start from
+
+Each one combines the wiring on the pages above into a working pattern.
+
+| You want to...                                             | Template                                                            |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| Replicate a UC table into Lakebase for sub-10ms reads      | [Sync Tables (Autoscaling)](/templates/sync-tables-autoscaling)     |
+| Stand up the full UC + Lakehouse Sync + medallion pipeline | [Operational Data Analytics](/templates/operational-data-analytics) |
+
+## Where to next
+
+- [Analytical reads](/docs/lakehouse/analytical-reads) with the Analytics plugin, SQL files, and on-behalf-of-user queries.
+- [Lakeflow Jobs](/docs/lakehouse/jobs) for the Jobs plugin, `runNow`, and SSE progress.
+- [Pipelines and freshness](/docs/lakehouse/pipelines) for freshness signals via the Analytics plugin.

--- a/docs/lakehouse/pipelines.md
+++ b/docs/lakehouse/pipelines.md
@@ -1,0 +1,65 @@
+---
+title: Lakeflow pipelines and data freshness
+sidebar_label: Pipelines and freshness
+description: Show "is this data fresh?" timestamps in your AppKit app. Read per-table refresh metadata and the pipeline update timeline through the Analytics plugin.
+---
+
+# Lakeflow pipelines and data freshness
+
+Lakeflow Spark Declarative Pipelines (SDP) populate the analytical tables your app reads. Authoring pipelines is a data engineering task you almost never touch as an AppKit dev. Your job is the read side: displaying pipeline output, and answering "is this fresh enough to show?" before you render it.
+
+Two SQL signals answer it: per-table refresh metadata for materialized views and streaming tables, and the pipeline update timeline. Both go through the [Analytics plugin](/docs/appkit/v0/plugins/analytics) you set up in [Analytical reads](/docs/lakehouse/analytical-reads).
+
+## What's under Lakeflow
+
+Lakeflow groups these products:
+
+- **Lakeflow Connect** for ingestion. Managed connectors for Salesforce, Workday, SQL Server, and others ingest data into Unity Catalog.
+- **Lakeflow Spark Declarative Pipelines** for transformation. Authored in SQL or Python, runs on Databricks Runtime, produces materialized views and streaming tables.
+- **Lakeflow Jobs** for orchestration. See [Lakeflow Jobs](/docs/lakehouse/jobs) for the app-trigger side.
+- **Lakeflow Designer** for no-code visual pipeline building (Public Preview).
+
+## Two freshness signals
+
+- **Per-table refresh metadata**: `DESCRIBE TABLE EXTENDED <name> AS JSON` returns a `refresh_information` block for materialized views and streaming tables. The block has `last_refreshed_at`, `last_refresh_type`, `latest_refresh_status`, `latest_refresh_link`, and `refresh_schedule`. See [DESCRIBE TABLE](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-aux-describe-table) for the full output schema.
+- **Pipeline update timeline (Public Preview)**: `system.lakeflow.pipeline_update_timeline` records every pipeline update with `pipeline_id`, `update_id`, `period_start_time`, `period_end_time`, `result_state` (one of `COMPLETED`, `FAILED`, `CANCELED`), and trigger details. Filter by `pipeline_id` and `result_state = 'COMPLETED'` to find the most recent successful update for the pipeline that owns a table. See the [system table reference](https://docs.databricks.com/aws/en/admin/system-tables/jobs#pipeline-update-timeline) for the full column list.
+
+For deeper troubleshooting (per-flow status, expectation results, lineage events), use the [pipeline event log](https://docs.databricks.com/aws/en/ldp/monitor-event-logs) via the `event_log()` table-valued function. The event log is the right place for "why did this update fail" questions, not "is this data fresh enough to show".
+
+## A "Last updated" badge query
+
+Put this in `config/queries/`. It runs through the Analytics plugin like any other SQL file.
+
+```sql title="config/queries/last_pipeline_update.obo.sql"
+-- @param pipelineId STRING
+SELECT period_end_time, result_state
+FROM system.lakeflow.pipeline_update_timeline
+WHERE pipeline_id = :pipelineId
+  AND result_state = 'COMPLETED'
+ORDER BY period_end_time DESC
+LIMIT 1;
+```
+
+Call the hook from React with the pipeline ID:
+
+```tsx
+import { useMemo } from "react";
+import { useAnalyticsQuery } from "@databricks/appkit-ui/react";
+import { sql } from "@databricks/appkit-ui/js";
+
+const params = useMemo(
+  () => ({ pipelineId: sql.string("ec2a0ff4-d2a5-4c8c-bf1d-d9f12f10e749") }),
+  [],
+);
+const { data } = useAnalyticsQuery("last_pipeline_update", params);
+```
+
+The `.obo.sql` filename runs the query as the signed-in user. If your app's service principal has `SELECT` on `system.lakeflow.pipeline_update_timeline`, drop the `.obo` and the query runs as the app. See [Author SQL files](/docs/lakehouse/analytical-reads#author-sql-files) for the full filename rule.
+
+## Triggering a refresh from the app
+
+There's no dedicated AppKit Pipelines plugin. Call the SDK directly from your handler with `w.pipelines.startUpdate({ pipelineId })`, or wrap the pipeline in a [Lakeflow Job](/docs/lakehouse/jobs) and use the Jobs plugin.
+
+## Where to next
+
+Try [Medallion Architecture from CDC History Tables](/templates/medallion-architecture-from-cdc) for the canonical SDP pipeline that produces these tables, or [Operational Data Analytics](/templates/operational-data-analytics) for the end-to-end UC + CDC + medallion pattern.

--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -14,6 +14,7 @@ Apps, AppKit, Lakebase Postgres, and Agent Bricks are layers of a full-stack Dat
 | **Apps**              | The hosting layer. Your app runs as a managed workspace resource with a fixed URL, built-in auth, and managed compute. Deploy with `databricks apps deploy`.                                                         |
 | **AppKit**            | The TypeScript SDK for building apps on Databricks Apps. Built-in Databricks OAuth handling, pre-built React UI components (data tables, charts, dialogs), and a plugin system for connecting to workspace services. |
 | **Lakebase Postgres** | The database layer. Managed Postgres for OLTP, co-located with your Lakehouse. Autoscales on demand, scales to zero when idle, and supports branching for development environments.                                  |
+| **Data Lakehouse**    | The analytical data tier. Unity Catalog tables, materialized views, and streaming tables populated by Lakeflow. Read with the Analytics plugin. Trigger Lakeflow Jobs from your app.                                 |
 | **Agent Bricks**      | The AI layer. Call Knowledge Assistants, Supervisor Agents, and governed LLM endpoints via the Model Serving plugin. Query Unity Catalog tables in natural language via the Genie plugin.                            |
 
 **[Unity Catalog](https://docs.databricks.com/aws/en/data-governance/)** and **[AI Gateway](/docs/agents/ai-gateway)** are workspace-level services your app connects to for data governance and model serving.
@@ -28,6 +29,7 @@ These docs go deeper on each platform layer:
 
 - **[Web apps (Databricks Apps)](/docs/apps/quickstart)**: Scaffold and deploy an AppKit app (TypeScript) or a Python app on Databricks Apps.
 - **[Lakebase Postgres](/docs/lakebase/quickstart)**: Provision a Lakebase Postgres project and connect it to an app.
+- **[Data Lakehouse](/docs/lakehouse/overview)**: Read Unity Catalog tables with the Analytics plugin, trigger Lakeflow Jobs, and surface data freshness.
 - **[Agent Bricks](/docs/agents/overview)**: Governed model endpoints ([AI Gateway](/docs/agents/ai-gateway)), natural-language data queries ([Genie](/docs/agents/genie)), and custom agent endpoints ([Custom agents](/docs/agents/custom-agents)).
 - **[Set up your environment](/docs/tools/databricks-cli)**: Databricks CLI, agent skills, and MCP server.
 - **[AppKit Reference](/docs/appkit/v0)**: Component library, plugin API, and TypeScript SDK reference.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -15,6 +15,7 @@ Your company already has a **Databricks workspace**: a URL like `https://<your-o
 
 - **[Databricks Apps](/docs/apps/overview)**: where your internal app runs. Built for interactive internal tools, not static dashboards. Managed hosting and workspace SSO. Build it with [AppKit](/docs/appkit/v0), the open-source TypeScript SDK that wires up auth, plugins, and pre-built React components.
 - **[Lakebase Postgres](/docs/lakebase/overview)**: managed Postgres for OLTP storage co-located with your workspace data. Use it for sessions, app state, conversation history, or any data your app reads and writes at low latency.
+- **[Data Lakehouse](/docs/lakehouse/overview)**: governed analytical data in Unity Catalog. Use it to read company data, trigger Lakeflow Jobs from a handler, and surface freshness in your UI.
 - **[Agent Bricks](/docs/agents/overview)**: Databricks' enterprise agent platform, unifying model access, execution, governance, and context. Use it for AI features in your app: chat with internal docs (Knowledge Assistants), ask-your-data in plain English (Genie), foundation-model calls, or custom Python agents.
 
 See [Platform overview](/docs/platform-overview) for how these layers fit together.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -204,6 +204,16 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
+      label: "Data Lakehouse",
+      items: [
+        "lakehouse/overview",
+        "lakehouse/analytical-reads",
+        "lakehouse/jobs",
+        "lakehouse/pipelines",
+      ],
+    },
+    {
+      type: "category",
       label: "Agent Bricks",
       items: [
         "agents/overview",


### PR DESCRIPTION
Adds a four-page Data Lakehouse companion section for AppKit devs: overview, analytical reads, Lakeflow Jobs, and pipeline freshness.