### PR TITLE
refactor(hackathon): use explicit per-card links instead of whole-card links

### DIFF
--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -2,6 +2,7 @@ import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
 import Layout from "@theme/Layout";
 import {
+  ArrowRight,
   ArrowUpRight,
   CalendarDays,
   HelpCircle,
@@ -25,11 +26,16 @@ import type { ComponentType, ReactNode } from "react";
  * the `HACKATHON_EVENT_SLUG` env var.
  */
 
+type HackathonResourceLink = {
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
 type HackathonResource = {
   title: string;
   description: ReactNode;
-  href: string;
-  external?: boolean;
+  links: HackathonResourceLink[];
   Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
 };
 
@@ -112,50 +118,64 @@ function EventEyebrow({ label }: { label: string }): ReactNode {
   );
 }
 
-function ResourceCard({
-  resource,
+function ResourceCardLink({
+  link,
 }: {
-  resource: HackathonResource;
+  link: HackathonResourceLink;
 }): ReactNode {
-  const { title, description, href, external, Icon } = resource;
-  const cardClasses =
-    "group flex h-full flex-col rounded-xl border border-black/10 bg-[#f7f6f4] p-6 no-underline transition-colors duration-200 hover:border-db-lava/50 dark:border-white/10 dark:bg-[#182a32] dark:hover:border-db-lava-light/55";
-  const body = (
-    <>
-      <div className="mb-3 flex items-center gap-2">
-        <Icon className="h-5 w-5 text-db-lava" aria-hidden />
-        <h3 className="m-0 text-lg font-medium text-black dark:text-white">
-          {title}
-        </h3>
-        {external && (
-          <ArrowUpRight
-            aria-hidden
-            className="ml-auto h-4 w-4 text-black/40 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 dark:text-white/40"
-          />
-        )}
-      </div>
-      <div className="text-[14px] leading-relaxed text-black/68 dark:text-white/68">
-        {description}
-      </div>
-    </>
-  );
+  const { label, href, external } = link;
+  const linkClasses =
+    "group inline-flex items-center gap-1 text-sm font-medium text-db-lava no-underline hover:underline";
   if (external) {
     return (
       <a
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className={cardClasses}
-        aria-label={`${title} (opens in new tab)`}
+        className={linkClasses}
       >
-        {body}
+        {label}
+        <ArrowUpRight
+          aria-hidden
+          className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+        />
       </a>
     );
   }
   return (
-    <Link to={href} className={cardClasses}>
-      {body}
+    <Link to={href} className={linkClasses}>
+      {label}
+      <ArrowRight
+        aria-hidden
+        className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5"
+      />
     </Link>
+  );
+}
+
+function ResourceCard({
+  resource,
+}: {
+  resource: HackathonResource;
+}): ReactNode {
+  const { title, description, links, Icon } = resource;
+  return (
+    <div className="flex h-full flex-col rounded-xl border border-black/10 bg-[#f7f6f4] p-6 dark:border-white/10 dark:bg-[#182a32]">
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="h-5 w-5 text-db-lava" aria-hidden />
+        <h3 className="m-0 text-lg font-medium text-black dark:text-white">
+          {title}
+        </h3>
+      </div>
+      <div className="text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+        {description}
+      </div>
+      <div className="mt-auto flex flex-col items-start gap-2 pt-4">
+        {links.map((link) => (
+          <ResourceCardLink key={link.label} link={link} />
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -52,52 +52,40 @@ const event: HackathonEvent = {
             Read the docs to learn how to set up your coding environment and
             start building your app.
           </p>
-          <p className="mt-2 mb-1">
+          <p className="mt-2 mb-0">
             We suggest reading the following pages before you start hacking:
           </p>
-          <ul className="m-0 list-disc pl-5">
-            <li>
-              <strong className="font-semibold text-black dark:text-white">
-                Start here
-              </strong>
-            </li>
-            <li>
-              <strong className="font-semibold text-black dark:text-white">
-                Platform overview
-              </strong>
-            </li>
-            <li>
-              <strong className="font-semibold text-black dark:text-white">
-                Set up your environment
-              </strong>
-            </li>
-          </ul>
         </>
       ),
-      href: "/docs/start-here",
+      links: [
+        { label: "Start here", href: "/docs/start-here" },
+        { label: "Platform overview", href: "/docs/platform-overview" },
+        {
+          label: "Set up your environment",
+          href: "/docs/tools/databricks-cli",
+        },
+      ],
       Icon: BookOpen,
     },
     {
       title: "App with Lakebase template",
       description:
         "Scaffold a Databricks app wired up to Lakebase from this template and start hacking right away \u2014 then adapt it to fit your project.",
-      href: "/templates/app-with-lakebase",
+      links: [{ label: "View template", href: "/templates/app-with-lakebase" }],
       Icon: LayoutTemplate,
     },
     {
       title: "Ask questions",
       description:
         "Stuck? Join our hackathon Discord server to ask questions and get help!",
-      href: "#",
-      external: true,
+      links: [{ label: "Join Discord", href: "#", external: true }],
       Icon: MessageSquare,
     },
     {
       title: "Official rules",
       description:
         "Eligibility, team requirements, IP, and judging rules for the hackathon.",
-      href: "#",
-      external: true,
+      links: [{ label: "Read the rules", href: "#", external: true }],
       Icon: FileText,
     },
   ],


### PR DESCRIPTION
## Summary

- Convert the hackathon resource cards from whole-card links into plain containers with an explicit per-link actions footer, so every card has clear, individual click targets (the cards no longer behave as one big link).
- "Get started" now exposes three real doc links - Start here (`/docs/start-here`), Platform overview (`/docs/platform-overview`), Set up your environment (`/docs/tools/databricks-cli`) - instead of non-clickable bold text.
- The remaining cards each get a single text link (View template, Join Discord, Read the rules). Internal links use a right arrow and stay in the same tab; external links use an up-right arrow and open in a new tab.

## Notes

- "Join Discord" and "Read the rules" still point to `#` placeholders (carried over from before this change); they need real URLs before the event.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Browser-checked `/hackathon/apps-agents-for-good-2026`: internal links navigate in the same tab, external links open in a new tab.