### PR TITLE
feat(prompt): add deployed-app verification step to default workflow

### DIFF
--- a/content/dev-guidelines.md
+++ b/content/dev-guidelines.md
@@ -63,6 +63,7 @@ Unless instructed otherwise, follow this workflow:
 5. Make it look great (see "Make it look great" below).
 6. Run and test locally.
 7. Deploy to production.
+8. Run and test deployed app (see "Run and test deployed app" below).
 
 ## Make it look great
 
@@ -76,6 +77,14 @@ Unless the user has specified a design preference, use these defaults:
 - Databricks brand palette: `#FF3621`, `#0B2026`, `#EEEDE9`, `#F9F7F4`.
 
 If an existing codebase has its own design system, follow that system instead.
+
+## Run and test deployed app
+
+- If the `databricks-apps` skill is available, follow its `agent-browser` reference to load the deployed app and test it; otherwise install `agent-browser` (`npm install -g agent-browser`) and drive the deployed URL with it directly.
+- If anything is off, fix it.
+- Inspect the app logs via the Databricks CLI and fix any errors.
+- Redeploy and repeat until all issues are resolved.
+- Report back to the user once the deployed app is verified.
 
 ## When you run into issues
 


### PR DESCRIPTION
## Summary

Adds a new step 8 to the default agent workflow in `content/dev-guidelines.md`: **run and test the deployed app end to end with `agent-browser` before reporting done**. The new section instructs agents to load the deployed app, smoke-test it, inspect logs via the Databricks CLI, and loop on redeploys until clean.

This content is concatenated into every `/api/bootstrap-prompt` response (powered by `composeAgentPrompt` in `src/lib/copy-preamble.ts`), so it ships immediately to:

- the homepage **Copy prompt for your agent** button
- every recipe / cookbook / example detail page's **Copy prompt** button

## Pending dependency

This PR is pending **[databricks/databricks-agent-skills#63](https://github.com/databricks/databricks-agent-skills/pull/63)**, which adds the `agent-browser` reference (`references/appkit/agent-browser.md`) to the `databricks-apps` skill. Once that PR lands, agents that have the `databricks-apps` skill loaded will automatically follow the full recipe (deployed URL with `--headed --profile <dir>` for one-time SSO, daemon flag gotchas, `databricks apps run-local` edge case for header-injection testing).

The new step is written to degrade gracefully when the skill isn't available — bullet 1 has an inline `npm install -g agent-browser` fallback so non-Databricks-skilled agents still execute the verification loop manually.

## Test plan

- [x] `npm run fmt` passes
- [x] `npm run typecheck` passes
- [x] `npx vitest run tests/bootstrap-prompt.test.ts` passes (13/13)
- [x] Pre-commit hook (`prettier -c .` + typecheck + verify:images + build) passes
- [ ] Eyeball `/api/bootstrap-prompt` response on the preview deployment to confirm the new section renders inline
- [ ] Eyeball the homepage **Copy prompt for your agent** button output on the preview deployment