### PR TITLE
feat(hackathon): support multiple events at /hackathon/<slug>

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,22 +38,23 @@ SHOW_DRAFTS=true
 
 A flag is **enabled only when its value is exactly `"true"`** — any other value (empty, `"1"`, `"yes"`) is treated as disabled.
 
-### Hackathon Banner
+### Hackathon Banner & Events
 
-The site-wide announcement bar that points visitors at [`/hackathon`](./src/pages/hackathon.tsx) is driven by env vars at build time and resolved by `src/lib/hackathon-banner-server.ts`. The banner uses Docusaurus' built-in `themeConfig.announcementBar` so it shows above the navbar on every page (docs, templates, solutions, MDX). It's intentionally **non-dismissible** so the banner stays as the only on-site entry point to `/hackathon` for the full event window.
+Each hackathon event is its own page at `/hackathon/<slug>`, served by a file under [`src/pages/hackathon/`](./src/pages/hackathon/) (for example [`apps-agents-for-good-2026.tsx`](./src/pages/hackathon/apps-agents-for-good-2026.tsx)). Events are fully independent — editing one never touches another. An event can reuse the shared [`HackathonEventPage`](./src/components/hackathon/hackathon-event-page.tsx) template by passing a typed `HackathonEvent` object, or render a completely bespoke layout instead. Event pages are `noindex` and kept out of `sitemap.xml`; entry is via the banner.
 
-| Env var                    | Purpose                                                                                                                                                                                                                                                                 |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HACKATHON_BANNER_ENABLED` | Escape hatch. `"true"` forces the banner on, `"false"` forces it off. Anything else (including unset) falls through to dates.                                                                                                                                           |
-| `HACKATHON_START`          | ISO date `YYYY-MM-DD`. Required (along with `HACKATHON_END`) for date-driven activation.                                                                                                                                                                                |
-| `HACKATHON_END`            | ISO date `YYYY-MM-DD`. Inclusive through 23:59:59.999 UTC of the given day.                                                                                                                                                                                             |
-| `HACKATHON_BANNER_TEXT`    | Optional override for the **lead-in text only** (HTML allowed). The "See resources" link to `/hackathon` is always appended, so a misconfigured override can never strand visitors on a banner with no way in. Defaults to `"Databricks Developer Hackathon is live."`. |
+`/hackathon` ([`src/pages/hackathon/index.tsx`](./src/pages/hackathon/index.tsx)) redirects to the active event named by `HACKATHON_EVENT_SLUG`. When no slug is set it shows a minimal placeholder instead of redirecting nowhere.
 
-Precedence: `HACKATHON_BANNER_ENABLED` wins. Otherwise the banner is active if both dates are set, parseable, `start <= end`, and "now" is within the window.
+The site-wide announcement bar is driven by env vars at build time and resolved by [`src/lib/hackathon-banner-server.ts`](./src/lib/hackathon-banner-server.ts). It uses Docusaurus' built-in `themeConfig.announcementBar` so it shows above the navbar on every page (docs, templates, solutions, MDX). It's intentionally **non-dismissible** so it stays the only on-site entry point to the event for the full window.
 
-The `/hackathon` page itself is always live (and discoverable in `sitemap.xml`) so the URL is shareable ahead of the event. It is not linked from the navbar or the footer — the banner is the only on-site entry point, and it only appears while the banner is active.
+| Env var                    | Purpose                                                                                                                                                                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HACKATHON_BANNER_ENABLED` | Banner on **only when the value is exactly `"true"`** — any other value (including unset) is off. Same convention as `SHOW_DRAFTS`.                                                                                                                     |
+| `HACKATHON_EVENT_SLUG`     | Slug of the active event. The banner links to `/hackathon/<slug>` and `/hackathon` redirects there. With no slug the banner links to `/hackathon` (which then shows the placeholder).                                                                   |
+| `HACKATHON_BANNER_TEXT`    | Optional override for the **lead-in text only** (HTML allowed). The "See resources" link is always appended, so a misconfigured override can never strand visitors on a banner with no way in. Defaults to `"Databricks Developer Hackathon is live."`. |
 
-Flipping the banner on Vercel is "edit env var → redeploy", the same model as `SHOW_DRAFTS`. Bump the `id` in `getHackathonBannerConfig` per event so prior dismissals (stored in `localStorage`) are reset for returning visitors.
+Flipping the banner on Vercel is "edit env var → redeploy", the same model as `SHOW_DRAFTS`. The banner `id` is namespaced per slug automatically (`hackathon-<slug>`), so prior dismissals reset cleanly between events.
+
+To stand up a new event: copy an existing file in `src/pages/hackathon/` to a new slug, edit its data (or write a custom layout), then set `HACKATHON_EVENT_SLUG=<new-slug>` and `HACKATHON_BANNER_ENABLED=true` on Vercel.
 
 ### Site URL Resolution
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -31,6 +31,9 @@ const config: Config = {
   favicon: "img/favicon.png",
   customFields: {
     showDrafts: showDrafts(),
+    // Slug of the active hackathon event. `/hackathon` redirects here and the
+    // announcement banner links to it. See src/lib/hackathon-banner-server.ts.
+    hackathonEventSlug: process.env.HACKATHON_EVENT_SLUG,
   },
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -100,7 +103,7 @@ const config: Config = {
           customCss: "./src/css/custom.css",
         },
         sitemap: {
-          ignorePatterns: ["/hackathon", "/hackathon/"],
+          ignorePatterns: ["/hackathon", "/hackathon/", "/hackathon/**"],
         },
       } satisfies Preset.Options,
     ],

--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -1,0 +1,341 @@
+import Head from "@docusaurus/Head";
+import Link from "@docusaurus/Link";
+import Layout from "@theme/Layout";
+import {
+  ArrowUpRight,
+  CalendarDays,
+  HelpCircle,
+  MapPin,
+  Trophy,
+  Upload,
+} from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
+
+/**
+ * Shared, opt-in template for a single hackathon event page.
+ *
+ * Each event lives at its own `/hackathon/<slug>` route (a file under
+ * `src/pages/hackathon/`). Events that want the standard look pass a typed
+ * `HackathonEvent` object to this component; events that need to be different
+ * can ignore it entirely and render their own layout. Editing one event never
+ * touches another.
+ *
+ * Entry to an event during its window is via the site-wide announcement banner
+ * (see `src/lib/hackathon-banner-server.ts`), which links to the slug named by
+ * the `HACKATHON_EVENT_SLUG` env var.
+ */
+
+type HackathonResource = {
+  title: string;
+  description: ReactNode;
+  href: string;
+  external?: boolean;
+  Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+};
+
+type HackathonTimelineItem = {
+  label: string;
+  date: string;
+  detail: string;
+};
+
+type HackathonJudgingCriterion = {
+  title: string;
+  detail: string;
+};
+
+type HackathonFaqItem = {
+  q: string;
+  a: string;
+};
+
+export type HackathonEvent = {
+  name: string;
+  eyebrow?: string;
+  dates: string;
+  location: string;
+  partner?: string;
+  tagline: ReactNode;
+  taglineSecondary?: ReactNode;
+  applyUrl: string;
+  applyLabel?: string;
+  applyNote?: ReactNode;
+  resources: HackathonResource[];
+  timeline: HackathonTimelineItem[];
+  submission: ReactNode;
+  judgingIntro?: ReactNode;
+  judgingCriteria: HackathonJudgingCriterion[];
+  faq: HackathonFaqItem[];
+  metaTitle?: string;
+  metaDescription?: string;
+};
+
+function DatabricksLogo({ className }: { className?: string }): ReactNode {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 712.77 112.97"
+      aria-hidden
+      focusable={false}
+      className={className}
+    >
+      <polygon
+        fill="#ff3621"
+        points="0 29.44 0 32.84 52.13 62.25 98.69 35.96 98.7 46.58 52.13 73.04 2.62 44.91 0 46.37 0 66.72 52.13 96.06 98.69 69.86 98.7 80.4 52.13 106.86 2.62 78.73 0 80.19 0 83.64 52.13 112.97 104.26 83.64 104.26 63.27 101.63 61.82 52.13 89.95 5.56 63.49 5.56 53 52.13 79.17 104.26 49.83 104.26 29.76 101.63 28.3 52.13 56.44 7.95 31.33 52.13 6.38 88.52 26.94 91.7 25.15 91.7 22.35 52.13 0 0 29.44"
+      />
+      <g fill="currentColor">
+        <path d="M202.16,96.24V6.4H188.32V40a1.19,1.19,0,0,1-2.09.77c-4.68-5.49-12-8.64-20-8.64-17.11,0-30.5,14.43-30.5,32.84a34.07,34.07,0,0,0,8.8,23.43,29.33,29.33,0,0,0,21.7,9.41,26,26,0,0,0,20-9,1.19,1.19,0,0,1,2.1.77v6.69Zm-32.84-11c-11,0-19.64-8.92-19.64-20.3s8.63-20.3,19.64-20.3S189,53.58,189,65s-8.63,20.3-19.65,20.3" />
+        <path d="M276,96.24V33.68H262.33V40a1.2,1.2,0,0,1-.79,1.12,1.17,1.17,0,0,1-1.31-.36c-4.65-5.54-11.75-8.6-20-8.6-17.1,0-30.5,14.43-30.5,32.84s13.4,32.84,30.5,32.84a25.75,25.75,0,0,0,20-9.11,1.18,1.18,0,0,1,1.32-.36,1.2,1.2,0,0,1,.79,1.12v6.79Zm-32.71-11c-11,0-19.65-8.92-19.65-20.3s8.63-20.3,19.65-20.3S263,53.58,263,65s-8.63,20.3-19.65,20.3" />
+        <path d="M393.28,96.24V33.68H379.56V40a1.19,1.19,0,0,1-2.1.76c-4.64-5.54-11.75-8.6-20-8.6C340.35,32.12,327,46.55,327,65s13.4,32.84,30.5,32.84a25.75,25.75,0,0,0,20-9.11,1.19,1.19,0,0,1,2.1.76v6.79Zm-32.71-11c-11,0-19.65-8.92-19.65-20.3s8.63-20.3,19.65-20.3,19.64,8.92,19.64,20.3-8.63,20.3-19.64,20.3" />
+        <path d="M418.41,88.81a1.14,1.14,0,0,1,.41-.07,1.21,1.21,0,0,1,.91.41c4.68,5.5,12,8.64,20,8.64,17.1,0,30.5-14.42,30.5-32.83a34.12,34.12,0,0,0-8.8-23.43,29.33,29.33,0,0,0-21.7-9.41,26,26,0,0,0-20,9,1.19,1.19,0,0,1-2.1-.76l0-34H403.82l0,89.84h13.84V89.93a1.2,1.2,0,0,1,.78-1.12M417,65c0-11.38,8.63-20.3,19.64-20.3s19.65,8.92,19.65,20.3-8.63,20.29-19.65,20.29S417,76.34,417,65" />
+        <path d="M510.07,46.48a16.07,16.07,0,0,1,3.34.31V32.61a11.84,11.84,0,0,0-2.3-.23A20.05,20.05,0,0,0,493.8,42a1.19,1.19,0,0,1-2.21-.61V33.68H477.88V96.24h13.84V68.73c0-13.73,7-22.25,18.35-22.25" />
+        <rect x="522.08" y="33.68" width="13.97" height="62.56" />
+        <path d="M528.9,6.46a8.48,8.48,0,1,0,8.48,8.47,8.48,8.48,0,0,0-8.48-8.47" />
+        <path d="M577.1,32.12C557.93,32.12,544,45.93,544,65c0,9.25,3.26,17.62,9.19,23.56S567.6,97.8,577,97.8c7.76,0,13.81-1.54,25.21-9.91l-7.86-8.29c-5.6,3.72-10.81,5.53-15.92,5.53-11.57,0-20.3-8.67-20.3-20.17s8.73-20.17,20.3-20.17a25.63,25.63,0,0,1,15.65,5.53L602.83,42c-10.2-8.86-19.56-9.89-25.73-9.89" />
+        <path d="M626.49,68.65a1.2,1.2,0,0,1,.8-.31h.08a1.24,1.24,0,0,1,.85.44l22.13,27.44,17,0L638.74,61.6a1.19,1.19,0,0,1,.08-1.6l26.32-26.32H648.26L625.59,56.46a1.18,1.18,0,0,1-2-.84l0-49.22H609.73V96.24h13.84V71.86A1.15,1.15,0,0,1,624,71Z" />
+        <path d="M689.94,97.8c11.35,0,22.83-6.87,22.83-20,0-8.56-5.35-14.46-16.37-18l-7.54-2.47c-5.06-1.69-7.53-4.11-7.53-7.41,0-3.77,3.38-6.4,8.22-6.4,4.6,0,8.7,3,11.29,8.24l11.11-6a24.44,24.44,0,0,0-22.4-13.63c-12.4,0-21.41,8-21.41,18.94,0,8.67,5.19,14.53,15.86,17.92l7.67,2.47c5.43,1.72,7.65,3.86,7.65,7.41,0,5.29-4.91,7.17-9.12,7.17-5.62,0-10.58-3.64-13-9.52L666,82.36c3.71,9.53,12.87,15.44,24,15.44" />
+        <path d="M314.38,97.16a73.68,73.68,0,0,0,10.51-.73v-12a64.56,64.56,0,0,1-6.94.45c-5.62,0-9.91-1-9.91-13.06V46.14A1.18,1.18,0,0,1,309.22,45h13.47V33.67H309.22A1.19,1.19,0,0,1,308,32.49V14.35H294.28V32.49a1.19,1.19,0,0,1-1.19,1.19h-9.64V45h9.63a1.18,1.18,0,0,1,1.19,1.18V75.28c0,21.88,14.6,21.88,20.1,21.88" />
+      </g>
+    </svg>
+  );
+}
+
+function EventEyebrow({ label }: { label: string }): ReactNode {
+  return (
+    <p className="mb-4 flex items-center gap-3 text-black/70 dark:text-white/70">
+      <DatabricksLogo className="h-4 w-auto" />
+      <span className="sr-only">Databricks </span>
+      <span className="text-[10px] font-semibold tracking-[0.12em] uppercase">
+        {label}
+      </span>
+    </p>
+  );
+}
+
+function ResourceCard({
+  resource,
+}: {
+  resource: HackathonResource;
+}): ReactNode {
+  const { title, description, href, external, Icon } = resource;
+  const cardClasses =
+    "group flex h-full flex-col rounded-xl border border-black/10 bg-[#f7f6f4] p-6 no-underline transition-colors duration-200 hover:border-db-lava/50 dark:border-white/10 dark:bg-[#182a32] dark:hover:border-db-lava-light/55";
+  const body = (
+    <>
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="h-5 w-5 text-db-lava" aria-hidden />
+        <h3 className="m-0 text-lg font-medium text-black dark:text-white">
+          {title}
+        </h3>
+        {external && (
+          <ArrowUpRight
+            aria-hidden
+            className="ml-auto h-4 w-4 text-black/40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 dark:text-white/40"
+          />
+        )}
+      </div>
+      <div className="text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+        {description}
+      </div>
+    </>
+  );
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cardClasses}
+        aria-label={`${title} (opens in new tab)`}
+      >
+        {body}
+      </a>
+    );
+  }
+  return (
+    <Link to={href} className={cardClasses}>
+      {body}
+    </Link>
+  );
+}
+
+export function HackathonEventPage({
+  event,
+}: {
+  event: HackathonEvent;
+}): ReactNode {
+  const metaTitle = event.metaTitle ?? event.name;
+  const metaDescription =
+    event.metaDescription ??
+    `${event.name} — schedule, resources, and how to apply.`;
+  const applyLabel = event.applyLabel ?? "Apply";
+  const judgingIntro =
+    event.judgingIntro ?? "Submissions will be judged on the following:";
+
+  return (
+    <Layout title={metaTitle} description={metaDescription}>
+      {/* Hide just the "See resources" link in the site-wide hackathon banner
+          when the visitor is already on an event page — the link points here, so
+          showing it would be redundant. The lead text still shows so the
+          event branding stays consistent across pages. Event pages are not
+          indexed; entry is via the banner. */}
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+        <style>{`.theme-announcement-bar a { display: none !important; }`}</style>
+      </Head>
+      <main className="border-t border-db-cyan/30 bg-db-bg dark:border-db-cyan/25 dark:bg-[#0d1a1f]">
+        <section className="container px-4 pt-16 pb-10 md:pt-20 md:pb-12">
+          <div className="mx-auto max-w-4xl">
+            {event.eyebrow && <EventEyebrow label={event.eyebrow} />}
+            <h1 className="mb-4 text-4xl leading-[1.06] font-medium tracking-tight text-black dark:text-white md:text-5xl">
+              <span className="text-db-lava">{event.name}</span>
+            </h1>
+            <p className="m-0 flex items-center gap-2 text-sm font-medium text-black/70 dark:text-white/70">
+              <CalendarDays className="h-4 w-4 text-db-lava" aria-hidden />
+              {event.dates}
+            </p>
+            <p className="m-0 mt-2 flex items-center gap-2 text-sm font-medium text-black/70 dark:text-white/70">
+              <MapPin className="h-4 w-4 text-db-lava" aria-hidden />
+              {event.location}
+            </p>
+            {event.partner && (
+              <p className="m-0 mt-3 mb-4 text-sm font-medium text-black/70 dark:text-white/70">
+                Partnering with{" "}
+                <span className="text-base font-semibold text-black dark:text-white">
+                  {event.partner}
+                </span>
+              </p>
+            )}
+            <p className="mb-4 max-w-2xl text-lg text-black/68 dark:text-white/68">
+              {event.tagline}
+            </p>
+            {event.taglineSecondary && (
+              <p className="mb-8 max-w-2xl text-base text-black/68 dark:text-white/68">
+                {event.taglineSecondary}
+              </p>
+            )}
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+              <a
+                href={event.applyUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full bg-db-lava px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-db-lava/90"
+              >
+                {applyLabel}
+                <ArrowUpRight aria-hidden className="h-4 w-4" />
+              </a>
+            </div>
+            {event.applyNote && (
+              <p className="mt-3 text-xs text-black/50 dark:text-white/50">
+                {event.applyNote}
+              </p>
+            )}
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 text-2xl font-medium text-black dark:text-white">
+              Resources
+            </h2>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {event.resources.map((resource) => (
+                <ResourceCard key={resource.title} resource={resource} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <CalendarDays className="h-5 w-5 text-db-lava" aria-hidden />
+              Timeline
+            </h2>
+            <ol className="m-0 list-none space-y-3 p-0">
+              {event.timeline.map((item) => (
+                <li
+                  key={item.label}
+                  className="grid grid-cols-1 gap-1 rounded-xl border border-black/10 bg-[#f7f6f4] p-4 md:grid-cols-[200px_1fr] md:gap-4 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <div>
+                    <p className="m-0 text-sm font-semibold text-black dark:text-white">
+                      {item.label}
+                    </p>
+                    <p className="m-0 text-xs text-db-lava">{item.date}</p>
+                  </div>
+                  <p className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {item.detail}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-3 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <Upload className="h-5 w-5 text-db-lava" aria-hidden />
+              Submission
+            </h2>
+            <div className="m-0 text-base text-black/68 dark:text-white/68">
+              {event.submission}
+            </div>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-3 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <Trophy className="h-5 w-5 text-db-lava" aria-hidden />
+              Judging
+            </h2>
+            <p className="mb-6 text-base text-black/68 dark:text-white/68">
+              {judgingIntro}
+            </p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {event.judgingCriteria.map((c) => (
+                <div
+                  key={c.title}
+                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <h3 className="m-0 mb-2 text-base font-medium text-black dark:text-white">
+                    {c.title}
+                  </h3>
+                  <p className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {c.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="container px-4 pt-10 pb-20 md:pt-14 md:pb-28">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <HelpCircle className="h-5 w-5 text-db-lava" aria-hidden />
+              FAQ
+            </h2>
+            <dl className="m-0 space-y-4">
+              {event.faq.map((item) => (
+                <div
+                  key={item.q}
+                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <dt className="m-0 mb-2 text-sm font-semibold text-black dark:text-white">
+                    {item.q}
+                  </dt>
+                  <dd className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {item.a}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}

--- a/src/lib/hackathon-banner-server.ts
+++ b/src/lib/hackathon-banner-server.ts
@@ -1,28 +1,27 @@
 /**
  * Server-side resolution of the site-wide hackathon banner.
  *
- * Activation precedence (mirrors the `showDrafts` env pattern — strict string
- * matching, no implicit dev/CI handling):
+ * The banner is purely env-driven (strict string matching, like the `showDrafts`
+ * flag — no implicit dev/CI handling and no date windows):
  *
- *   1. `HACKATHON_BANNER_ENABLED="true"`  → force on, ignore dates
- *   2. `HACKATHON_BANNER_ENABLED="false"` → force off, ignore dates
- *   3. otherwise → on iff `now` is between `HACKATHON_START` 00:00 UTC and
- *      `HACKATHON_END` 23:59:59.999 UTC (both required, both ISO `YYYY-MM-DD`,
- *      and `start <= end`).
+ *   - `HACKATHON_BANNER_ENABLED="true"` → banner on. Any other value (including
+ *     unset) → off.
+ *   - `HACKATHON_EVENT_SLUG` → which event the banner points at. The link
+ *     targets `/hackathon/<slug>`; with no slug it falls back to `/hackathon`,
+ *     which itself redirects to the active event.
+ *   - `HACKATHON_BANNER_TEXT` → optional override of the lead-in copy. The "See
+ *     resources" link is always appended so a misconfigured override can never
+ *     strand visitors on a banner with no way in.
  *
- * Optional `HACKATHON_BANNER_TEXT` overrides the banner copy so messaging can
- * change without a code edit.
- *
- * The resolver is a pure function so it can be unit-tested with synthetic
- * envs and a fixed `now`. The config builder is the thin imperative shell
- * consumed by `docusaurus.config.ts` at build time.
+ * The resolver is a pure function so it can be unit-tested with synthetic envs.
+ * The config builder is the thin imperative shell consumed by
+ * `docusaurus.config.ts` at build time.
  */
 
-export type HackathonBannerEnv = {
+type HackathonBannerEnv = {
   HACKATHON_BANNER_ENABLED?: string;
-  HACKATHON_START?: string;
-  HACKATHON_END?: string;
   HACKATHON_BANNER_TEXT?: string;
+  HACKATHON_EVENT_SLUG?: string;
 };
 
 type HackathonBannerConfig = {
@@ -33,57 +32,35 @@ type HackathonBannerConfig = {
   isCloseable: boolean;
 };
 
-const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
-
-function parseStartOfDayUtc(value: string | undefined): number | null {
-  if (!value || !ISO_DATE.test(value)) return null;
-  const ms = Date.parse(`${value}T00:00:00.000Z`);
-  return Number.isNaN(ms) ? null : ms;
-}
-
-function parseEndOfDayUtc(value: string | undefined): number | null {
-  if (!value || !ISO_DATE.test(value)) return null;
-  const ms = Date.parse(`${value}T23:59:59.999Z`);
-  return Number.isNaN(ms) ? null : ms;
-}
-
-export function resolveHackathonBannerActive(
-  env: HackathonBannerEnv,
-  now: Date,
-): boolean {
-  if (env.HACKATHON_BANNER_ENABLED === "true") return true;
-  if (env.HACKATHON_BANNER_ENABLED === "false") return false;
-
-  const start = parseStartOfDayUtc(env.HACKATHON_START);
-  const end = parseEndOfDayUtc(env.HACKATHON_END);
-  if (start === null || end === null) return false;
-  if (start > end) return false;
-
-  const nowMs = now.getTime();
-  return nowMs >= start && nowMs <= end;
+export function resolveHackathonBannerActive(env: HackathonBannerEnv): boolean {
+  return env.HACKATHON_BANNER_ENABLED === "true";
 }
 
 const DEFAULT_BANNER_LEAD_TEXT = "Databricks Developer Hackathon is live.";
-const BANNER_LINK_HTML = '<a href="/hackathon"><b>See resources &rarr;</b></a>';
+
+function bannerLinkHtml(slug: string): string {
+  const target = slug ? `/hackathon/${slug}` : "/hackathon";
+  return `<a href="${target}"><b>See resources &rarr;</b></a>`;
+}
 
 export function getHackathonBannerConfig(
   env: HackathonBannerEnv = process.env as HackathonBannerEnv,
-  now: Date = new Date(),
 ): HackathonBannerConfig | undefined {
-  if (!resolveHackathonBannerActive(env, now)) return undefined;
+  if (!resolveHackathonBannerActive(env)) return undefined;
+  const slug = (env.HACKATHON_EVENT_SLUG ?? "").trim();
   const leadText = (
     env.HACKATHON_BANNER_TEXT ?? DEFAULT_BANNER_LEAD_TEXT
   ).trim();
   return {
     // Non-dismissible by design: the banner is the only on-site entry point to
-    // /hackathon during the event window, so we don't want visitors to close
-    // it and lose the way in. `id` is retained for future per-event resets if
-    // we re-enable dismissals.
-    id: "hackathon-2026",
+    // the event during its window, so we don't want visitors to close it and
+    // lose the way in. `id` is namespaced per event so any future re-enabling
+    // of dismissals resets cleanly between events.
+    id: `hackathon-${slug || "event"}`,
     // HACKATHON_BANNER_TEXT overrides only the lead-in copy; the "See
     // resources" link is always appended so visitors can never end up on a
-    // banner with no way to reach /hackathon.
-    content: `${leadText} ${BANNER_LINK_HTML}`,
+    // banner with no way to reach the event.
+    content: `${leadText} ${bannerLinkHtml(slug)}`,
     backgroundColor: "var(--db-lava)",
     textColor: "#ffffff",
     isCloseable: false,

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -1,0 +1,183 @@
+import {
+  BookOpen,
+  FileText,
+  LayoutTemplate,
+  MessageSquare,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  HackathonEventPage,
+  type HackathonEvent,
+} from "@/components/hackathon/hackathon-event-page";
+
+/**
+ * Apps & Agents for Good Hackathon at Data + AI Summit 2026.
+ *
+ * Served at `/hackathon/apps-agents-for-good-2026`. Content is hardcoded here so
+ * it can be edited without touching other events or shared schema. To stand up a
+ * new event, copy this file to a new slug and edit the data (or render a fully
+ * custom layout instead of `HackathonEventPage`).
+ */
+
+const event: HackathonEvent = {
+  name: "Apps & Agents for Good Hackathon",
+  eyebrow: "Data + AI Summit",
+  dates: "June 15 \u2013 June 16, 2026",
+  location: "Marriott Marquis, San Francisco",
+  partner: "OpenAI",
+  applyUrl:
+    "https://events.mlh.com/events/13878-databricks-apps-agents-hackathon-for-good",
+  applyLabel: "Apply on MLH",
+  applyNote: (
+    <>
+      Applications close Sunday, May 31, 2026 &middot; 11:59pm PT. Apply in
+      teams of 2&ndash;4 &mdash; every teammate must be registered for Data + AI
+      Summit 2026.
+    </>
+  ),
+  tagline:
+    "The Databricks Apps & Agents for Good Hackathon 2026 is a multi-day competition hosted in partnership with OpenAI, bringing developers together to drive meaningful change. This year's hackathon challenges teams to build powerful agentic data apps for social impact using Lakebase, Agent Bricks, and Databricks Apps.",
+  taglineSecondary:
+    "The event culminates in live judging, a showcase of standout projects, and cash prizes for the most impactful and imaginative solutions. The hackathon is part of Data + AI Summit 2026 \u2014 you and every teammate must be registered for the summit to participate.",
+  metaTitle:
+    "Apps & Agents for Good Hackathon \u2014 Databricks Data + AI Summit 2026",
+  metaDescription:
+    "Databricks Apps & Agents for Good Hackathon at Data + AI Summit 2026 \u2014 schedule, resources, and how to apply.",
+  resources: [
+    {
+      title: "Get started",
+      description: (
+        <>
+          <p className="m-0">
+            Read the docs to learn how to set up your coding environment and
+            start building your app.
+          </p>
+          <p className="mt-2 mb-1">
+            We suggest reading the following pages before you start hacking:
+          </p>
+          <ul className="m-0 list-disc pl-5">
+            <li>
+              <strong className="font-semibold text-black dark:text-white">
+                Start here
+              </strong>
+            </li>
+            <li>
+              <strong className="font-semibold text-black dark:text-white">
+                Platform overview
+              </strong>
+            </li>
+            <li>
+              <strong className="font-semibold text-black dark:text-white">
+                Set up your environment
+              </strong>
+            </li>
+          </ul>
+        </>
+      ),
+      href: "/docs/start-here",
+      Icon: BookOpen,
+    },
+    {
+      title: "App with Lakebase template",
+      description:
+        "Scaffold a Databricks app wired up to Lakebase from this template and start hacking right away \u2014 then adapt it to fit your project.",
+      href: "/templates/app-with-lakebase",
+      Icon: LayoutTemplate,
+    },
+    {
+      title: "Ask questions",
+      description:
+        "Stuck? Join our hackathon Discord server to ask questions and get help!",
+      href: "#",
+      external: true,
+      Icon: MessageSquare,
+    },
+    {
+      title: "Official rules",
+      description:
+        "Eligibility, team requirements, IP, and judging rules for the hackathon.",
+      href: "#",
+      external: true,
+      Icon: FileText,
+    },
+  ],
+  timeline: [
+    {
+      label: "Applications close",
+      date: "May 31, 2026 \u00b7 11:59pm PT",
+      detail: "Apply on MLH in teams of 2\u20134.",
+    },
+    {
+      label: "Opening + hacking begins",
+      date: "June 15, 2026 \u00b7 8:00am\u20134:00pm PT",
+      detail:
+        "Opening ceremony and kickoff at Marriott Marquis, San Francisco.",
+    },
+    {
+      label: "Hacker's Corner (optional)",
+      date: "June 16, 2026 \u00b7 11:00am\u20135:00pm PT",
+      detail: "Open collaboration space.",
+    },
+    {
+      label: "Judging + awards",
+      date: "June 16, 2026 \u00b7 6:00pm\u20139:00pm PT",
+      detail: "Live judging, followed by the awards ceremony.",
+    },
+    {
+      label: "Winners showcase",
+      date: "June 17, 2026",
+      detail:
+        "Winning teams and selected projects presented at Hacker's Corner for Data + AI Summit attendees.",
+    },
+  ],
+  submission:
+    "Submit a Git repo and a live Databricks App. Be prepared to give a three-minute demo explaining the user, workflow, technical approach, and key tradeoffs.",
+  judgingIntro: "Submissions will be judged on four dimensions:",
+  judgingCriteria: [
+    {
+      title: "Product judgment",
+      detail: "Is the user clear? Are the workflow and tradeoffs thoughtful?",
+    },
+    {
+      title: "Evidence and uncertainty",
+      detail:
+        "Are outputs grounded in citations? Is uncertainty handled honestly?",
+    },
+    {
+      title: "Technical execution",
+      detail:
+        "Does the app work reliably in a live demo? Are Databricks capabilities used well?",
+    },
+    {
+      title: "Ambition",
+      detail:
+        "Did the team go beyond the minimum workflow in a meaningful way?",
+    },
+  ],
+  faq: [
+    {
+      q: "Do I need to be registered for Data + AI Summit 2026?",
+      a: "Yes. The hackathon is part of Data + AI Summit 2026, and every participant \u2014 including all teammates \u2014 must be registered for the summit to take part.",
+    },
+    {
+      q: "When do applications close?",
+      a: "Sunday, May 31, 2026 at 11:59pm PT. Apply through the MLH event page; if you've applied, hold off on booking Monday activities in the DAIS attendee portal until you hear back.",
+    },
+    {
+      q: "Where is the hackathon?",
+      a: "In-person only at the Marriott Marquis in San Francisco, alongside Data + AI Summit 2026.",
+    },
+    {
+      q: "How big can my team be?",
+      a: "Teams of 2 to 4 people. Every teammate must also be registered for Data + AI Summit 2026.",
+    },
+    {
+      q: "What if I'm new to Databricks?",
+      a: 'Start with the "Start here" docs and copy one of the templates as a prompt for your coding agent \u2014 it will scaffold a working app and walk you through the rest.',
+    },
+  ],
+};
+
+export default function AppsAgentsForGood2026Page(): ReactNode {
+  return <HackathonEventPage event={event} />;
+}

--- a/src/pages/hackathon/index.tsx
+++ b/src/pages/hackathon/index.tsx
@@ -1,428 +1,64 @@
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
+import { Redirect } from "@docusaurus/router";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
-import {
-  ArrowUpRight,
-  BookOpen,
-  CalendarDays,
-  FileText,
-  HelpCircle,
-  LayoutTemplate,
-  MapPin,
-  MessageSquare,
-  Sparkles,
-  Trophy,
-  Upload,
-} from "lucide-react";
-import type { ComponentType, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 /**
- * Always-live evergreen hackathon resources page. The home/nav don't link to
- * it; entry is via the site-wide announcement banner during the event window
- * (see `src/lib/hackathon-banner-server.ts`).
+ * `/hackathon` redirects to the active event named by the `HACKATHON_EVENT_SLUG`
+ * env var (exposed via `customFields` in `docusaurus.config.ts`). Each event
+ * lives at `/hackathon/<slug>`. When no slug is configured, a minimal,
+ * non-indexed placeholder is shown instead of redirecting nowhere.
  *
- * Content is hardcoded so it can be edited per-event without touching schema
- * or env vars. Bump the dates / event name in this file before each hackathon.
+ * The client-side `<Redirect>` handles SPA navigation; the `<meta refresh>`
+ * covers no-JS visitors. The page is `noindex` either way.
  */
 
-const EVENT_NAME = "Apps & Agents for Good Hackathon";
-const EVENT_DATES = "June 15 \u2013 June 16, 2026";
-const EVENT_LOCATION = "Marriott Marquis, San Francisco";
-const APPLY_URL =
-  "https://events.mlh.com/events/13878-databricks-apps-agents-hackathon-for-good";
-const APPLICATION_DEADLINE = "Sunday, May 31, 2026 \u00b7 11:59pm PT";
-const EVENT_TAGLINE =
-  "The Databricks Apps & Agents for Good Hackathon 2026 is a multi-day competition hosted in partnership with OpenAI, bringing developers together to drive meaningful change. This year's hackathon challenges teams to build powerful agentic data apps for social impact using Lakebase, Agent Bricks, and Databricks Apps.";
-const EVENT_TAGLINE_SECONDARY =
-  "The event culminates in live judging, a showcase of standout projects, and cash prizes for the most impactful and imaginative solutions. The hackathon is part of Data + AI Summit 2026 \u2014 you and every teammate must be registered for the summit to participate.";
+export default function HackathonIndex(): ReactNode {
+  const { siteConfig } = useDocusaurusContext();
+  const fields = siteConfig.customFields as Record<string, unknown>;
+  const slug = (
+    typeof fields.hackathonEventSlug === "string"
+      ? fields.hackathonEventSlug
+      : ""
+  ).trim();
+  const target = useBaseUrl(`/hackathon/${slug}`);
 
-type Resource = {
-  title: string;
-  description: ReactNode;
-  href: string;
-  external?: boolean;
-  Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
-};
-
-const RESOURCES: Resource[] = [
-  {
-    title: "Get started",
-    description: (
-      <>
-        <p className="m-0">
-          Read the docs to learn how to set up your coding environment and start
-          building your app.
-        </p>
-        <p className="mt-2 mb-1">
-          We suggest reading the following pages before you start hacking:
-        </p>
-        <ul className="m-0 list-disc pl-5">
-          <li>
-            <strong className="font-semibold text-black dark:text-white">
-              Start here
-            </strong>
-          </li>
-          <li>
-            <strong className="font-semibold text-black dark:text-white">
-              Platform overview
-            </strong>
-          </li>
-          <li>
-            <strong className="font-semibold text-black dark:text-white">
-              Set up your environment
-            </strong>
-          </li>
-        </ul>
-      </>
-    ),
-    href: "/docs/start-here",
-    Icon: BookOpen,
-  },
-  {
-    title: "App with Lakebase template",
-    description:
-      "Scaffold a Databricks app wired up to Lakebase from this template and start hacking right away \u2014 then adapt it to fit your project.",
-    href: "/templates/app-with-lakebase",
-    Icon: LayoutTemplate,
-  },
-  {
-    title: "Ask questions",
-    description:
-      "Stuck? Join our hackathon Discord server to ask questions and get help!",
-    href: "#",
-    external: true,
-    Icon: MessageSquare,
-  },
-  {
-    title: "Official rules",
-    description:
-      "Eligibility, team requirements, IP, and judging rules for the hackathon.",
-    href: "#",
-    external: true,
-    Icon: FileText,
-  },
-];
-
-const TIMELINE = [
-  {
-    label: "Applications close",
-    date: "May 31, 2026 \u00b7 11:59pm PT",
-    detail: "Apply on MLH in teams of 2\u20134.",
-  },
-  {
-    label: "Opening + hacking begins",
-    date: "June 15, 2026 \u00b7 8:00am\u20134:00pm PT",
-    detail: "Opening ceremony and kickoff at Marriott Marquis, San Francisco.",
-  },
-  {
-    label: "Hacker's Corner (optional)",
-    date: "June 16, 2026 \u00b7 11:00am\u20135:00pm PT",
-    detail: "Open collaboration space.",
-  },
-  {
-    label: "Judging + awards",
-    date: "June 16, 2026 \u00b7 6:00pm\u20139:00pm PT",
-    detail: "Live judging, followed by the awards ceremony.",
-  },
-  {
-    label: "Winners showcase",
-    date: "June 17, 2026",
-    detail:
-      "Winning teams and selected projects presented at Hacker's Corner for Data + AI Summit attendees.",
-  },
-];
-
-const JUDGING_CRITERIA = [
-  {
-    title: "Product judgment",
-    detail: "Is the user clear? Are the workflow and tradeoffs thoughtful?",
-  },
-  {
-    title: "Evidence and uncertainty",
-    detail:
-      "Are outputs grounded in citations? Is uncertainty handled honestly?",
-  },
-  {
-    title: "Technical execution",
-    detail:
-      "Does the app work reliably in a live demo? Are Databricks capabilities used well?",
-  },
-  {
-    title: "Ambition",
-    detail: "Did the team go beyond the minimum workflow in a meaningful way?",
-  },
-];
-
-const FAQ = [
-  {
-    q: "Do I need to be registered for Data + AI Summit 2026?",
-    a: "Yes. The hackathon is part of Data + AI Summit 2026, and every participant \u2014 including all teammates \u2014 must be registered for the summit to take part.",
-  },
-  {
-    q: "When do applications close?",
-    a: "Sunday, May 31, 2026 at 11:59pm PT. Apply through the MLH event page; if you've applied, hold off on booking Monday activities in the DAIS attendee portal until you hear back.",
-  },
-  {
-    q: "Where is the hackathon?",
-    a: "In-person only at the Marriott Marquis in San Francisco, alongside Data + AI Summit 2026.",
-  },
-  {
-    q: "How big can my team be?",
-    a: "Teams of 2 to 4 people. Every teammate must also be registered for Data + AI Summit 2026.",
-  },
-  {
-    q: "What if I'm new to Databricks?",
-    a: 'Start with the "Start here" docs and copy one of the templates as a prompt for your coding agent \u2014 it will scaffold a working app and walk you through the rest.',
-  },
-];
-
-function DatabricksLogo({ className }: { className?: string }): ReactNode {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 712.77 112.97"
-      aria-hidden
-      focusable={false}
-      className={className}
-    >
-      <polygon
-        fill="#ff3621"
-        points="0 29.44 0 32.84 52.13 62.25 98.69 35.96 98.7 46.58 52.13 73.04 2.62 44.91 0 46.37 0 66.72 52.13 96.06 98.69 69.86 98.7 80.4 52.13 106.86 2.62 78.73 0 80.19 0 83.64 52.13 112.97 104.26 83.64 104.26 63.27 101.63 61.82 52.13 89.95 5.56 63.49 5.56 53 52.13 79.17 104.26 49.83 104.26 29.76 101.63 28.3 52.13 56.44 7.95 31.33 52.13 6.38 88.52 26.94 91.7 25.15 91.7 22.35 52.13 0 0 29.44"
-      />
-      <g fill="currentColor">
-        <path d="M202.16,96.24V6.4H188.32V40a1.19,1.19,0,0,1-2.09.77c-4.68-5.49-12-8.64-20-8.64-17.11,0-30.5,14.43-30.5,32.84a34.07,34.07,0,0,0,8.8,23.43,29.33,29.33,0,0,0,21.7,9.41,26,26,0,0,0,20-9,1.19,1.19,0,0,1,2.1.77v6.69Zm-32.84-11c-11,0-19.64-8.92-19.64-20.3s8.63-20.3,19.64-20.3S189,53.58,189,65s-8.63,20.3-19.65,20.3" />
-        <path d="M276,96.24V33.68H262.33V40a1.2,1.2,0,0,1-.79,1.12,1.17,1.17,0,0,1-1.31-.36c-4.65-5.54-11.75-8.6-20-8.6-17.1,0-30.5,14.43-30.5,32.84s13.4,32.84,30.5,32.84a25.75,25.75,0,0,0,20-9.11,1.18,1.18,0,0,1,1.32-.36,1.2,1.2,0,0,1,.79,1.12v6.79Zm-32.71-11c-11,0-19.65-8.92-19.65-20.3s8.63-20.3,19.65-20.3S263,53.58,263,65s-8.63,20.3-19.65,20.3" />
-        <path d="M393.28,96.24V33.68H379.56V40a1.19,1.19,0,0,1-2.1.76c-4.64-5.54-11.75-8.6-20-8.6C340.35,32.12,327,46.55,327,65s13.4,32.84,30.5,32.84a25.75,25.75,0,0,0,20-9.11,1.19,1.19,0,0,1,2.1.76v6.79Zm-32.71-11c-11,0-19.65-8.92-19.65-20.3s8.63-20.3,19.65-20.3,19.64,8.92,19.64,20.3-8.63,20.3-19.64,20.3" />
-        <path d="M418.41,88.81a1.14,1.14,0,0,1,.41-.07,1.21,1.21,0,0,1,.91.41c4.68,5.5,12,8.64,20,8.64,17.1,0,30.5-14.42,30.5-32.83a34.12,34.12,0,0,0-8.8-23.43,29.33,29.33,0,0,0-21.7-9.41,26,26,0,0,0-20,9,1.19,1.19,0,0,1-2.1-.76l0-34H403.82l0,89.84h13.84V89.93a1.2,1.2,0,0,1,.78-1.12M417,65c0-11.38,8.63-20.3,19.64-20.3s19.65,8.92,19.65,20.3-8.63,20.29-19.65,20.29S417,76.34,417,65" />
-        <path d="M510.07,46.48a16.07,16.07,0,0,1,3.34.31V32.61a11.84,11.84,0,0,0-2.3-.23A20.05,20.05,0,0,0,493.8,42a1.19,1.19,0,0,1-2.21-.61V33.68H477.88V96.24h13.84V68.73c0-13.73,7-22.25,18.35-22.25" />
-        <rect x="522.08" y="33.68" width="13.97" height="62.56" />
-        <path d="M528.9,6.46a8.48,8.48,0,1,0,8.48,8.47,8.48,8.48,0,0,0-8.48-8.47" />
-        <path d="M577.1,32.12C557.93,32.12,544,45.93,544,65c0,9.25,3.26,17.62,9.19,23.56S567.6,97.8,577,97.8c7.76,0,13.81-1.54,25.21-9.91l-7.86-8.29c-5.6,3.72-10.81,5.53-15.92,5.53-11.57,0-20.3-8.67-20.3-20.17s8.73-20.17,20.3-20.17a25.63,25.63,0,0,1,15.65,5.53L602.83,42c-10.2-8.86-19.56-9.89-25.73-9.89" />
-        <path d="M626.49,68.65a1.2,1.2,0,0,1,.8-.31h.08a1.24,1.24,0,0,1,.85.44l22.13,27.44,17,0L638.74,61.6a1.19,1.19,0,0,1,.08-1.6l26.32-26.32H648.26L625.59,56.46a1.18,1.18,0,0,1-2-.84l0-49.22H609.73V96.24h13.84V71.86A1.15,1.15,0,0,1,624,71Z" />
-        <path d="M689.94,97.8c11.35,0,22.83-6.87,22.83-20,0-8.56-5.35-14.46-16.37-18l-7.54-2.47c-5.06-1.69-7.53-4.11-7.53-7.41,0-3.77,3.38-6.4,8.22-6.4,4.6,0,8.7,3,11.29,8.24l11.11-6a24.44,24.44,0,0,0-22.4-13.63c-12.4,0-21.41,8-21.41,18.94,0,8.67,5.19,14.53,15.86,17.92l7.67,2.47c5.43,1.72,7.65,3.86,7.65,7.41,0,5.29-4.91,7.17-9.12,7.17-5.62,0-10.58-3.64-13-9.52L666,82.36c3.71,9.53,12.87,15.44,24,15.44" />
-        <path d="M314.38,97.16a73.68,73.68,0,0,0,10.51-.73v-12a64.56,64.56,0,0,1-6.94.45c-5.62,0-9.91-1-9.91-13.06V46.14A1.18,1.18,0,0,1,309.22,45h13.47V33.67H309.22A1.19,1.19,0,0,1,308,32.49V14.35H294.28V32.49a1.19,1.19,0,0,1-1.19,1.19h-9.64V45h9.63a1.18,1.18,0,0,1,1.19,1.18V75.28c0,21.88,14.6,21.88,20.1,21.88" />
-      </g>
-    </svg>
-  );
-}
-
-function SummitEyebrow(): ReactNode {
-  return (
-    <p className="mb-4 flex items-center gap-3 text-black/70 dark:text-white/70">
-      <DatabricksLogo className="h-4 w-auto" />
-      <span className="sr-only">Databricks </span>
-      <span className="text-[10px] font-semibold tracking-[0.12em] uppercase">
-        Data + AI Summit
-      </span>
-    </p>
-  );
-}
-
-function ResourceCard({ resource }: { resource: Resource }): ReactNode {
-  const { title, description, href, external, Icon } = resource;
-  const cardClasses =
-    "group flex h-full flex-col rounded-xl border border-black/10 bg-[#f7f6f4] p-6 no-underline transition-colors duration-200 hover:border-db-lava/50 dark:border-white/10 dark:bg-[#182a32] dark:hover:border-db-lava-light/55";
-  const body = (
-    <>
-      <div className="mb-3 flex items-center gap-2">
-        <Icon className="h-5 w-5 text-db-lava" aria-hidden />
-        <h3 className="m-0 text-lg font-medium text-black dark:text-white">
-          {title}
-        </h3>
-        {external && (
-          <ArrowUpRight
-            aria-hidden
-            className="ml-auto h-4 w-4 text-black/40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 dark:text-white/40"
-          />
-        )}
-      </div>
-      <div className="text-[14px] leading-relaxed text-black/68 dark:text-white/68">
-        {description}
-      </div>
-    </>
-  );
-  if (external) {
+  if (slug) {
     return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cardClasses}
-        aria-label={`${title} (opens in new tab)`}
-      >
-        {body}
-      </a>
+      <>
+        <Head>
+          <meta name="robots" content="noindex, nofollow" />
+          <meta httpEquiv="refresh" content={`0; url=${target}`} />
+        </Head>
+        <Redirect to={target} />
+      </>
     );
   }
-  return (
-    <Link to={href} className={cardClasses}>
-      {body}
-    </Link>
-  );
-}
 
-export default function HackathonPage(): ReactNode {
   return (
-    <Layout
-      title={`${EVENT_NAME} \u2014 Databricks Data + AI Summit 2026`}
-      description={`Databricks ${EVENT_NAME} at Data + AI Summit 2026 \u2014 schedule, resources, and how to apply.`}
-    >
-      {/* Hide just the "See resources" link in the site-wide hackathon banner
-          when the visitor is already on this page — the link points here, so
-          showing it would be redundant. The lead text still shows so the
-          event branding stays consistent across pages. */}
+    <Layout title="Hackathon" description="Databricks developer hackathons.">
       <Head>
         <meta name="robots" content="noindex, nofollow" />
-        <style>{`.theme-announcement-bar a { display: none !important; }`}</style>
       </Head>
       <main className="border-t border-db-cyan/30 bg-db-bg dark:border-db-cyan/25 dark:bg-[#0d1a1f]">
-        <section className="container px-4 pt-16 pb-10 md:pt-20 md:pb-12">
-          <div className="mx-auto max-w-4xl">
-            <SummitEyebrow />
-            <h1 className="mb-4 text-4xl leading-[1.06] font-medium tracking-tight text-black dark:text-white md:text-5xl">
-              <span className="text-db-lava">{EVENT_NAME}</span>
+        <section className="container px-4 pt-20 pb-28 md:pt-28 md:pb-36">
+          <div className="mx-auto max-w-2xl text-center">
+            <h1 className="mb-4 text-3xl font-medium tracking-tight text-black dark:text-white md:text-4xl">
+              No active hackathon right now
             </h1>
-            <p className="m-0 flex items-center gap-2 text-sm font-medium text-black/70 dark:text-white/70">
-              <CalendarDays className="h-4 w-4 text-db-lava" aria-hidden />
-              {EVENT_DATES}
+            <p className="mb-8 text-base text-black/68 dark:text-white/68">
+              There isn&rsquo;t a hackathon running at the moment. In the
+              meantime, explore templates to jumpstart your next Databricks app.
             </p>
-            <p className="m-0 mt-2 flex items-center gap-2 text-sm font-medium text-black/70 dark:text-white/70">
-              <MapPin className="h-4 w-4 text-db-lava" aria-hidden />
-              {EVENT_LOCATION}
-            </p>
-            <p className="m-0 mt-3 mb-4 text-sm font-medium text-black/70 dark:text-white/70">
-              Partnering with{" "}
-              <span className="text-base font-semibold text-black dark:text-white">
-                OpenAI
-              </span>
-            </p>
-            <p className="mb-4 max-w-2xl text-lg text-black/68 dark:text-white/68">
-              {EVENT_TAGLINE}
-            </p>
-            <p className="mb-8 max-w-2xl text-base text-black/68 dark:text-white/68">
-              {EVENT_TAGLINE_SECONDARY}
-            </p>
-            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-              <a
-                href={APPLY_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-full bg-db-lava px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-db-lava/90"
-              >
-                Apply on MLH
-                <ArrowUpRight aria-hidden className="h-4 w-4" />
-              </a>
-            </div>
-            <p className="mt-3 text-xs text-black/50 dark:text-white/50">
-              Applications close {APPLICATION_DEADLINE}. Apply in teams of
-              2&ndash;4 &mdash; every teammate must be registered for Data + AI
-              Summit 2026.
-            </p>
-          </div>
-        </section>
-
-        <section className="container px-4 py-10 md:py-14">
-          <div className="mx-auto max-w-4xl">
-            <h2 className="mb-6 text-2xl font-medium text-black dark:text-white">
-              Resources
-            </h2>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {RESOURCES.map((resource) => (
-                <ResourceCard key={resource.title} resource={resource} />
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="container px-4 py-10 md:py-14">
-          <div className="mx-auto max-w-4xl">
-            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
-              <CalendarDays className="h-5 w-5 text-db-lava" aria-hidden />
-              Timeline
-            </h2>
-            <ol className="m-0 list-none space-y-3 p-0">
-              {TIMELINE.map((item) => (
-                <li
-                  key={item.label}
-                  className="grid grid-cols-1 gap-1 rounded-xl border border-black/10 bg-[#f7f6f4] p-4 md:grid-cols-[200px_1fr] md:gap-4 dark:border-white/10 dark:bg-[#182a32]"
-                >
-                  <div>
-                    <p className="m-0 text-sm font-semibold text-black dark:text-white">
-                      {item.label}
-                    </p>
-                    <p className="m-0 text-xs text-db-lava">{item.date}</p>
-                  </div>
-                  <p className="m-0 text-sm text-black/68 dark:text-white/68">
-                    {item.detail}
-                  </p>
-                </li>
-              ))}
-            </ol>
-          </div>
-        </section>
-
-        <section className="container px-4 py-10 md:py-14">
-          <div className="mx-auto max-w-4xl">
-            <h2 className="mb-3 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
-              <Upload className="h-5 w-5 text-db-lava" aria-hidden />
-              Submission
-            </h2>
-            <p className="m-0 text-base text-black/68 dark:text-white/68">
-              Submit a Git repo and a live Databricks App. Be prepared to give a
-              three-minute demo explaining the user, workflow, technical
-              approach, and key tradeoffs.
-            </p>
-          </div>
-        </section>
-
-        <section className="container px-4 py-10 md:py-14">
-          <div className="mx-auto max-w-4xl">
-            <h2 className="mb-3 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
-              <Trophy className="h-5 w-5 text-db-lava" aria-hidden />
-              Judging
-            </h2>
-            <p className="mb-6 text-base text-black/68 dark:text-white/68">
-              Submissions will be judged on four dimensions:
-            </p>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {JUDGING_CRITERIA.map((c) => (
-                <div
-                  key={c.title}
-                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
-                >
-                  <h3 className="m-0 mb-2 text-base font-medium text-black dark:text-white">
-                    {c.title}
-                  </h3>
-                  <p className="m-0 text-sm text-black/68 dark:text-white/68">
-                    {c.detail}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="container px-4 pt-10 pb-20 md:pt-14 md:pb-28">
-          <div className="mx-auto max-w-4xl">
-            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
-              <HelpCircle className="h-5 w-5 text-db-lava" aria-hidden />
-              FAQ
-            </h2>
-            <dl className="m-0 space-y-4">
-              {FAQ.map((item) => (
-                <div
-                  key={item.q}
-                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
-                >
-                  <dt className="m-0 mb-2 text-sm font-semibold text-black dark:text-white">
-                    {item.q}
-                  </dt>
-                  <dd className="m-0 text-sm text-black/68 dark:text-white/68">
-                    {item.a}
-                  </dd>
-                </div>
-              ))}
-            </dl>
+            <Link
+              to="/templates"
+              className="inline-flex items-center gap-2 rounded-full bg-db-lava px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-db-lava/90"
+            >
+              Browse templates
+            </Link>
           </div>
         </section>
       </main>

--- a/tests/hackathon-banner.test.ts
+++ b/tests/hackathon-banner.test.ts
@@ -2,112 +2,23 @@ import { describe, expect, test } from "vitest";
 import {
   getHackathonBannerConfig,
   resolveHackathonBannerActive,
-  type HackathonBannerEnv,
 } from "../src/lib/hackathon-banner-server";
-
-const INSIDE = new Date("2026-06-15T12:00:00Z");
-const BEFORE = new Date("2026-05-01T12:00:00Z");
-const AFTER = new Date("2026-08-01T12:00:00Z");
-const ON_START_MIDNIGHT = new Date("2026-06-10T00:00:00Z");
-const ON_END_LAST_MS = new Date("2026-06-20T23:59:59.999Z");
-const JUST_BEFORE_START = new Date("2026-06-09T23:59:59.999Z");
-const JUST_AFTER_END = new Date("2026-06-21T00:00:00.000Z");
-
-const WINDOW = {
-  HACKATHON_START: "2026-06-10",
-  HACKATHON_END: "2026-06-20",
-} satisfies HackathonBannerEnv;
 
 describe("resolveHackathonBannerActive", () => {
   test("returns false when no env vars are set", () => {
-    expect(resolveHackathonBannerActive({}, INSIDE)).toBe(false);
+    expect(resolveHackathonBannerActive({})).toBe(false);
   });
 
-  test('HACKATHON_BANNER_ENABLED="true" forces on, ignoring dates', () => {
+  test('returns true only when HACKATHON_BANNER_ENABLED is exactly "true"', () => {
     expect(
-      resolveHackathonBannerActive(
-        { HACKATHON_BANNER_ENABLED: "true" },
-        BEFORE,
-      ),
-    ).toBe(true);
-    expect(
-      resolveHackathonBannerActive(
-        { HACKATHON_BANNER_ENABLED: "true", ...WINDOW },
-        AFTER,
-      ),
+      resolveHackathonBannerActive({ HACKATHON_BANNER_ENABLED: "true" }),
     ).toBe(true);
   });
 
-  test('HACKATHON_BANNER_ENABLED="false" forces off, ignoring dates', () => {
-    expect(
-      resolveHackathonBannerActive(
-        { HACKATHON_BANNER_ENABLED: "false", ...WINDOW },
-        INSIDE,
-      ),
-    ).toBe(false);
-  });
-
-  test("non-boolean enable values fall through to the date window", () => {
-    for (const value of ["1", "yes", "True", "TRUE", ""]) {
+  test("returns false for any other enable value", () => {
+    for (const value of ["1", "yes", "True", "TRUE", "", "false"]) {
       expect(
-        resolveHackathonBannerActive(
-          { HACKATHON_BANNER_ENABLED: value, ...WINDOW },
-          INSIDE,
-        ),
-      ).toBe(true);
-      expect(
-        resolveHackathonBannerActive(
-          { HACKATHON_BANNER_ENABLED: value, ...WINDOW },
-          BEFORE,
-        ),
-      ).toBe(false);
-    }
-  });
-
-  test("date window is inclusive on both ends", () => {
-    expect(resolveHackathonBannerActive(WINDOW, ON_START_MIDNIGHT)).toBe(true);
-    expect(resolveHackathonBannerActive(WINDOW, ON_END_LAST_MS)).toBe(true);
-    expect(resolveHackathonBannerActive(WINDOW, INSIDE)).toBe(true);
-  });
-
-  test("date window excludes times outside the range", () => {
-    expect(resolveHackathonBannerActive(WINDOW, BEFORE)).toBe(false);
-    expect(resolveHackathonBannerActive(WINDOW, AFTER)).toBe(false);
-    expect(resolveHackathonBannerActive(WINDOW, JUST_BEFORE_START)).toBe(false);
-    expect(resolveHackathonBannerActive(WINDOW, JUST_AFTER_END)).toBe(false);
-  });
-
-  test("requires both start and end to be set", () => {
-    expect(
-      resolveHackathonBannerActive({ HACKATHON_START: "2026-06-10" }, INSIDE),
-    ).toBe(false);
-    expect(
-      resolveHackathonBannerActive({ HACKATHON_END: "2026-06-20" }, INSIDE),
-    ).toBe(false);
-  });
-
-  test("rejects start > end", () => {
-    expect(
-      resolveHackathonBannerActive(
-        { HACKATHON_START: "2026-06-20", HACKATHON_END: "2026-06-10" },
-        INSIDE,
-      ),
-    ).toBe(false);
-  });
-
-  test("rejects malformed or non-ISO dates", () => {
-    for (const [start, end] of [
-      ["06/10/2026", "06/20/2026"],
-      ["2026-6-10", "2026-6-20"],
-      ["not-a-date", "2026-06-20"],
-      ["2026-06-10", "not-a-date"],
-      ["2026-13-01", "2026-13-20"],
-    ] as const) {
-      expect(
-        resolveHackathonBannerActive(
-          { HACKATHON_START: start, HACKATHON_END: end },
-          INSIDE,
-        ),
+        resolveHackathonBannerActive({ HACKATHON_BANNER_ENABLED: value }),
       ).toBe(false);
     }
   });
@@ -115,32 +26,62 @@ describe("resolveHackathonBannerActive", () => {
 
 describe("getHackathonBannerConfig", () => {
   test("returns undefined when inactive", () => {
-    expect(getHackathonBannerConfig({}, INSIDE)).toBeUndefined();
+    expect(getHackathonBannerConfig({})).toBeUndefined();
+    expect(
+      getHackathonBannerConfig({ HACKATHON_BANNER_ENABLED: "false" }),
+    ).toBeUndefined();
   });
 
   test("returns a brand-styled, non-dismissible config when active", () => {
-    const config = getHackathonBannerConfig(
-      { HACKATHON_BANNER_ENABLED: "true" },
-      INSIDE,
-    );
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+      HACKATHON_EVENT_SLUG: "apps-agents-for-good-2026",
+    });
     expect(config).toBeDefined();
-    expect(config?.id).toBe("hackathon-2026");
     expect(config?.isCloseable).toBe(false);
     expect(config?.backgroundColor).toBe("var(--db-lava)");
     expect(config?.textColor).toBe("#ffffff");
+  });
+
+  test("links to the event slug and namespaces the id per event", () => {
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+      HACKATHON_EVENT_SLUG: "apps-agents-for-good-2026",
+    });
+    expect(config?.content).toContain(
+      'href="/hackathon/apps-agents-for-good-2026"',
+    );
+    expect(config?.id).toBe("hackathon-apps-agents-for-good-2026");
+  });
+
+  test("falls back to /hackathon and a generic id when no slug is set", () => {
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+    });
     expect(config?.content).toContain('href="/hackathon"');
+    expect(config?.content).not.toContain('href="/hackathon/');
+    expect(config?.id).toBe("hackathon-event");
+  });
+
+  test("trims surrounding whitespace from the slug", () => {
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+      HACKATHON_EVENT_SLUG: "  spring-2027  ",
+    });
+    expect(config?.content).toContain('href="/hackathon/spring-2027"');
+    expect(config?.id).toBe("hackathon-spring-2027");
   });
 
   test("HACKATHON_BANNER_TEXT overrides only the lead text; link is always appended", () => {
-    const config = getHackathonBannerConfig(
-      {
-        HACKATHON_BANNER_ENABLED: "true",
-        HACKATHON_BANNER_TEXT: "Custom message",
-      },
-      INSIDE,
-    );
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+      HACKATHON_EVENT_SLUG: "apps-agents-for-good-2026",
+      HACKATHON_BANNER_TEXT: "Custom message",
+    });
     expect(config?.content).toContain("Custom message");
-    expect(config?.content).toContain('href="/hackathon"');
+    expect(config?.content).toContain(
+      'href="/hackathon/apps-agents-for-good-2026"',
+    );
     expect(config?.content).toContain("See resources");
     expect(config?.content).not.toContain(
       "Databricks Developer Hackathon is live",
@@ -148,26 +89,23 @@ describe("getHackathonBannerConfig", () => {
   });
 
   test("trims trailing whitespace from HACKATHON_BANNER_TEXT before appending the link", () => {
-    const config = getHackathonBannerConfig(
-      {
-        HACKATHON_BANNER_ENABLED: "true",
-        HACKATHON_BANNER_TEXT: "Custom message   ",
-      },
-      INSIDE,
-    );
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+      HACKATHON_EVENT_SLUG: "apps-agents-for-good-2026",
+      HACKATHON_BANNER_TEXT: "Custom message   ",
+    });
     expect(config?.content).toBe(
-      'Custom message <a href="/hackathon"><b>See resources &rarr;</b></a>',
+      'Custom message <a href="/hackathon/apps-agents-for-good-2026"><b>See resources &rarr;</b></a>',
     );
   });
 
   test("default lead text is used when HACKATHON_BANNER_TEXT is unset", () => {
-    const config = getHackathonBannerConfig(
-      { HACKATHON_BANNER_ENABLED: "true" },
-      INSIDE,
-    );
+    const config = getHackathonBannerConfig({
+      HACKATHON_BANNER_ENABLED: "true",
+      HACKATHON_EVENT_SLUG: "apps-agents-for-good-2026",
+    });
     expect(config?.content).toContain(
       "Databricks Developer Hackathon is live.",
     );
-    expect(config?.content).toContain('href="/hackathon"');
   });
 });


### PR DESCRIPTION
## Summary

- Each hackathon event is now its own page at `/hackathon/<slug>` (a file under `src/pages/hackathon/`), reusing the shared `HackathonEventPage` template or a fully custom layout. The current event lives at `/hackathon/apps-agents-for-good-2026`.
- `/hackathon` redirects to the env-selected active event (`HACKATHON_EVENT_SLUG`) and renders a minimal `noindex` placeholder when no slug is set.
- The announcement banner is now purely env-driven (`HACKATHON_BANNER_ENABLED`, `HACKATHON_EVENT_SLUG`, `HACKATHON_BANNER_TEXT`); the date-window logic (`HACKATHON_START` / `HACKATHON_END`) is removed.
- Event pages stay `noindex` and out of `sitemap.xml`; `CONTRIBUTING.md` and the banner unit tests are updated.

## Deploy / migration note

- Set `HACKATHON_EVENT_SLUG=apps-agents-for-good-2026` in the Vercel project (alongside `HACKATHON_BANNER_ENABLED` / `HACKATHON_BANNER_TEXT`).
- The old `HACKATHON_START` / `HACKATHON_END` env vars are now ignored and can be removed.
- `/hackathon` now redirects instead of rendering content directly; existing `/hackathon` links still resolve via the redirect.

## Test plan

- [x] `npm run fmt` and `npm run typecheck` clean
- [x] `npm run build` passes; inspected generated HTML — event page is `noindex` with full content, `/hackathon` redirects when a slug is set and shows the placeholder when unset, the banner links to the slug, and `sitemap.xml` excludes hackathon routes
- [x] `vitest run` full unit suite passes (incl. rewritten banner tests)
- [x] `fallow dead-code` / `dupes` report nothing for the new code
- [ ] Playwright e2e (CI) — unaffected; e2e specs do not cover `/hackathon`