### PR TITLE
fix: rename DevHub launch title

### DIFF
--- a/src/lib/solutions/solutions.ts
+++ b/src/lib/solutions/solutions.ts
@@ -55,7 +55,7 @@ export const solutions: Solution[] = [
   {
     type: "native",
     id: "devhub-launch",
-    title: "Introducing dev.databricks.com",
+    title: "Introducing DevHub",
     description:
       "A new developer hub for building on Databricks: opinionated, copy-pasteable templates and agent-ready documentation for software engineers.",
     tags: ["Launch", "Developer Experience", "Agent-Led Development"],

--- a/tests/api-markdown.test.ts
+++ b/tests/api-markdown.test.ts
@@ -117,7 +117,7 @@ describe("/api/markdown about-devhub preamble policy", () => {
     expect(result.statusCode).toBe(200);
     expect(result.body).not.toContain("# About DevHub");
     expect(result.body).not.toContain("/llms.txt");
-    expect(result.body).toContain("Introducing dev.databricks.com");
+    expect(result.body).toContain("Introducing DevHub");
   });
 
   test("solution frontmatter url is absolute and reflects the request host", () => {
@@ -140,9 +140,7 @@ describe("/api/markdown about-devhub preamble policy", () => {
       slug: "devhub-launch",
       host: "dev.databricks.com",
     });
-    expect(result.body).toMatch(
-      /^title:\s+"Introducing dev\.databricks\.com"$/m,
-    );
+    expect(result.body).toMatch(/^title:\s+"Introducing DevHub"$/m);
     expect(result.body).toMatch(/^summary:\s+".+"$/m);
     expect(result.body).toMatch(/^publishedAt:\s*2026-05-04$/m);
     expect(result.body).toMatch(/^authors:$/m);

--- a/tests/e2e/copy-markdown.spec.ts
+++ b/tests/e2e/copy-markdown.spec.ts
@@ -199,7 +199,7 @@ test.describe("copy markdown exports raw markdown on solution pages", () => {
     expect(copied).not.toContain("# About DevHub");
     expect(copied).not.toContain("/llms.txt");
     expect(copied).toContain("**dev.databricks.com**");
-    expect(copied).toContain('title: "Introducing dev.databricks.com"');
+    expect(copied).toContain('title: "Introducing DevHub"');
   });
 });
 

--- a/tests/e2e/pages.spec.ts
+++ b/tests/e2e/pages.spec.ts
@@ -5,7 +5,7 @@ const PAGES = [
   { path: "/solutions", title: "Solutions" },
   {
     path: "/solutions/devhub-launch",
-    title: "Introducing dev.databricks.com",
+    title: "Introducing DevHub",
   },
   { path: "/templates", title: "Templates" },
   { path: "/templates/ai-chat-app", title: "AI Chat App" },

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -28,7 +28,7 @@ describe("detail markdown resolver", () => {
     expect(frontmatter).not.toBeNull();
     if (!frontmatter) return;
     const block = frontmatter[1];
-    expect(block).toMatch(/^title:\s+"Introducing dev\.databricks\.com"$/m);
+    expect(block).toMatch(/^title:\s+"Introducing DevHub"$/m);
     expect(block).toMatch(
       /^url:\s+https:\/\/dev\.databricks\.com\/solutions\/devhub-launch$/m,
     );


### PR DESCRIPTION
## Summary
- Rename the DevHub launch solution title from `Introducing dev.databricks.com` to `Introducing DevHub` so the page title does not depend on a changing domain.
- Update markdown/API/e2e assertions that read the solution title from the registry.

## Test plan
- `npm run fmt`
- `npm run validate:content`
- `npm run typecheck`
- `npx vitest run tests/markdown.test.ts tests/api-markdown.test.ts`
- `npx fallow dead-code` (reports pre-existing unused-code inventory)
- `npx fallow dupes` (reports pre-existing duplicate-code inventory)
- `npm run build`
- Pre-commit hook: prettier check, typecheck, validate:content, verify:images, build