### PR TITLE
feat(hackathon): add dataset card with Open in Databricks button

### DIFF
--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight,
   ArrowUpRight,
   CalendarDays,
+  Database,
   HelpCircle,
   MapPin,
   Trophy,
@@ -67,6 +68,11 @@ export type HackathonEvent = {
   applyLabel?: string;
   applyNote?: ReactNode;
   resources: HackathonResource[];
+  /**
+   * Optional marketplace listing for the event dataset. When set, an "Open in
+   * Databricks" button is rendered in the Resources section.
+   */
+  datasetUrl?: string;
   timeline: HackathonTimelineItem[];
   submission: ReactNode;
   judgingIntro?: ReactNode;
@@ -179,6 +185,38 @@ function ResourceCard({
   );
 }
 
+function OpenInDatabricksButton({ href }: { href: string }): ReactNode {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex shrink-0 items-center gap-1 rounded bg-db-lava px-2 py-1 text-sm leading-normal font-semibold whitespace-nowrap text-white no-underline transition-colors hover:bg-db-lava/90"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden
+        focusable={false}
+        className="shrink-0"
+      >
+        <path
+          fill="currentColor"
+          d="M10 1h5v5h-1.5V3.56L8.53 8.53 7.47 7.47l4.97-4.97H10z"
+        />
+        <path
+          fill="currentColor"
+          d="M1 2.75A.75.75 0 0 1 1.75 2H8v1.5H2.5v10h10V8H14v6.25a.75.75 0 0 1-.75.75H1.75a.75.75 0 0 1-.75-.75z"
+        />
+      </svg>
+      Open in Databricks
+    </a>
+  );
+}
+
 export function HackathonEventPage({
   event,
 }: {
@@ -263,6 +301,23 @@ export function HackathonEventPage({
                 <ResourceCard key={resource.title} resource={resource} />
               ))}
             </div>
+            {event.datasetUrl && (
+              <div className="mt-4 flex flex-col items-start gap-4 rounded-xl border border-black/10 bg-[#f7f6f4] p-6 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-[#182a32]">
+                <div>
+                  <div className="mb-1 flex items-center gap-2">
+                    <Database className="h-5 w-5 text-db-lava" aria-hidden />
+                    <h3 className="m-0 text-lg font-medium text-black dark:text-white">
+                      Hackathon dataset
+                    </h3>
+                  </div>
+                  <p className="m-0 text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+                    Add the hackathon dataset to your Databricks workspace to
+                    start building with it.
+                  </p>
+                </div>
+                <OpenInDatabricksButton href={event.datasetUrl} />
+              </div>
+            )}
           </div>
         </section>
 

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -43,6 +43,8 @@ const event: HackathonEvent = {
     "Apps & Agents for Good Hackathon \u2014 Databricks Data + AI Summit 2026",
   metaDescription:
     "Databricks Apps & Agents for Good Hackathon at Data + AI Summit 2026 \u2014 schedule, resources, and how to apply.",
+  datasetUrl:
+    "https://login.databricks.com/signup?intent=SIGN_UP&destination_url=%2Fmarketplace%2Fconsumer%2Flistings%2Fed6cf259-81e7-4758-94c5-b444f8a5275a%3FshowModal%3Dtrue&utm_source=open-in-databricks&utm_medium=marketplace&utm_campaign=wanderbricks-test",
   resources: [
     {
       title: "Get started",


### PR DESCRIPTION
## Summary

- Add a "Hackathon dataset" card to the Resources section of the Data + AI Summit hackathon page, with an "Open in Databricks" button that opens the dataset's Marketplace listing in a new tab.
- Add an optional `datasetUrl` field to the `HackathonEvent` type plus an `OpenInDatabricksButton` component; the card renders only when `datasetUrl` is set, so other events are unaffected.
- The button uses the brand color (`db-lava`) and the standard "Open in Databricks" SVG glyph, implemented with Tailwind to match repo conventions.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build` (also runs via the husky pre-commit hook)
- [x] Browser-checked `/hackathon/apps-agents-for-good-2026`: the dataset card renders and the button opens the Marketplace listing in a new tab.