### PR TITLE
docs: address review feedback across platform docs

### DIFF
--- a/docs/agents/genie.md
+++ b/docs/agents/genie.md
@@ -18,11 +18,11 @@ Give your users a chat box that queries your data. No text-to-SQL, no schema map
 
 ## Why Genie
 
-Genie does three things that otherwise take a team of engineers to build:
+From question to result, Genie:
 
-- **Understands your schema.** Trained on Unity Catalog tables plus a knowledge store of synonyms, example SQL, and column descriptions.
-- **Generates SQL.** A compound AI system turns natural-language questions into executable queries, with follow-up clarifications when the prompt is ambiguous.
-- **Runs the query.** Databricks executes against the warehouse and returns tabular results ready to render.
+- **Understands your schema** from Unity Catalog tables, synonyms, example SQL, and column descriptions.
+- **Generates SQL** from natural-language questions, with follow-up clarifications when the prompt is ambiguous.
+- **Runs the query** against your warehouse and returns tabular results ready to render.
 
 The [`genie` plugin](/docs/appkit/v0/plugins/genie) wires all of that to your chat UI with SSE streaming, auth, and conversation replay handled.
 

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -43,14 +43,14 @@ For server logic outside a route handler, call `AppKit.serving("alias").asUser(r
 
 You could call a serving endpoint directly with `fetch` and a token. The plugin isn't doing something you can't do yourself. It's doing these things so you don't have to:
 
-- **Per-user permissions for free.** Both the Model Serving plugin and Genie plugin routes run as the authenticated user by default. Your users only see endpoints and data they are already allowed to see. No OAuth code on your side. See [Execution context](/docs/appkit/v0/plugins/execution-context) for the details.
-- **Streaming plumbing done.** SSE parsing, abort on unmount, token accumulation, error handling. `useServingStream` and `useGenieChat` handle these.
-- **No secrets in the frontend.** The plugin proxies through your server. Tokens stay on the backend. No PAT in the React bundle.
-- **Typed endpoint aliases.** If your serving endpoint publishes an OpenAPI schema, AppKit generates TypeScript types for request and response per alias. Autocomplete for chunk shapes, not `unknown`.
+- Routes run as the authenticated user, so **per-user permissions** apply automatically. Your users only see endpoints and data they're already allowed to see. No OAuth code on your side. See [Execution context](/docs/appkit/v0/plugins/execution-context) for the details.
+- All **streaming** is handled for you. SSE parsing, abort on unmount, token accumulation, and error handling. `useServingStream` and `useGenieChat` do this.
+- No **secrets** in the frontend. The plugin proxies through your server and tokens stay on the backend. No PAT in the React bundle.
+- When your serving endpoint publishes an OpenAPI schema, AppKit generates **typed endpoint aliases** with TypeScript types for request and response per alias. Autocomplete for chunk shapes, not `unknown`.
 
-:::note[Authoring a custom agent]
+:::note[Creating a custom agent]
 
-Authoring a custom agent from scratch is a Python workflow: the `ResponsesAgent` interface, an agent framework (OpenAI Agents SDK, LangGraph, LlamaIndex), and MLflow for tracing. See [Create an AI agent](https://docs.databricks.com/aws/en/generative-ai/agent-framework/create-agent) on docs.databricks.com for that track.
+Creating a custom agent is a Python workflow: the `ResponsesAgent` interface, an agent framework (OpenAI Agents SDK, LangGraph, LlamaIndex), and MLflow for tracing. See [Create an AI agent](https://docs.databricks.com/aws/en/generative-ai/agent-framework/create-agent) on docs.databricks.com for that track.
 
 :::
 

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -40,7 +40,7 @@ Apps are about **interactivity**, not only analytics. A dashboard is great for r
 ## When not to use it
 
 - **Static sites with no Databricks data access.** Host these anywhere.
-- **Public-facing or customer-facing apps.** Users have to be authenticated as identities in your Databricks account, so anyone outside your enterprise directory can't sign in.
+- **Public-facing or customer-facing apps.** By default, users must be authenticated identities in your Databricks workspace. For external or customer-facing access, see [App Users](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/key-concepts/#app-users).
 - **Pure read-only dashboards** that AI/BI [Dashboards](https://docs.databricks.com/aws/en/dashboards/) already cover. Use a dashboard until you need to persist user input or run custom logic on top of it.
 
 ## Where to next

--- a/docs/lakebase/development.md
+++ b/docs/lakebase/development.md
@@ -73,6 +73,13 @@ For collaborators and other identities that need local read/write access, add th
 
 [Postgres password authentication](https://docs.databricks.com/aws/en/oltp/projects/authentication#overview) is a simpler alternative that avoids OAuth role setup. Set a password in the Branch Overview page and use it as `PGPASSWORD` in `.env`.
 
+You can also generate a short-lived credential for use with any PostgreSQL client (DBeaver, pgAdmin, DataGrip, or a language driver):
+
+```bash
+databricks postgres generate-database-credential \
+  projects/my-project/branches/production/endpoints/primary
+```
+
 The [AppKit plugin docs: local development](/docs/appkit/v0/plugins/lakebase#local-development) cover fine-grained permission alternatives for teams that need schema-scoped access.
 
 ## Feature branches

--- a/docs/lakebase/overview.md
+++ b/docs/lakebase/overview.md
@@ -12,10 +12,10 @@ Use it for the data your apps actively write and read at low latency: user state
 
 ## What makes it different from running your own Postgres
 
-- **Co-located with your workspace**: no VPC peering, no cross-cloud credential management, no added latency from network boundaries. Your app and your data are in the same place.
-- **Instant branching**: create isolated database copies in seconds using copy-on-write storage, similar to git branches. Branches share unchanged data, so they're cheap to create and maintain.
-- **Autoscales with your workload**: compute scales up under load and back down when demand drops, within a configured min/max range. No capacity planning or manual resize.
-- **Scales to zero**: the database pauses when idle and resumes on the next query. No cost for idle compute. Development branches suspend by default after five minutes.
+- **Runs inside your workspace**, eliminating VPC peering, cross-cloud credential management, and network latency.
+- **Instant branching** via copy-on-write storage creates isolated database copies in seconds, similar to git branches. Branches share unchanged data so they're cheap to create and maintain.
+- **Autoscales** with your workload, scaling up under load and back down when demand drops, within a configured min/max range. No capacity planning or manual resize.
+- **Scales to zero** when idle and resumes on the next query. No cost for idle compute. Development branches suspend by default after five minutes.
 
 ## How AppKit wires it up
 
@@ -47,7 +47,7 @@ The plugin handles OAuth token refresh and connection pooling automatically. Whe
 ## When not to use it
 
 - Pure analytics: read-only queries against large datasets belong in Unity Catalog, not Lakebase Postgres.
-- Apps with no other Databricks workspace dependencies. The colocation advantage doesn't apply, and auth is your responsibility.
+- Apps with no other Databricks workspace dependencies. The colocation advantage doesn't apply, and auth becomes your responsibility (Databricks does not inject credentials or refresh tokens for apps running outside the workspace).
 
 ## Where to next
 

--- a/docs/lakebase/quickstart.md
+++ b/docs/lakebase/quickstart.md
@@ -7,7 +7,7 @@ title: Quickstart
 ## Prerequisites
 
 - Databricks CLI `v0.296+` with an [authenticated profile](/docs/tools/databricks-cli#authenticate)
-- `psql` (PostgreSQL client) if using `databricks psql`. Alternatively, use [`generate-database-credential`](/docs/lakebase/development#connect) with any PostgreSQL client.
+- `psql` (PostgreSQL client) if using `databricks psql`. Alternatively, use [`generate-database-credential`](/docs/lakebase/development#local-database-access) with any PostgreSQL client.
 - Workspace with Lakebase Postgres access enabled
 
 ## Template path

--- a/docs/lakehouse/overview.md
+++ b/docs/lakehouse/overview.md
@@ -6,7 +6,7 @@ description: The data tier of the Databricks Data Intelligence Platform. Governe
 
 # What is the Data Lakehouse?
 
-The Data Lakehouse is the analytical tier of your Databricks workspace: tables and views governed by Unity Catalog and populated by Lakeflow. Lakeflow is Databricks's data engineering family, covering ingestion, pipelines, and jobs. From an AppKit app, you read its tables, trigger Lakeflow Jobs, and show "last updated" timestamps from the pipelines that populated them.
+The Data Lakehouse is the analytical tier of your Databricks workspace: tables and views governed by Unity Catalog and populated by Lakeflow. Lakeflow is Databricks' suite of data engineering services covering ingestion, orchestration, and pipeline management. From an AppKit app, you read its tables, trigger Lakeflow Jobs, and show "last updated" timestamps from the pipelines that populated them.
 
 The [Analytics plugin](/docs/appkit/v0/plugins/analytics) handles SQL warehouse reads (see [Analytical reads](/docs/lakehouse/analytical-reads) and [Pipelines and freshness](/docs/lakehouse/pipelines)). The [Jobs plugin](/docs/appkit/v0/plugins/jobs) handles run triggering and progress (see [Lakeflow Jobs](/docs/lakehouse/jobs)).
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -9,14 +9,14 @@ This site is for building internal apps on Databricks. Pick a template, scaffold
 
 ## Your workspace is the foundation
 
-Your company already has a **Databricks workspace**: a URL like `https://<your-org>.cloud.databricks.com` your team signs in to. For the internal app you're about to build, it determines **who** can sign in, **what** data the app can read or write (Unity Catalog tables and Lakebase Postgres), and **where** the app runs. Hosting, auth, and networking are handled for you. From your local machine, you connect to it with the [Databricks CLI](/docs/tools/databricks-cli).
+Everything you build here runs on a **Databricks workspace**. Your workspace URL looks like `https://<your-org>.cloud.databricks.com`. For the app you're building, it determines **who** can sign in, **what** data the app can read or write (Unity Catalog tables and Lakebase Postgres), and **where** the app runs. Hosting, auth, and networking are handled for you. From your local machine, you connect to it with the [Databricks CLI](/docs/tools/databricks-cli).
 
 ## What you'll build
 
-- **[Databricks Apps](/docs/apps/overview)**: where your internal app runs. Built for interactive internal tools, not static dashboards. Managed hosting and workspace SSO. Build it with [AppKit](/docs/appkit/v0), the open-source TypeScript SDK that wires up auth, plugins, and pre-built React components.
+- **[Databricks Apps](/docs/apps/overview)**: where your app runs. Built for interactive tools, not static dashboards. Managed hosting and workspace SSO. Build it with [AppKit](/docs/appkit/v0), the open-source TypeScript SDK that wires up auth, plugins, and pre-built React components.
 - **[Lakebase Postgres](/docs/lakebase/overview)**: managed Postgres for OLTP storage co-located with your workspace data. Use it for sessions, app state, conversation history, or any data your app reads and writes at low latency.
-- **[Agent Bricks](/docs/agents/overview)**: Databricks' enterprise agent platform, unifying model access, execution, governance, and context. Use it for AI features in your app: chat with internal docs (Knowledge Assistants), ask-your-data in plain English (Genie), foundation-model calls, or custom Python agents.
-- **[Data Lakehouse](/docs/lakehouse/overview)**: governed analytical data in Unity Catalog. Use it to read company data, trigger Lakeflow Jobs from a handler, and surface freshness in your UI.
+- **[Agent Bricks](/docs/agents/overview)**: Databricks' enterprise agent platform, unifying model access, execution, governance, and context. Use it for AI features in your app: chat with your company's docs (Knowledge Assistants), ask-your-data in plain English (Genie), foundation-model calls, or custom Python agents.
+- **[Data Lakehouse](/docs/lakehouse/overview)**: governed analytical data in Unity Catalog. Use it to read company data, trigger Lakeflow Jobs from a handler, and display data freshness in your UI.
 
 See [Platform overview](/docs/platform-overview) for how these layers fit together.
 
@@ -25,4 +25,4 @@ See [Platform overview](/docs/platform-overview) for how these layers fit togeth
 1. **Note your workspace URL** (looks like `https://<id>.cloud.databricks.com`).
 2. **Install and authenticate the [Databricks CLI](/docs/tools/databricks-cli).** Required for every template on this site.
 3. **Install [agent skills](/docs/tools/ai-tools/agent-skills)** so your coding agent has Databricks platform context.
-4. **Pick a [template](/templates)** that matches your internal app. Browse [Apps overview](/docs/apps/overview) first if you want the conceptual picture.
+4. **Pick a [template](/templates)** that matches your app. Browse [Apps overview](/docs/apps/overview) first if you want the conceptual picture.

--- a/docs/tools/ai-tools/docs-mcp-server.md
+++ b/docs/tools/ai-tools/docs-mcp-server.md
@@ -8,13 +8,21 @@ The DevHub Docs MCP Server gives coding agents and IDE assistants read access to
 
 ## Install
 
-Add the server to any supported coding agent (Cursor, Claude Code, VS Code, Codex, and more) with a single command:
+Add the server to any supported coding agent (Cursor, Claude Code, VS Code, Codex, and more) with a single command.
+
+Global install (user-level, available across all projects):
+
+```bash
+npx add-mcp https://dev.databricks.com/api/mcp --name devhub-docs -g
+```
+
+Project-level install (current directory only):
 
 ```bash
 npx add-mcp https://dev.databricks.com/api/mcp --name devhub-docs
 ```
 
-Use `-g` to install globally (user-level) instead of project-level, and `-a` to target a specific agent:
+To target a specific agent, add `-a`:
 
 ```bash
 npx add-mcp https://dev.databricks.com/api/mcp --name devhub-docs -g -a cursor

--- a/docs/tools/databricks-cli.mdx
+++ b/docs/tools/databricks-cli.mdx
@@ -7,11 +7,11 @@ import TabItem from "@theme/TabItem";
 
 # Databricks CLI
 
-The Databricks CLI is required for every template on this site. Install it and authenticate before starting any template.
+The Databricks CLI is required for every template on this site, which includes CLI commands for scaffolding and deployment. Install and authenticate before you begin.
 
 Command-line tool for workspace operations, app deployment, and automation. This page covers installation and authentication. Product-specific commands (`databricks apps`, `databricks postgres`, `databricks serving-endpoints`) are covered in each product's docs.
 
-For the full command reference, see the [official CLI docs](https://docs.databricks.com/aws/en/dev-tools/cli/). If you start from a [template](/templates), the CLI is already part of that workflow.
+For the full command reference, see the [official CLI docs](https://docs.databricks.com/aws/en/dev-tools/cli/).
 
 ## Install or upgrade
 
@@ -98,7 +98,7 @@ Install [agent skills](/docs/tools/ai-tools/agent-skills) to give AI coding assi
 databricks experimental aitools install
 ```
 
-By default, skills install globally. Pass `--project` to install into the current project instead. See the [agent skills page](/docs/tools/ai-tools/agent-skills) for all options.
+By default, skills install globally. Pass `--project` to install into the current project directory instead. See the [agent skills page](/docs/tools/ai-tools/agent-skills) for all options.
 
 ## Where to next
 


### PR DESCRIPTION
Addresses a round of reviewer feedback across the platform docs, and made additional changes along the way:

- Broadens internal-only framing to reflect that apps can support external users via App Users
- Clarifies workspace assumption, CLI setup, and MCP server install instructions
- Fixes a buried link in the Lakebase quickstart
- Improves wording throughout: Lakeflow description, "authoring" → "creating", freshness copy, bold placement in feature lists, and so on

Thanks Daniel Price for the review! 