### PR TITLE
feat(hackathon): add /hackathon resources page and env-driven announcement banner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,23 @@ SHOW_DRAFTS=true
 
 A flag is **enabled only when its value is exactly `"true"`** — any other value (empty, `"1"`, `"yes"`) is treated as disabled.
 
+### Hackathon Banner
+
+The site-wide announcement bar that points visitors at [`/hackathon`](./src/pages/hackathon.tsx) is driven by env vars at build time and resolved by `src/lib/hackathon-banner-server.ts`. The banner uses Docusaurus' built-in `themeConfig.announcementBar` so it shows above the navbar on every page (docs, templates, solutions, MDX). It's intentionally **non-dismissible** so the banner stays as the only on-site entry point to `/hackathon` for the full event window.
+
+| Env var                    | Purpose                                                                                                                                                                                                                                                                 |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HACKATHON_BANNER_ENABLED` | Escape hatch. `"true"` forces the banner on, `"false"` forces it off. Anything else (including unset) falls through to dates.                                                                                                                                           |
+| `HACKATHON_START`          | ISO date `YYYY-MM-DD`. Required (along with `HACKATHON_END`) for date-driven activation.                                                                                                                                                                                |
+| `HACKATHON_END`            | ISO date `YYYY-MM-DD`. Inclusive through 23:59:59.999 UTC of the given day.                                                                                                                                                                                             |
+| `HACKATHON_BANNER_TEXT`    | Optional override for the **lead-in text only** (HTML allowed). The "See resources" link to `/hackathon` is always appended, so a misconfigured override can never strand visitors on a banner with no way in. Defaults to `"Databricks Developer Hackathon is live."`. |
+
+Precedence: `HACKATHON_BANNER_ENABLED` wins. Otherwise the banner is active if both dates are set, parseable, `start <= end`, and "now" is within the window.
+
+The `/hackathon` page itself is always live (and discoverable in `sitemap.xml`) so the URL is shareable ahead of the event. It is not linked from the navbar or the footer — the banner is the only on-site entry point, and it only appears while the banner is active.
+
+Flipping the banner on Vercel is "edit env var → redeploy", the same model as `SHOW_DRAFTS`. Bump the `id` in `getHackathonBannerConfig` per event so prior dismissals (stored in `localStorage`) are reset for returning visitors.
+
 ### Site URL Resolution
 
 Anywhere we need an absolute URL — `llms.txt`, `sitemap.xml`, `robots.txt`, JSON-LD, `/api/markdown`, `/api/bootstrap-prompt`, `/api/mcp`, the `Copy prompt` / `Copy Markdown` buttons — we resolve the site origin in this order (see `src/lib/site-url.ts`):

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,6 +11,7 @@ import remarkCliTabs from "./plugins/remark-cli-tabs";
 import remarkSiteUrl from "./plugins/remark-site-url";
 import robotsTxtPlugin from "./plugins/robots-txt";
 import { showDrafts } from "./src/lib/feature-flags-server";
+import { getHackathonBannerConfig } from "./src/lib/hackathon-banner-server";
 import {
   resolveSiteBaseUrl,
   resolveSiteOrigin,
@@ -22,6 +23,7 @@ import {
 const siteOrigin = resolveSiteOrigin();
 const siteBaseUrl = resolveSiteBaseUrl();
 const publicSiteUrl = siteUrlFromConfig(siteOrigin, siteBaseUrl);
+const hackathonBanner = getHackathonBannerConfig();
 
 const config: Config = {
   title: "Databricks Developer",
@@ -161,6 +163,7 @@ const config: Config = {
   ],
 
   themeConfig: {
+    ...(hackathonBanner && { announcementBar: hackathonBanner }),
     image: "img/databricks-social-card.svg",
     colorMode: {
       respectPrefersColorScheme: true,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1348,3 +1348,30 @@
 .db-docs-article .theme-doc-markdown th code {
   overflow-wrap: break-word;
 }
+
+/* Hackathon announcement bar — taller + a touch larger text than the
+ * Docusaurus defaults (30px / 14px). The height variable is the documented
+ * Docusaurus override; the font/padding rules target `.theme-announcement-bar`
+ * (a stable, unhashed Docusaurus theme class) so we don't depend on the
+ * hashed CSS Module class name. Mobile keeps `auto` height so wrapped text
+ * isn't clipped. */
+@media (min-width: 997px) {
+  :root {
+    --docusaurus-announcement-bar-height: 44px;
+  }
+}
+
+.theme-announcement-bar {
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  font-weight: 500;
+  padding-block: 0.5rem;
+}
+
+.theme-announcement-bar a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  /* Breathing room between the lead text and the "See resources" CTA. */
+  margin-left: 0.25rem;
+}

--- a/src/lib/hackathon-banner-server.ts
+++ b/src/lib/hackathon-banner-server.ts
@@ -1,0 +1,91 @@
+/**
+ * Server-side resolution of the site-wide hackathon banner.
+ *
+ * Activation precedence (mirrors the `showDrafts` env pattern — strict string
+ * matching, no implicit dev/CI handling):
+ *
+ *   1. `HACKATHON_BANNER_ENABLED="true"`  → force on, ignore dates
+ *   2. `HACKATHON_BANNER_ENABLED="false"` → force off, ignore dates
+ *   3. otherwise → on iff `now` is between `HACKATHON_START` 00:00 UTC and
+ *      `HACKATHON_END` 23:59:59.999 UTC (both required, both ISO `YYYY-MM-DD`,
+ *      and `start <= end`).
+ *
+ * Optional `HACKATHON_BANNER_TEXT` overrides the banner copy so messaging can
+ * change without a code edit.
+ *
+ * The resolver is a pure function so it can be unit-tested with synthetic
+ * envs and a fixed `now`. The config builder is the thin imperative shell
+ * consumed by `docusaurus.config.ts` at build time.
+ */
+
+export type HackathonBannerEnv = {
+  HACKATHON_BANNER_ENABLED?: string;
+  HACKATHON_START?: string;
+  HACKATHON_END?: string;
+  HACKATHON_BANNER_TEXT?: string;
+};
+
+type HackathonBannerConfig = {
+  id: string;
+  content: string;
+  backgroundColor: string;
+  textColor: string;
+  isCloseable: boolean;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseStartOfDayUtc(value: string | undefined): number | null {
+  if (!value || !ISO_DATE.test(value)) return null;
+  const ms = Date.parse(`${value}T00:00:00.000Z`);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function parseEndOfDayUtc(value: string | undefined): number | null {
+  if (!value || !ISO_DATE.test(value)) return null;
+  const ms = Date.parse(`${value}T23:59:59.999Z`);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function resolveHackathonBannerActive(
+  env: HackathonBannerEnv,
+  now: Date,
+): boolean {
+  if (env.HACKATHON_BANNER_ENABLED === "true") return true;
+  if (env.HACKATHON_BANNER_ENABLED === "false") return false;
+
+  const start = parseStartOfDayUtc(env.HACKATHON_START);
+  const end = parseEndOfDayUtc(env.HACKATHON_END);
+  if (start === null || end === null) return false;
+  if (start > end) return false;
+
+  const nowMs = now.getTime();
+  return nowMs >= start && nowMs <= end;
+}
+
+const DEFAULT_BANNER_LEAD_TEXT = "Databricks Developer Hackathon is live.";
+const BANNER_LINK_HTML = '<a href="/hackathon"><b>See resources &rarr;</b></a>';
+
+export function getHackathonBannerConfig(
+  env: HackathonBannerEnv = process.env as HackathonBannerEnv,
+  now: Date = new Date(),
+): HackathonBannerConfig | undefined {
+  if (!resolveHackathonBannerActive(env, now)) return undefined;
+  const leadText = (
+    env.HACKATHON_BANNER_TEXT ?? DEFAULT_BANNER_LEAD_TEXT
+  ).trim();
+  return {
+    // Non-dismissible by design: the banner is the only on-site entry point to
+    // /hackathon during the event window, so we don't want visitors to close
+    // it and lose the way in. `id` is retained for future per-event resets if
+    // we re-enable dismissals.
+    id: "hackathon-2026",
+    // HACKATHON_BANNER_TEXT overrides only the lead-in copy; the "See
+    // resources" link is always appended so visitors can never end up on a
+    // banner with no way to reach /hackathon.
+    content: `${leadText} ${BANNER_LINK_HTML}`,
+    backgroundColor: "var(--db-lava)",
+    textColor: "#ffffff",
+    isCloseable: false,
+  };
+}

--- a/src/pages/hackathon.tsx
+++ b/src/pages/hackathon.tsx
@@ -1,0 +1,313 @@
+import Head from "@docusaurus/Head";
+import Link from "@docusaurus/Link";
+import Layout from "@theme/Layout";
+import {
+  ArrowUpRight,
+  BookOpen,
+  CalendarDays,
+  HelpCircle,
+  MessageSquare,
+  Sparkles,
+  Trophy,
+} from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
+import { BootstrapCopyButton } from "@/components/home/bootstrap-copy-button";
+
+/**
+ * Always-live evergreen hackathon resources page. The home/nav don't link to
+ * it; entry is via the site-wide announcement banner during the event window
+ * (see `src/lib/hackathon-banner-server.ts`).
+ *
+ * Content is hardcoded so it can be edited per-event without touching schema
+ * or env vars. Bump the dates / event name in this file before each hackathon.
+ */
+
+const EVENT_NAME = "Databricks Developer Hackathon";
+const EVENT_DATES = "June 15 \u2013 June 16, 2026";
+const EVENT_TAGLINE =
+  "Ship an agentic app on Databricks in just 2 days. Open to all developers \u2014 students, professionals, and weekend hackers.";
+
+type Resource = {
+  title: string;
+  description: string;
+  href: string;
+  external?: boolean;
+  Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+};
+
+const RESOURCES: Resource[] = [
+  {
+    title: "Templates",
+    description:
+      "Pre-built starters for AI chat apps, Lakebase-backed apps, Genie analytics, and more. Copy as a prompt for your agent or follow the steps yourself.",
+    href: "/templates",
+    Icon: Sparkles,
+  },
+  {
+    title: "Start here docs",
+    description:
+      "Set up your Databricks workspace, install the CLI, and ship your first app. The 60-second path from zero to deployed.",
+    href: "/docs/start-here",
+    Icon: BookOpen,
+  },
+  {
+    title: "Ask questions on Reddit",
+    description:
+      "Stuck on a Databricks-specific issue? r/databricks is the fastest place to get unstuck during the hackathon.",
+    href: "https://www.reddit.com/r/databricks",
+    external: true,
+    Icon: MessageSquare,
+  },
+];
+
+const TIMELINE = [
+  {
+    label: "Registration opens",
+    date: "June 14, 2026",
+    detail: "Sign up on the event page \u2014 link coming soon.",
+  },
+  {
+    label: "Hacking begins",
+    date: "June 15, 2026",
+    detail: "Kickoff livestream + prompts dropped.",
+  },
+  {
+    label: "Submissions close",
+    date: "June 16, 2026 \u00b7 11:59pm PT",
+    detail: "Submit your repo, demo video, and one-paragraph writeup.",
+  },
+  {
+    label: "Winners announced",
+    date: "June 18, 2026",
+    detail: "Judging by Databricks engineering and DevRel.",
+  },
+];
+
+const JUDGING_CRITERIA = [
+  {
+    title: "Impact",
+    detail:
+      "Does it solve a real problem someone would actually use? Bonus for measurable outcomes.",
+  },
+  {
+    title: "Technical execution",
+    detail:
+      "Idiomatic use of the Databricks developer stack \u2014 Lakebase, Agent Bricks, Apps, model serving.",
+  },
+  {
+    title: "Polish",
+    detail:
+      "Working demo, clear README, sensible UX. We reward shipped over feature-complete.",
+  },
+  {
+    title: "Originality",
+    detail: "A fresh take beats a polished clone of an existing app.",
+  },
+];
+
+const FAQ = [
+  {
+    q: "Do I need a Databricks account to participate?",
+    a: "Yes. The free trial is enough for most submissions \u2014 sign up at databricks.com/signup.",
+  },
+  {
+    q: "Can I work in a team?",
+    a: "Teams of up to four are allowed. Solo submissions are welcome too.",
+  },
+  {
+    q: "What if I'm new to Databricks?",
+    a: 'Start with the "Start here" docs and copy one of the templates as a prompt for your coding agent \u2014 it will scaffold a working app and walk you through the rest.',
+  },
+  {
+    q: "How are submissions judged?",
+    a: "Against the criteria above by a panel of Databricks engineers and DevRel folks. Tie-breakers go to the more original entry.",
+  },
+];
+
+function EyebrowLabel({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <p className="mb-4 inline-flex items-center gap-2 text-[10px] font-semibold tracking-[0.12em] text-black/60 uppercase dark:text-white/60">
+      <span className="text-db-lava">&#9658;</span>
+      {children}
+    </p>
+  );
+}
+
+function ResourceCard({ resource }: { resource: Resource }): ReactNode {
+  const { title, description, href, external, Icon } = resource;
+  const cardClasses =
+    "group flex h-full flex-col rounded-xl border border-black/10 bg-[#f7f6f4] p-6 no-underline transition-colors duration-200 hover:border-db-lava/50 dark:border-white/10 dark:bg-[#182a32] dark:hover:border-db-lava-light/55";
+  const body = (
+    <>
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="h-5 w-5 text-db-lava" aria-hidden />
+        <h3 className="m-0 text-lg font-medium text-black dark:text-white">
+          {title}
+        </h3>
+        {external && (
+          <ArrowUpRight
+            aria-hidden
+            className="ml-auto h-4 w-4 text-black/40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 dark:text-white/40"
+          />
+        )}
+      </div>
+      <p className="m-0 text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+        {description}
+      </p>
+    </>
+  );
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cardClasses}
+        aria-label={`${title} (opens in new tab)`}
+      >
+        {body}
+      </a>
+    );
+  }
+  return (
+    <Link to={href} className={cardClasses}>
+      {body}
+    </Link>
+  );
+}
+
+export default function HackathonPage(): ReactNode {
+  return (
+    <Layout
+      title="Hackathon"
+      description={`${EVENT_NAME} \u2014 resources, templates, timeline, and FAQ.`}
+    >
+      {/* Hide just the "See resources" link in the site-wide hackathon banner
+          when the visitor is already on this page — the link points here, so
+          showing it would be redundant. The lead text still shows so the
+          event branding stays consistent across pages. */}
+      <Head>
+        <style>{`.theme-announcement-bar a { display: none !important; }`}</style>
+      </Head>
+      <main className="border-t border-db-cyan/30 bg-db-bg dark:border-db-cyan/25 dark:bg-[#0d1a1f]">
+        <section className="container px-4 pt-16 pb-10 md:pt-20 md:pb-12">
+          <div className="mx-auto max-w-4xl">
+            <EyebrowLabel>Hackathon</EyebrowLabel>
+            <h1 className="mb-4 text-4xl leading-[1.06] font-medium tracking-tight text-black dark:text-white md:text-5xl">
+              <span className="text-db-lava">{EVENT_NAME}</span>
+            </h1>
+            <p className="m-0 mb-4 inline-flex items-center gap-2 text-sm font-medium text-black/70 dark:text-white/70">
+              <CalendarDays className="h-4 w-4 text-db-lava" aria-hidden />
+              {EVENT_DATES}
+            </p>
+            <p className="mb-8 max-w-2xl text-lg text-black/68 dark:text-white/68">
+              {EVENT_TAGLINE}
+            </p>
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+              <BootstrapCopyButton source="hackathon" />
+              <Link
+                to="/templates"
+                className="inline-flex items-center gap-2 rounded-full border border-black/15 bg-white px-5 py-2 text-sm font-medium text-black/80 no-underline dark:border-white/15 dark:bg-white/8 dark:text-white/80"
+              >
+                Browse templates
+                <ArrowUpRight aria-hidden className="h-4 w-4" />
+              </Link>
+            </div>
+            <p className="mt-3 text-xs text-black/50 dark:text-white/50">
+              Copy the prompt into Cursor, Claude Code, Codex, or any coding
+              agent and it will scaffold a Databricks app for you.
+            </p>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 text-2xl font-medium text-black dark:text-white">
+              Resources
+            </h2>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              {RESOURCES.map((resource) => (
+                <ResourceCard key={resource.title} resource={resource} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <CalendarDays className="h-5 w-5 text-db-lava" aria-hidden />
+              Timeline
+            </h2>
+            <ol className="m-0 list-none space-y-3 p-0">
+              {TIMELINE.map((item) => (
+                <li
+                  key={item.label}
+                  className="grid grid-cols-1 gap-1 rounded-xl border border-black/10 bg-[#f7f6f4] p-4 md:grid-cols-[200px_1fr] md:gap-4 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <div>
+                    <p className="m-0 text-sm font-semibold text-black dark:text-white">
+                      {item.label}
+                    </p>
+                    <p className="m-0 text-xs text-db-lava">{item.date}</p>
+                  </div>
+                  <p className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {item.detail}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <Trophy className="h-5 w-5 text-db-lava" aria-hidden />
+              Judging criteria
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {JUDGING_CRITERIA.map((c) => (
+                <div
+                  key={c.title}
+                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <h3 className="m-0 mb-2 text-base font-medium text-black dark:text-white">
+                    {c.title}
+                  </h3>
+                  <p className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {c.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="container px-4 pt-10 pb-20 md:pt-14 md:pb-28">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <HelpCircle className="h-5 w-5 text-db-lava" aria-hidden />
+              FAQ
+            </h2>
+            <dl className="m-0 space-y-4">
+              {FAQ.map((item) => (
+                <div
+                  key={item.q}
+                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <dt className="m-0 mb-2 text-sm font-semibold text-black dark:text-white">
+                    {item.q}
+                  </dt>
+                  <dd className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {item.a}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/hackathon.tsx
+++ b/src/pages/hackathon.tsx
@@ -64,21 +64,21 @@ const TIMELINE = [
   {
     label: "Registration opens",
     date: "June 14, 2026",
-    detail: "Sign up on the event page \u2014 link coming soon.",
+    detail: "Sign up \u2014 more info coming soon.",
   },
   {
     label: "Hacking begins",
-    date: "June 15, 2026",
-    detail: "Kickoff livestream + prompts dropped.",
+    date: "June 15, 2026 \u00b7 8:00am",
+    detail: "Kickoff + prompts dropped.",
   },
   {
     label: "Submissions close",
-    date: "June 16, 2026 \u00b7 11:59pm PT",
-    detail: "Submit your repo, demo video, and one-paragraph writeup.",
+    date: "June 16, 2026 \u00b7 5:00pm",
+    detail: "Submit your completed app.",
   },
   {
-    label: "Winners announced",
-    date: "June 18, 2026",
+    label: "Judging + Winners announced",
+    date: "June 16, 2026 \u00b7 5:00pm - 9:00pm",
     detail: "Judging by Databricks engineering and DevRel.",
   },
 ];
@@ -108,7 +108,7 @@ const JUDGING_CRITERIA = [
 const FAQ = [
   {
     q: "Do I need a Databricks account to participate?",
-    a: "Yes. The free trial is enough for most submissions \u2014 sign up at databricks.com/signup.",
+    a: "Yes. A free edition account is enough for most submissions \u2014 sign up at databricks.com/learn/free-edition.",
   },
   {
     q: "Can I work in a team?",

--- a/tests/hackathon-banner.test.ts
+++ b/tests/hackathon-banner.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "vitest";
+import {
+  getHackathonBannerConfig,
+  resolveHackathonBannerActive,
+  type HackathonBannerEnv,
+} from "../src/lib/hackathon-banner-server";
+
+const INSIDE = new Date("2026-06-15T12:00:00Z");
+const BEFORE = new Date("2026-05-01T12:00:00Z");
+const AFTER = new Date("2026-08-01T12:00:00Z");
+const ON_START_MIDNIGHT = new Date("2026-06-10T00:00:00Z");
+const ON_END_LAST_MS = new Date("2026-06-20T23:59:59.999Z");
+const JUST_BEFORE_START = new Date("2026-06-09T23:59:59.999Z");
+const JUST_AFTER_END = new Date("2026-06-21T00:00:00.000Z");
+
+const WINDOW = {
+  HACKATHON_START: "2026-06-10",
+  HACKATHON_END: "2026-06-20",
+} satisfies HackathonBannerEnv;
+
+describe("resolveHackathonBannerActive", () => {
+  test("returns false when no env vars are set", () => {
+    expect(resolveHackathonBannerActive({}, INSIDE)).toBe(false);
+  });
+
+  test('HACKATHON_BANNER_ENABLED="true" forces on, ignoring dates', () => {
+    expect(
+      resolveHackathonBannerActive(
+        { HACKATHON_BANNER_ENABLED: "true" },
+        BEFORE,
+      ),
+    ).toBe(true);
+    expect(
+      resolveHackathonBannerActive(
+        { HACKATHON_BANNER_ENABLED: "true", ...WINDOW },
+        AFTER,
+      ),
+    ).toBe(true);
+  });
+
+  test('HACKATHON_BANNER_ENABLED="false" forces off, ignoring dates', () => {
+    expect(
+      resolveHackathonBannerActive(
+        { HACKATHON_BANNER_ENABLED: "false", ...WINDOW },
+        INSIDE,
+      ),
+    ).toBe(false);
+  });
+
+  test("non-boolean enable values fall through to the date window", () => {
+    for (const value of ["1", "yes", "True", "TRUE", ""]) {
+      expect(
+        resolveHackathonBannerActive(
+          { HACKATHON_BANNER_ENABLED: value, ...WINDOW },
+          INSIDE,
+        ),
+      ).toBe(true);
+      expect(
+        resolveHackathonBannerActive(
+          { HACKATHON_BANNER_ENABLED: value, ...WINDOW },
+          BEFORE,
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test("date window is inclusive on both ends", () => {
+    expect(resolveHackathonBannerActive(WINDOW, ON_START_MIDNIGHT)).toBe(true);
+    expect(resolveHackathonBannerActive(WINDOW, ON_END_LAST_MS)).toBe(true);
+    expect(resolveHackathonBannerActive(WINDOW, INSIDE)).toBe(true);
+  });
+
+  test("date window excludes times outside the range", () => {
+    expect(resolveHackathonBannerActive(WINDOW, BEFORE)).toBe(false);
+    expect(resolveHackathonBannerActive(WINDOW, AFTER)).toBe(false);
+    expect(resolveHackathonBannerActive(WINDOW, JUST_BEFORE_START)).toBe(false);
+    expect(resolveHackathonBannerActive(WINDOW, JUST_AFTER_END)).toBe(false);
+  });
+
+  test("requires both start and end to be set", () => {
+    expect(
+      resolveHackathonBannerActive({ HACKATHON_START: "2026-06-10" }, INSIDE),
+    ).toBe(false);
+    expect(
+      resolveHackathonBannerActive({ HACKATHON_END: "2026-06-20" }, INSIDE),
+    ).toBe(false);
+  });
+
+  test("rejects start > end", () => {
+    expect(
+      resolveHackathonBannerActive(
+        { HACKATHON_START: "2026-06-20", HACKATHON_END: "2026-06-10" },
+        INSIDE,
+      ),
+    ).toBe(false);
+  });
+
+  test("rejects malformed or non-ISO dates", () => {
+    for (const [start, end] of [
+      ["06/10/2026", "06/20/2026"],
+      ["2026-6-10", "2026-6-20"],
+      ["not-a-date", "2026-06-20"],
+      ["2026-06-10", "not-a-date"],
+      ["2026-13-01", "2026-13-20"],
+    ] as const) {
+      expect(
+        resolveHackathonBannerActive(
+          { HACKATHON_START: start, HACKATHON_END: end },
+          INSIDE,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("getHackathonBannerConfig", () => {
+  test("returns undefined when inactive", () => {
+    expect(getHackathonBannerConfig({}, INSIDE)).toBeUndefined();
+  });
+
+  test("returns a brand-styled, non-dismissible config when active", () => {
+    const config = getHackathonBannerConfig(
+      { HACKATHON_BANNER_ENABLED: "true" },
+      INSIDE,
+    );
+    expect(config).toBeDefined();
+    expect(config?.id).toBe("hackathon-2026");
+    expect(config?.isCloseable).toBe(false);
+    expect(config?.backgroundColor).toBe("var(--db-lava)");
+    expect(config?.textColor).toBe("#ffffff");
+    expect(config?.content).toContain('href="/hackathon"');
+  });
+
+  test("HACKATHON_BANNER_TEXT overrides only the lead text; link is always appended", () => {
+    const config = getHackathonBannerConfig(
+      {
+        HACKATHON_BANNER_ENABLED: "true",
+        HACKATHON_BANNER_TEXT: "Custom message",
+      },
+      INSIDE,
+    );
+    expect(config?.content).toContain("Custom message");
+    expect(config?.content).toContain('href="/hackathon"');
+    expect(config?.content).toContain("See resources");
+    expect(config?.content).not.toContain(
+      "Databricks Developer Hackathon is live",
+    );
+  });
+
+  test("trims trailing whitespace from HACKATHON_BANNER_TEXT before appending the link", () => {
+    const config = getHackathonBannerConfig(
+      {
+        HACKATHON_BANNER_ENABLED: "true",
+        HACKATHON_BANNER_TEXT: "Custom message   ",
+      },
+      INSIDE,
+    );
+    expect(config?.content).toBe(
+      'Custom message <a href="/hackathon"><b>See resources &rarr;</b></a>',
+    );
+  });
+
+  test("default lead text is used when HACKATHON_BANNER_TEXT is unset", () => {
+    const config = getHackathonBannerConfig(
+      { HACKATHON_BANNER_ENABLED: "true" },
+      INSIDE,
+    );
+    expect(config?.content).toContain(
+      "Databricks Developer Hackathon is live.",
+    );
+    expect(config?.content).toContain('href="/hackathon"');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an evergreen `/hackathon` resources page (`src/pages/hackathon.tsx`) that is always live and discoverable in `sitemap.xml` so the URL is shareable ahead of the event, but **unlinked from the navbar and the footer** so the banner is the only on-site entry point while it's active.
- Adds a site-wide announcement bar wired through Docusaurus' built-in `themeConfig.announcementBar` (no theme swizzling). The bar is **non-dismissible**, brand-styled (lava red on white), and links to `/hackathon`. On `/hackathon` itself the link is hidden via a colocated `<Head>` style tag so the CTA is never redundant.
- Activation is build-time and resolved by a pure function in `src/lib/hackathon-banner-server.ts` — mirrors the existing `SHOW_DRAFTS` pattern, with full unit-test coverage in `tests/hackathon-banner.test.ts` (14 tests covering force on/off, inclusive date window, malformed dates, lead-text override, whitespace handling, etc.).
- Documents the four env vars and the precedence rule in `CONTRIBUTING.md` (new "Hackathon Banner" subsection under Feature Flags).

### Env contract

| Env var | Purpose |
| --- | --- |
| `HACKATHON_BANNER_ENABLED` | Escape hatch. `"true"` forces on, `"false"` forces off. Anything else falls through to dates. |
| `HACKATHON_START` | ISO `YYYY-MM-DD`. Required along with `HACKATHON_END` for date-driven activation. |
| `HACKATHON_END` | ISO `YYYY-MM-DD`. Inclusive through 23:59:59.999 UTC. |
| `HACKATHON_BANNER_TEXT` | Optional override for the lead-in text only. The "See resources" link to `/hackathon` is always appended so a misconfigured override can never strand visitors. |

Flipping the banner on Vercel is "edit env var → redeploy" — same model as `SHOW_DRAFTS`.

## Important — content is placeholder

**The content on `src/pages/hackathon.tsx` (event name, dates, tagline, timeline entries, judging criteria, FAQ) is all placeholder copy.** It needs to be updated to the real hackathon details before any event goes live. Likewise, the default banner copy (`"Databricks Developer Hackathon is live."`) and the `id: "hackathon-2026"` in `getHackathonBannerConfig` should be reviewed / bumped per event.

## Test plan

- [x] `npm run fmt` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run verify:images` — 64 images verified
- [x] `npx vitest run` — 269 tests pass (14 new banner tests)
- [x] `npm run build` — production build succeeds; `/hackathon` rendered, sitemap includes `https://dev.databricks.com/hackathon`
- [x] Spot-checked locally with `HACKATHON_BANNER_ENABLED=true` in `.env.local` — banner renders site-wide; link is hidden on `/hackathon`; bar disappears when env is unset and the build regenerates
- [ ] Reviewer: confirm placeholder copy on `/hackathon` is intentional pending real event content