### PR TITLE
feat(hackathon): Data + AI Summit 2026 hackathon page updates

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -34,6 +34,9 @@ const config: Config = {
     // Slug of the active hackathon event. `/hackathon` redirects here and the
     // announcement banner links to it. See src/lib/hackathon-banner-server.ts.
     hackathonEventSlug: process.env.HACKATHON_EVENT_SLUG,
+    // When "true", the hackathon dataset card is shown in the event Resources
+    // section. Defaults to hidden.
+    showHackathonDataset: process.env.HACKATHON_SHOW_DATASET === "true",
   },
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future

--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -1,5 +1,6 @@
 import Head from "@docusaurus/Head";
 import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import {
   ArrowRight,
@@ -279,6 +280,10 @@ export function HackathonEventPage({
   const applyLabel = event.applyLabel ?? "Apply";
   const judgingIntro =
     event.judgingIntro ?? "Submissions will be judged on the following:";
+  const { siteConfig } = useDocusaurusContext();
+  const showHackathonDataset = Boolean(
+    (siteConfig.customFields as Record<string, unknown>).showHackathonDataset,
+  );
 
   return (
     <Layout title={metaTitle} description={metaDescription}>
@@ -377,7 +382,7 @@ export function HackathonEventPage({
                 <ResourceCard key={resource.title} resource={resource} />
               ))}
             </div>
-            {event.datasetUrl && (
+            {event.datasetUrl && showHackathonDataset && (
               <ResourceCallout
                 Icon={Database}
                 title="Hackathon dataset"

--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -9,6 +9,7 @@ import {
   HelpCircle,
   Lock,
   MapPin,
+  Rocket,
   Trophy,
   Upload,
 } from "lucide-react";
@@ -54,7 +55,7 @@ type HackathonJudgingCriterion = {
 
 type HackathonFaqItem = {
   q: string;
-  a: string;
+  a: ReactNode;
 };
 
 export type HackathonEvent = {
@@ -75,8 +76,13 @@ export type HackathonEvent = {
   registrationClosed?: boolean;
   resources: HackathonResource[];
   /**
+   * Optional setup guide URL. When set, a "Set up Free Edition" callout is
+   * rendered above the resources grid.
+   */
+  setupGuideUrl?: string;
+  /**
    * Optional marketplace listing for the event dataset. When set, an "Open in
-   * Databricks" button is rendered in the Resources section.
+   * Databricks" button is rendered below the resources grid.
    */
   datasetUrl?: string;
   timeline: HackathonTimelineItem[];
@@ -228,6 +234,39 @@ function OpenInDatabricksButton({ href }: { href: string }): ReactNode {
   );
 }
 
+function ResourceCallout({
+  Icon,
+  title,
+  description,
+  className,
+  children,
+}: {
+  Icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  title: string;
+  description: ReactNode;
+  className?: string;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <div
+      className={`flex flex-col items-start gap-4 rounded-xl border border-black/10 bg-[#f7f6f4] p-6 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-[#182a32] ${className ?? ""}`}
+    >
+      <div>
+        <div className="mb-1 flex items-center gap-2">
+          <Icon className="h-5 w-5 text-db-lava" aria-hidden />
+          <h3 className="m-0 text-lg font-medium text-black dark:text-white">
+            {title}
+          </h3>
+        </div>
+        <p className="m-0 text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+          {description}
+        </p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
 export function HackathonEventPage({
   event,
 }: {
@@ -314,27 +353,39 @@ export function HackathonEventPage({
             <h2 className="mb-6 text-2xl font-medium text-black dark:text-white">
               Resources
             </h2>
+            {event.setupGuideUrl && (
+              <ResourceCallout
+                Icon={Rocket}
+                title="Set up Free Edition"
+                description="Create a Databricks Free Edition workspace and get your team set up to build and demo."
+                className="mb-4"
+              >
+                <Link
+                  to={event.setupGuideUrl}
+                  className="group inline-flex shrink-0 items-center gap-1 text-sm font-medium text-db-lava no-underline hover:underline"
+                >
+                  Read the setup guide
+                  <ArrowRight
+                    aria-hidden
+                    className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5"
+                  />
+                </Link>
+              </ResourceCallout>
+            )}
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {event.resources.map((resource) => (
                 <ResourceCard key={resource.title} resource={resource} />
               ))}
             </div>
             {event.datasetUrl && (
-              <div className="mt-4 flex flex-col items-start gap-4 rounded-xl border border-black/10 bg-[#f7f6f4] p-6 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-[#182a32]">
-                <div>
-                  <div className="mb-1 flex items-center gap-2">
-                    <Database className="h-5 w-5 text-db-lava" aria-hidden />
-                    <h3 className="m-0 text-lg font-medium text-black dark:text-white">
-                      Hackathon dataset
-                    </h3>
-                  </div>
-                  <p className="m-0 text-[14px] leading-relaxed text-black/68 dark:text-white/68">
-                    Add the hackathon dataset to your Databricks workspace to
-                    start building with it.
-                  </p>
-                </div>
+              <ResourceCallout
+                Icon={Database}
+                title="Hackathon dataset"
+                description="Add the hackathon dataset to your Databricks workspace to start building with it."
+                className="mt-4"
+              >
                 <OpenInDatabricksButton href={event.datasetUrl} />
-              </div>
+              </ResourceCallout>
             )}
           </div>
         </section>

--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -81,6 +81,11 @@ export type HackathonEvent = {
   datasetUrl?: string;
   timeline: HackathonTimelineItem[];
   submission: ReactNode;
+  /**
+   * Optional URL where teams submit their project. When set, a "Submit your
+   * project" button is rendered in the Submission section.
+   */
+  submissionUrl?: string;
   judgingIntro?: ReactNode;
   judgingCriteria: HackathonJudgingCriterion[];
   faq: HackathonFaqItem[];
@@ -370,6 +375,17 @@ export function HackathonEventPage({
             <div className="m-0 text-base text-black/68 dark:text-white/68">
               {event.submission}
             </div>
+            {event.submissionUrl && (
+              <a
+                href={event.submissionUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 inline-flex items-center gap-2 rounded-full bg-db-lava px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-db-lava/90"
+              >
+                Submit your project
+                <ArrowUpRight aria-hidden className="h-4 w-4" />
+              </a>
+            )}
           </div>
         </section>
 

--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -7,6 +7,7 @@ import {
   CalendarDays,
   Database,
   HelpCircle,
+  Lock,
   MapPin,
   Trophy,
   Upload,
@@ -67,6 +68,11 @@ export type HackathonEvent = {
   applyUrl: string;
   applyLabel?: string;
   applyNote?: ReactNode;
+  /**
+   * When true, the apply button is replaced with a non-interactive
+   * "registration closed" notice that shows `applyNote` as the reason.
+   */
+  registrationClosed?: boolean;
   resources: HackathonResource[];
   /**
    * Optional marketplace listing for the event dataset. When set, an "Open in
@@ -273,17 +279,24 @@ export function HackathonEventPage({
               </p>
             )}
             <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-              <a
-                href={event.applyUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-full bg-db-lava px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-db-lava/90"
-              >
-                {applyLabel}
-                <ArrowUpRight aria-hidden className="h-4 w-4" />
-              </a>
+              {event.registrationClosed ? (
+                <p className="m-0 flex items-center gap-2 rounded-lg border border-black/10 bg-black/4 px-4 py-2.5 text-sm font-medium text-black/70 dark:border-white/10 dark:bg-white/6 dark:text-white/70">
+                  <Lock aria-hidden className="h-4 w-4 shrink-0 text-db-lava" />
+                  {event.applyNote}
+                </p>
+              ) : (
+                <a
+                  href={event.applyUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full bg-db-lava px-5 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-db-lava/90"
+                >
+                  {applyLabel}
+                  <ArrowUpRight aria-hidden className="h-4 w-4" />
+                </a>
+              )}
             </div>
-            {event.applyNote && (
+            {event.applyNote && !event.registrationClosed && (
               <p className="mt-3 text-xs text-black/50 dark:text-white/50">
                 {event.applyNote}
               </p>

--- a/src/components/hackathon/hackathon-event-page.tsx
+++ b/src/components/hackathon/hackathon-event-page.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRight,
   ArrowUpRight,
   CalendarDays,
+  Database,
   HelpCircle,
   MapPin,
   Trophy,
@@ -67,6 +68,11 @@ export type HackathonEvent = {
   applyLabel?: string;
   applyNote?: ReactNode;
   resources: HackathonResource[];
+  /**
+   * Optional marketplace listing for the event dataset. When set, an "Open in
+   * Databricks" button is rendered in the Resources section.
+   */
+  datasetUrl?: string;
   timeline: HackathonTimelineItem[];
   submission: ReactNode;
   judgingIntro?: ReactNode;
@@ -179,6 +185,38 @@ function ResourceCard({
   );
 }
 
+function OpenInDatabricksButton({ href }: { href: string }): ReactNode {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex shrink-0 items-center gap-1 rounded bg-db-lava px-2 py-1 text-sm leading-normal font-semibold whitespace-nowrap text-white no-underline transition-colors hover:bg-db-lava/90"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden
+        focusable={false}
+        className="shrink-0"
+      >
+        <path
+          fill="currentColor"
+          d="M10 1h5v5h-1.5V3.56L8.53 8.53 7.47 7.47l4.97-4.97H10z"
+        />
+        <path
+          fill="currentColor"
+          d="M1 2.75A.75.75 0 0 1 1.75 2H8v1.5H2.5v10h10V8H14v6.25a.75.75 0 0 1-.75.75H1.75a.75.75 0 0 1-.75-.75z"
+        />
+      </svg>
+      Open in Databricks
+    </a>
+  );
+}
+
 export function HackathonEventPage({
   event,
 }: {
@@ -263,6 +301,23 @@ export function HackathonEventPage({
                 <ResourceCard key={resource.title} resource={resource} />
               ))}
             </div>
+            {event.datasetUrl && (
+              <div className="mt-4 flex flex-col items-start gap-4 rounded-xl border border-black/10 bg-[#f7f6f4] p-6 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-[#182a32]">
+                <div>
+                  <div className="mb-1 flex items-center gap-2">
+                    <Database className="h-5 w-5 text-db-lava" aria-hidden />
+                    <h3 className="m-0 text-lg font-medium text-black dark:text-white">
+                      Hackathon dataset
+                    </h3>
+                  </div>
+                  <p className="m-0 text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+                    Add the hackathon dataset to your Databricks workspace to
+                    start building with it.
+                  </p>
+                </div>
+                <OpenInDatabricksButton href={event.datasetUrl} />
+              </div>
+            )}
           </div>
         </section>
 

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -103,23 +103,17 @@ const event: HackathonEvent = {
       label: "Opening + hacking begins",
       date: "June 15, 2026 \u00b7 8:00am\u20134:00pm PT",
       detail:
-        "Opening ceremony and kickoff at Marriott Marquis, San Francisco.",
+        "A full day of hacking, kicking off with the opening ceremony at Marriott Marquis, San Francisco.",
     },
     {
       label: "Hacker's Corner (optional)",
       date: "June 16, 2026 \u00b7 11:00am\u20135:00pm PT",
-      detail: "Open collaboration space.",
+      detail: "Open collaboration space with mentors on hand to help.",
     },
     {
       label: "Judging + awards",
       date: "June 16, 2026 \u00b7 6:00pm\u20139:00pm PT",
       detail: "Live judging, followed by the awards ceremony.",
-    },
-    {
-      label: "Winners showcase",
-      date: "June 17, 2026",
-      detail:
-        "Winning teams and selected projects presented at Hacker's Corner for Data + AI Summit attendees.",
     },
   ],
   submission:

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -83,7 +83,13 @@ const event: HackathonEvent = {
       title: "Official rules",
       description:
         "Eligibility, team requirements, IP, and judging rules for the hackathon.",
-      links: [{ label: "Read the rules", href: "#", external: true }],
+      links: [
+        {
+          label: "Read the rules",
+          href: "https://bit.ly/4d0Gj7w",
+          external: true,
+        },
+      ],
       Icon: FileText,
     },
   ],

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -28,13 +28,9 @@ const event: HackathonEvent = {
   applyUrl:
     "https://events.mlh.com/events/13878-databricks-apps-agents-hackathon-for-good",
   applyLabel: "Apply on MLH",
-  applyNote: (
-    <>
-      Applications close Sunday, May 31, 2026 &middot; 11:59pm PT. Apply in
-      teams of 2&ndash;4 &mdash; every teammate must be registered for Data + AI
-      Summit 2026.
-    </>
-  ),
+  applyNote:
+    "Registration is now closed. The hackathon is open only to Data + AI Summit 2026 attendees.",
+  registrationClosed: true,
   tagline:
     "The Databricks Apps & Agents for Good Hackathon 2026 is a multi-day competition hosted in partnership with OpenAI, bringing developers together to drive meaningful change. This year's hackathon challenges teams to build powerful agentic data apps for social impact using Lakebase, Agent Bricks, and Databricks Apps.",
   taglineSecondary:

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -123,7 +123,8 @@ const event: HackathonEvent = {
     },
   ],
   submission:
-    "Submit a Git repo and a live Databricks App. Be prepared to give a three-minute demo explaining the user, workflow, technical approach, and key tradeoffs.",
+    "Submit a Git repo. Be prepared to give a three-minute demo explaining the user, workflow, technical approach, and key tradeoffs.",
+  submissionUrl: "https://dais-for-good-2026.devpost.com/",
   judgingIntro: "Submissions will be judged on four dimensions:",
   judgingCriteria: [
     {

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -117,7 +117,7 @@ const event: HackathonEvent = {
     },
   ],
   submission:
-    "Submit a Git repo. Be prepared to give a three-minute demo explaining the user, workflow, technical approach, and key tradeoffs.",
+    "Submit a Git repo and a description of your project. Be prepared to give a three-minute demo explaining the user, workflow, technical approach, and key tradeoffs.",
   submissionUrl: "https://dais-for-good-2026.devpost.com/",
   judgingIntro: "Submissions will be judged on four dimensions:",
   judgingCriteria: [

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -1,3 +1,4 @@
+import Link from "@docusaurus/Link";
 import {
   BookOpen,
   FileText,
@@ -39,11 +40,12 @@ const event: HackathonEvent = {
     "Apps & Agents for Good Hackathon \u2014 Databricks Data + AI Summit 2026",
   metaDescription:
     "Databricks Apps & Agents for Good Hackathon at Data + AI Summit 2026 \u2014 schedule, resources, and how to apply.",
+  setupGuideUrl: "/hackathon/free-edition-setup",
   datasetUrl:
     "https://login.databricks.com/signup?intent=SIGN_UP&destination_url=%2Fmarketplace%2Fconsumer%2Flistings%2Fed6cf259-81e7-4758-94c5-b444f8a5275a%3FshowModal%3Dtrue&utm_source=open-in-databricks&utm_medium=marketplace&utm_campaign=wanderbricks-test",
   resources: [
     {
-      title: "Get started",
+      title: "Read the Docs",
       description: (
         <>
           <p className="m-0">
@@ -51,17 +53,16 @@ const event: HackathonEvent = {
             start building your app.
           </p>
           <p className="mt-2 mb-0">
-            We suggest reading the following pages before you start hacking:
+            We highly suggest reading the following pages before you start
+            hacking:
           </p>
         </>
       ),
       links: [
         { label: "Start here", href: "/docs/start-here" },
         { label: "Platform overview", href: "/docs/platform-overview" },
-        {
-          label: "Set up your environment",
-          href: "/docs/tools/databricks-cli",
-        },
+        { label: "Databricks CLI", href: "/docs/tools/databricks-cli" },
+        { label: "Agent skills", href: "/docs/tools/ai-tools/agent-skills" },
       ],
       Icon: BookOpen,
     },
@@ -161,6 +162,23 @@ const event: HackathonEvent = {
     {
       q: "What if I'm new to Databricks?",
       a: 'Start with the "Start here" docs and copy one of the templates as a prompt for your coding agent \u2014 it will scaffold a working app and walk you through the rest.',
+    },
+    {
+      q: "Which Databricks account should I use?",
+      a: (
+        <>
+          Use a personal Databricks Free Edition account, not your work or
+          enterprise account. Building and demoing on Free Edition keeps every
+          team on the same playing field &mdash; see the{" "}
+          <Link
+            to="/hackathon/free-edition-setup"
+            className="font-medium text-db-lava underline underline-offset-2 hover:text-db-lava-dark"
+          >
+            Free Edition setup guide
+          </Link>{" "}
+          to get set up.
+        </>
+      ),
     },
   ],
 };

--- a/src/pages/hackathon/apps-agents-for-good-2026.tsx
+++ b/src/pages/hackathon/apps-agents-for-good-2026.tsx
@@ -43,6 +43,8 @@ const event: HackathonEvent = {
     "Apps & Agents for Good Hackathon \u2014 Databricks Data + AI Summit 2026",
   metaDescription:
     "Databricks Apps & Agents for Good Hackathon at Data + AI Summit 2026 \u2014 schedule, resources, and how to apply.",
+  datasetUrl:
+    "https://login.databricks.com/signup?intent=SIGN_UP&destination_url=%2Fmarketplace%2Fconsumer%2Flistings%2Fed6cf259-81e7-4758-94c5-b444f8a5275a%3FshowModal%3Dtrue&utm_source=open-in-databricks&utm_medium=marketplace&utm_campaign=wanderbricks-test",
   resources: [
     {
       title: "Get started",

--- a/src/pages/hackathon/free-edition-setup.tsx
+++ b/src/pages/hackathon/free-edition-setup.tsx
@@ -141,7 +141,7 @@ const faqs: { q: string; a: string }[] = [
   },
   {
     q: "What if I use up my Free Edition credits or quota?",
-    a: "We expect to have a process for refilling hackathon credits. Details will be shared before or during the event.",
+    a: "While the default credit limits are generous, we can add credits if needed. If you hit a limit during the hackathon, simply post your account ID in the #get-databricks-credits Discord channel.",
   },
   {
     q: "What limits should I expect?",

--- a/src/pages/hackathon/free-edition-setup.tsx
+++ b/src/pages/hackathon/free-edition-setup.tsx
@@ -1,0 +1,226 @@
+import Head from "@docusaurus/Head";
+import Link from "@docusaurus/Link";
+import Layout from "@theme/Layout";
+import { ArrowLeft, HelpCircle } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * Free Edition setup guide for the hackathon. Served at
+ * `/hackathon/free-edition-setup` and linked from the event page's Resources
+ * section. Like the event pages, this is non-indexed; entry is via the
+ * hackathon page. Wording follows the "Free Edition Setup" tab of the
+ * hackathon challenge doc.
+ */
+
+const inlineLink =
+  "font-medium text-db-lava underline underline-offset-2 hover:text-db-lava-dark";
+// Lists hug the lead-in line above them (small top margin) while their items
+// keep a little breathing room between each other.
+const bulletList = "m-0 mt-1 list-disc space-y-1 pl-5";
+const strong = "font-semibold text-black dark:text-white";
+
+type SetupStep = { title: string; body: ReactNode };
+
+const steps: SetupStep[] = [
+  {
+    title: "1. Create or use a Free Edition account",
+    body: (
+      <>
+        <p className="m-0">
+          Start here:{" "}
+          <a
+            href="https://www.databricks.com/learn/free-edition"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={inlineLink}
+          >
+            https://www.databricks.com/learn/free-edition
+          </a>
+        </p>
+        <p className="m-0 mt-2">
+          Click <strong className={strong}>Sign up for Free Edition</strong>.
+        </p>
+        <p className="m-0 mt-2">
+          If you already have a Free Edition account, you may use it for the
+          hackathon.
+        </p>
+        <p className="m-0 mt-2">
+          Please do <strong className={strong}>not</strong> use an enterprise
+          Databricks workspace or paid organizational account for your
+          submission. To keep the challenge fair, teams should build and demo on
+          Free Edition.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "2. Work locally when it helps",
+    body: (
+      <>
+        <p className="m-0">
+          For app development, we recommend iterating locally when possible,
+          then deploying to Free Edition regularly.
+        </p>
+        <p className="m-0 mt-3">A practical workflow is:</p>
+        <ul className={bulletList}>
+          <li>Build and test the frontend or app code locally.</li>
+          <li>
+            Use Free Edition for Databricks-specific pieces such as data access,
+            SQL, model serving, Vector Search, Lakebase, and the deployed
+            Databricks App.
+          </li>
+          <li>
+            Deploy early at least once, then continue iterating locally and
+            redeploying as needed.
+          </li>
+        </ul>
+        <p className="m-0 mt-3">
+          This helps conserve Free Edition resources and keeps your final demo
+          close to the deployed environment.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "3. Collaborate with your team",
+    body: (
+      <>
+        <p className="m-0">
+          Each teammate should have their own Free Edition workspace and can use
+          it for exploration, prototyping, notebooks, local app development, and
+          experiments.
+        </p>
+        <p className="m-0 mt-2">
+          As the project becomes more concrete, choose one teammate&rsquo;s Free
+          Edition workspace as the team&rsquo;s{" "}
+          <strong className={strong}>final demo workspace</strong>. This is
+          where the shared dataset, deployed Databricks App, and final demo
+          state should live.
+        </p>
+        <p className="m-0 mt-3">Suggested team setup:</p>
+        <ul className={bulletList}>
+          <li>
+            Everyone creates or uses their own Free Edition workspace for
+            individual development.
+          </li>
+          <li>
+            Keep source code in Git so teammates can share changes across
+            workspaces.
+          </li>
+          <li>
+            Pick one final demo workspace early enough to avoid last-minute
+            migration work.
+          </li>
+          <li>
+            Invite teammates to the final demo workspace if they need to inspect
+            data, run notebooks, or help deploy the app.
+          </li>
+          <li>Decide who owns the final deployment before demo time.</li>
+        </ul>
+      </>
+    ),
+  },
+];
+
+const faqs: { q: string; a: string }[] = [
+  {
+    q: "Can I use my company or enterprise Databricks account?",
+    a: "Please don't. Use Free Edition so every team is working under the same platform constraints.",
+  },
+  {
+    q: "What if I already have a Free Edition account?",
+    a: "Use it. You do not need to create a new one unless your existing workspace is blocked, out of resources, or tied up with other work.",
+  },
+  {
+    q: "What if I cannot get into my Free Edition account?",
+    a: "Create a new Free Edition account with another email address or email alias.",
+  },
+  {
+    q: "What if my existing Free Edition account has resources running that I do not want to tear down?",
+    a: "Create a separate Free Edition account for the hackathon using another email address or alias.",
+  },
+  {
+    q: "What if I use up my Free Edition credits or quota?",
+    a: "We expect to have a process for refilling hackathon credits. Details will be shared before or during the event.",
+  },
+  {
+    q: "What limits should I expect?",
+    a: "Free Edition is serverless-only and quota-limited. Plan to build efficiently, stop unused workloads, and avoid long-running jobs where possible.",
+  },
+];
+
+export default function FreeEditionSetupPage(): ReactNode {
+  return (
+    <Layout
+      title="Set up Databricks Free Edition"
+      description="How to set up Databricks Free Edition for the hackathon: create your account, work locally, and get your team ready to build and demo."
+    >
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+      <main className="border-t border-db-cyan/30 bg-db-bg dark:border-db-cyan/25 dark:bg-[#0d1a1f]">
+        <section className="container px-4 pt-16 pb-10 md:pt-20 md:pb-12">
+          <div className="mx-auto max-w-4xl">
+            <Link
+              to="/hackathon"
+              className="mb-6 inline-flex items-center gap-1 text-sm font-medium text-db-lava no-underline hover:underline"
+            >
+              <ArrowLeft aria-hidden className="h-4 w-4" />
+              Back to the hackathon
+            </Link>
+            <h1 className="mb-4 text-4xl leading-[1.06] font-medium tracking-tight text-black dark:text-white md:text-5xl">
+              Set up Databricks{" "}
+              <span className="text-db-lava">Free Edition</span>
+            </h1>
+            <p className="m-0 max-w-2xl text-lg text-black/68 dark:text-white/68">
+              Build and demo your hackathon project on Databricks Free Edition.
+              Here&rsquo;s how to get your account and team set up.
+            </p>
+          </div>
+        </section>
+
+        <section className="container px-4 py-10 md:py-14">
+          <div className="mx-auto max-w-4xl space-y-4">
+            {steps.map((step) => (
+              <div
+                key={step.title}
+                className="rounded-xl border border-black/10 bg-[#f7f6f4] p-6 dark:border-white/10 dark:bg-[#182a32]"
+              >
+                <h2 className="m-0 mb-3 text-lg font-medium text-black dark:text-white">
+                  {step.title}
+                </h2>
+                <div className="text-[14px] leading-relaxed text-black/68 dark:text-white/68">
+                  {step.body}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="container px-4 pt-10 pb-20 md:pt-14 md:pb-28">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="mb-6 flex items-center gap-2 text-2xl font-medium text-black dark:text-white">
+              <HelpCircle className="h-5 w-5 text-db-lava" aria-hidden />
+              FAQ
+            </h2>
+            <dl className="m-0 space-y-4">
+              {faqs.map((item) => (
+                <div
+                  key={item.q}
+                  className="rounded-xl border border-black/10 bg-[#f7f6f4] p-5 dark:border-white/10 dark:bg-[#182a32]"
+                >
+                  <dt className="m-0 mb-2 text-sm font-semibold text-black dark:text-white">
+                    {item.q}
+                  </dt>
+                  <dd className="m-0 text-sm text-black/68 dark:text-white/68">
+                    {item.a}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </section>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Updates to the Apps & Agents for Good Hackathon page (Data + AI Summit 2026), plus a new Free Edition setup page.

- Registration closed: replaced the "Apply on MLH" button with a "registration is now closed" notice.
- Linked the official rules doc and the Devpost submission page; submission now requires a Git repo + a project description (dropped the live-app requirement).
- Timeline: clarified June 15 is a full day of hacking, noted mentors at Hacker's Corner, and removed the Winners showcase card.
- New Free Edition setup page at `/hackathon/free-edition-setup` (setup steps + FAQ), linked from Resources.
- Resources: Free Edition and the dataset are now full-width callouts around a clean 2x2 card grid; renamed "Get started" -> "Read the Docs" with Databricks CLI + Agent skills links.
- FAQ: added "Which Databricks account should I use?" (links to the setup guide).
- Dataset card is gated behind the `HACKATHON_SHOW_DATASET` env var (hidden by default).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Browser-checked the event page and Free Edition page (links, callouts, registration notice, timeline, FAQ)
- [x] Verified the dataset env-var toggle via build (hidden by default; shown with `HACKATHON_SHOW_DATASET=true`)
- [x] Preview deploy

## Notes

- To show the dataset card in an environment, set `HACKATHON_SHOW_DATASET=true` (e.g., in the Vercel project env). It is hidden by default.
- The "Join Discord" link in Resources is still a `#` placeholder and needs the real invite before launch.