### PR TITLE
fix(site): auto-recover stale tabs that 404 on old assets after redeploy

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -90,6 +90,10 @@ const config: Config = {
 
   themes: ["@docusaurus/theme-mermaid"],
 
+  // Transparently recovers stale tabs that 404 on old chunks after a redeploy.
+  // See src/client/chunk-reload.ts.
+  clientModules: [require.resolve("./src/client/chunk-reload.ts")],
+
   presets: [
     [
       "classic",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import path from "path";
 import aboutDevhubPlugin from "./plugins/about-devhub";
+import chunkReloadPlugin from "./plugins/chunk-reload";
 import contentEntriesPlugin from "./plugins/content-entries";
 import cookbooksPlugin from "./plugins/cookbooks";
 import llmsTxtPlugin from "./plugins/llms-txt";
@@ -90,10 +91,6 @@ const config: Config = {
 
   themes: ["@docusaurus/theme-mermaid"],
 
-  // Transparently recovers stale tabs that 404 on old chunks after a redeploy.
-  // See src/client/chunk-reload.ts.
-  clientModules: [require.resolve("./src/client/chunk-reload.ts")],
-
   presets: [
     [
       "classic",
@@ -173,6 +170,7 @@ const config: Config = {
     aboutDevhubPlugin,
     cookbooksPlugin,
     perspectivesPlugin,
+    chunkReloadPlugin,
   ],
 
   themeConfig: {

--- a/plugins/chunk-reload.ts
+++ b/plugins/chunk-reload.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from "@docusaurus/types";
+import { installChunkReload } from "../src/client/chunk-reload";
+
+/**
+ * Injects installChunkReload as an inline <head> script on every page.
+ *
+ * It must be inline (not a clientModule bundled into the hashed app JS) so it
+ * still runs when a stale tab's hashed bundles 404 after a redeploy -- the
+ * exact case that shows Docusaurus's "site did not load properly" banner. A
+ * clientModule would live inside the 404'd file and never execute.
+ *
+ * See src/client/chunk-reload.ts for the self-containment constraints.
+ */
+export default function chunkReloadPlugin(): Plugin {
+  return {
+    name: "docusaurus-chunk-reload",
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: "script",
+            innerHTML: ";(" + installChunkReload.toString() + ")();",
+          },
+        ],
+      };
+    },
+  };
+}

--- a/src/client/chunk-reload.ts
+++ b/src/client/chunk-reload.ts
@@ -1,82 +1,92 @@
-// When DevHub is redeployed, its content-hashed JS/CSS chunks get new
+// When DevHub is redeployed, its content-hashed JS/CSS bundles get new
 // filenames and the old files stop existing at the production domain. A tab
-// left open across a deploy then 404s when it lazy-loads a route chunk, which
-// surfaces as a ChunkLoadError and triggers Docusaurus's "site did not load
-// properly" fallback (misleadingly blaming baseUrl). Recover transparently by
-// reloading the page so the browser fetches the current deployment's assets.
+// left open across a deploy then 404s on those assets. On the homepage this
+// triggers Docusaurus's "site did not load properly" banner (misleadingly
+// blaming baseUrl), rendered unstyled because the CSS 404'd too. Recover by
+// reloading onto the current deployment.
+//
+// IMPORTANT: installChunkReload is serialized with .toString() and injected as
+// an inline <head> script by plugins/chunk-reload.ts. It therefore must be
+// fully self-contained (no imports, no module-scope references) and use only
+// browser globals, so that it still runs even when the hashed app bundle
+// itself fails to load -- a clientModule would be bundled into that 404'd file
+// and never execute. Keep the body to conservative ES (no optional chaining /
+// nullish coalescing / spread) so transpilation never injects runtime helpers
+// into the inlined source.
 //
 // Why not Vercel Skew Protection? Docusaurus is not a zero-config Skew
-// Protection framework (only Next.js, SvelteKit, Qwik, Astro, and Nuxt are), so
-// it never attaches a ?dpl= deployment ID to its <script>/<link> or dynamic
-// import chunk requests. The only signal that works for its tag-based asset
-// loads is the __vdpl cookie set in middleware, but that pins document
-// navigations too, trapping users on a stale deployment until it ages past
-// max-age (then it 404s again). Dashboard-only enablement is effectively a
-// no-op here: without a dpl signal on asset requests the production domain
-// still 404s old chunks. This reload fallback already removes the user-visible
-// symptom, so Skew Protection would only save a single reload flash at the cost
-// of real complexity and staleness risk. Not worth it for a docs site.
+// Protection framework, so it never attaches a ?dpl= deployment ID to its
+// asset requests. The only signal that works for its tag-based loads is the
+// __vdpl cookie, which pins document navigations too and traps users on a
+// stale deployment until it ages past max-age. This inline reload is simpler
+// and has no staleness risk.
 
-const LAST_RELOAD_KEY = "devhub:chunk-reload-at";
+export function installChunkReload(): void {
+  var RELOAD_KEY = "devhub:chunk-reload-at";
+  var COOLDOWN_MS = 10000;
 
-// Cooldown between auto-reloads. A genuine stale-tab failure is fixed by a
-// single reload, so a second failure inside this window means the asset is
-// actually broken (not just stale) and we must stop to avoid a reload loop.
-const RELOAD_COOLDOWN_MS = 10_000;
+  function reloadOnce(): void {
+    var now = Date.now();
+    var last = 0;
+    try {
+      last = Number(window.sessionStorage.getItem(RELOAD_KEY)) || 0;
+    } catch (e) {
+      last = 0;
+    }
+    if (now - last < COOLDOWN_MS) return;
+    try {
+      window.sessionStorage.setItem(RELOAD_KEY, String(now));
+    } catch (e) {
+      // sessionStorage unavailable (private mode); reload anyway, once.
+    }
+    window.location.reload();
+  }
 
-// Equivalent to @docusaurus/ExecutionEnvironment, inlined so this module is
-// importable in plain Node (tests) without Docusaurus's webpack alias.
-const canUseDOM =
-  typeof window !== "undefined" &&
-  typeof window.document !== "undefined" &&
-  typeof window.document.createElement !== "undefined";
+  function isStaleAsset(url: unknown): boolean {
+    return typeof url === "string" && url.indexOf("/assets/") !== -1;
+  }
 
-export function isChunkLoadError(reason: unknown): boolean {
-  if (!(reason instanceof Error)) return false;
-  const name = reason.name || "";
-  const message = reason.message || "";
-  return (
-    name === "ChunkLoadError" ||
-    /Loading (CSS )?chunk [\w-]+ failed/i.test(message) ||
-    /error loading dynamically imported module/i.test(message) ||
-    /failed to fetch dynamically imported module/i.test(message) ||
-    /importing a module script failed/i.test(message)
-  );
-}
-
-export function reloadOnce(): void {
-  const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY) || 0);
-  if (Date.now() - lastReloadAt < RELOAD_COOLDOWN_MS) return;
-  sessionStorage.setItem(LAST_RELOAD_KEY, String(Date.now()));
-  window.location.reload();
-}
-
-export function installChunkReloadHandler(target: Window): void {
-  target.addEventListener("unhandledrejection", (event) => {
-    if (isChunkLoadError(event.reason)) reloadOnce();
-  });
-
-  target.addEventListener(
+  // Capture phase: failed <script>/<link> loads do not bubble. Catches the
+  // hashed bundle/stylesheet 404s directly.
+  window.addEventListener(
     "error",
-    (event) => {
-      if (isChunkLoadError(event.error)) {
-        reloadOnce();
-        return;
-      }
-      // Failed <script>/<link> resource loads don't bubble, so they only reach
-      // this listener in the capture phase and carry no Error object.
-      const element = event.target;
+    function (event: Event): void {
+      var el = event.target as HTMLScriptElement & HTMLLinkElement;
+      if (!el || !el.tagName) return;
+      var tag = el.tagName.toUpperCase();
+      if (tag !== "SCRIPT" && tag !== "LINK") return;
+      if (isStaleAsset(el.src) || isStaleAsset(el.href)) reloadOnce();
+    },
+    true,
+  );
+
+  // Post-boot route chunk failures surface as rejected dynamic imports.
+  window.addEventListener(
+    "unhandledrejection",
+    function (event: PromiseRejectionEvent): void {
+      var reason = event.reason;
+      var name = reason && reason.name ? reason.name : "";
+      var message = reason && reason.message ? reason.message : "";
       if (
-        element instanceof HTMLScriptElement ||
-        element instanceof HTMLLinkElement
+        name === "ChunkLoadError" ||
+        /Loading (CSS )?chunk [\w-]+ failed/i.test(message) ||
+        /dynamically imported module/i.test(message)
       ) {
         reloadOnce();
       }
     },
-    true,
   );
-}
 
-if (canUseDOM) {
-  installChunkReloadHandler(window);
+  // Primary boot-failure signal, mirroring Docusaurus's own BaseUrlIssueBanner
+  // check: if the client bundle never set window.docusaurus by the time the DOM
+  // is ready, an asset failed to load -- recover by reloading.
+  function checkBoot(): void {
+    var w = window as unknown as { docusaurus?: unknown };
+    if (typeof w.docusaurus === "undefined") reloadOnce();
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", checkBoot);
+  } else {
+    checkBoot();
+  }
 }

--- a/src/client/chunk-reload.ts
+++ b/src/client/chunk-reload.ts
@@ -1,0 +1,82 @@
+// When DevHub is redeployed, its content-hashed JS/CSS chunks get new
+// filenames and the old files stop existing at the production domain. A tab
+// left open across a deploy then 404s when it lazy-loads a route chunk, which
+// surfaces as a ChunkLoadError and triggers Docusaurus's "site did not load
+// properly" fallback (misleadingly blaming baseUrl). Recover transparently by
+// reloading the page so the browser fetches the current deployment's assets.
+//
+// Why not Vercel Skew Protection? Docusaurus is not a zero-config Skew
+// Protection framework (only Next.js, SvelteKit, Qwik, Astro, and Nuxt are), so
+// it never attaches a ?dpl= deployment ID to its <script>/<link> or dynamic
+// import chunk requests. The only signal that works for its tag-based asset
+// loads is the __vdpl cookie set in middleware, but that pins document
+// navigations too, trapping users on a stale deployment until it ages past
+// max-age (then it 404s again). Dashboard-only enablement is effectively a
+// no-op here: without a dpl signal on asset requests the production domain
+// still 404s old chunks. This reload fallback already removes the user-visible
+// symptom, so Skew Protection would only save a single reload flash at the cost
+// of real complexity and staleness risk. Not worth it for a docs site.
+
+const LAST_RELOAD_KEY = "devhub:chunk-reload-at";
+
+// Cooldown between auto-reloads. A genuine stale-tab failure is fixed by a
+// single reload, so a second failure inside this window means the asset is
+// actually broken (not just stale) and we must stop to avoid a reload loop.
+const RELOAD_COOLDOWN_MS = 10_000;
+
+// Equivalent to @docusaurus/ExecutionEnvironment, inlined so this module is
+// importable in plain Node (tests) without Docusaurus's webpack alias.
+const canUseDOM =
+  typeof window !== "undefined" &&
+  typeof window.document !== "undefined" &&
+  typeof window.document.createElement !== "undefined";
+
+export function isChunkLoadError(reason: unknown): boolean {
+  if (!(reason instanceof Error)) return false;
+  const name = reason.name || "";
+  const message = reason.message || "";
+  return (
+    name === "ChunkLoadError" ||
+    /Loading (CSS )?chunk [\w-]+ failed/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /failed to fetch dynamically imported module/i.test(message) ||
+    /importing a module script failed/i.test(message)
+  );
+}
+
+export function reloadOnce(): void {
+  const lastReloadAt = Number(sessionStorage.getItem(LAST_RELOAD_KEY) || 0);
+  if (Date.now() - lastReloadAt < RELOAD_COOLDOWN_MS) return;
+  sessionStorage.setItem(LAST_RELOAD_KEY, String(Date.now()));
+  window.location.reload();
+}
+
+export function installChunkReloadHandler(target: Window): void {
+  target.addEventListener("unhandledrejection", (event) => {
+    if (isChunkLoadError(event.reason)) reloadOnce();
+  });
+
+  target.addEventListener(
+    "error",
+    (event) => {
+      if (isChunkLoadError(event.error)) {
+        reloadOnce();
+        return;
+      }
+      // Failed <script>/<link> resource loads don't bubble, so they only reach
+      // this listener in the capture phase and carry no Error object.
+      const element = event.target;
+      if (
+        element instanceof HTMLScriptElement ||
+        element instanceof HTMLLinkElement
+      ) {
+        reloadOnce();
+      }
+    },
+    true,
+  );
+}
+
+if (canUseDOM) {
+  installChunkReloadHandler(window);
+}

--- a/tests/chunk-reload.test.ts
+++ b/tests/chunk-reload.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import {
-  installChunkReloadHandler,
-  isChunkLoadError,
-  reloadOnce,
-} from "../src/client/chunk-reload";
+import { installChunkReload } from "../src/client/chunk-reload";
 
 function fakeSessionStorage(): Storage {
   const store = new Map<string, string>();
@@ -19,129 +15,136 @@ function fakeSessionStorage(): Storage {
   };
 }
 
+type Listener = (event: unknown) => void;
+
+function setup(options: { docusaurusBooted?: boolean; readyState?: string }) {
+  const reload = vi.fn();
+  const windowListeners: Record<string, Listener[]> = {};
+  const documentListeners: Record<string, Listener[]> = {};
+
+  const win = {
+    sessionStorage: fakeSessionStorage(),
+    location: { reload },
+    addEventListener: (type: string, cb: Listener) => {
+      (windowListeners[type] ??= []).push(cb);
+    },
+  } as Record<string, unknown>;
+  if (options.docusaurusBooted) win.docusaurus = {};
+
+  const doc = {
+    readyState: options.readyState ?? "loading",
+    addEventListener: (type: string, cb: Listener) => {
+      (documentListeners[type] ??= []).push(cb);
+    },
+  };
+
+  vi.stubGlobal("window", win);
+  vi.stubGlobal("document", doc);
+
+  installChunkReload();
+
+  return {
+    reload,
+    fireWindow: (type: string, event: unknown) =>
+      windowListeners[type]?.forEach((cb) => cb(event)),
+    fireDocument: (type: string, event: unknown) =>
+      documentListeners[type]?.forEach((cb) => cb(event)),
+  };
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
-describe("isChunkLoadError", () => {
-  test.each([
-    ["webpack ChunkLoadError by name", "boom", "ChunkLoadError"],
-    ["webpack JS chunk message", "Loading chunk 42 failed.", "Error"],
-    ["webpack CSS chunk message", "Loading CSS chunk 7 failed.", "Error"],
-    [
-      "native dynamic import (Chrome)",
-      "Failed to fetch dynamically imported module: https://x/y.js",
-      "TypeError",
-    ],
-    [
-      "native dynamic import (Firefox)",
-      "error loading dynamically imported module",
-      "Error",
-    ],
-    [
-      "native dynamic import (Safari)",
-      "Importing a module script failed.",
-      "TypeError",
-    ],
-  ])("matches %s", (_label, message, name) => {
-    const error = new Error(message);
-    error.name = name;
-    expect(isChunkLoadError(error)).toBe(true);
-  });
-
-  test("ignores unrelated errors", () => {
-    expect(isChunkLoadError(new TypeError("x is not a function"))).toBe(false);
-    expect(isChunkLoadError(new Error("Network request failed"))).toBe(false);
-  });
-
-  test("ignores non-Error values", () => {
-    expect(isChunkLoadError(undefined)).toBe(false);
-    expect(isChunkLoadError("ChunkLoadError")).toBe(false);
-    expect(isChunkLoadError({ name: "ChunkLoadError" })).toBe(false);
-  });
-});
-
-describe("reloadOnce", () => {
-  test("reloads when no prior reload is recorded", () => {
-    const reload = vi.fn();
-    vi.stubGlobal("sessionStorage", fakeSessionStorage());
-    vi.stubGlobal("window", { location: { reload } });
-
-    reloadOnce();
-
+describe("installChunkReload boot check", () => {
+  test("reloads when the app never booted (window.docusaurus undefined)", () => {
+    const { reload, fireDocument } = setup({ docusaurusBooted: false });
+    fireDocument("DOMContentLoaded", {});
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  test("suppresses a second reload inside the cooldown window", () => {
-    const reload = vi.fn();
-    vi.stubGlobal("sessionStorage", fakeSessionStorage());
-    vi.stubGlobal("window", { location: { reload } });
-    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
-
-    reloadOnce();
-    reloadOnce();
-
-    expect(reload).toHaveBeenCalledTimes(1);
-  });
-
-  test("reloads again once the cooldown has elapsed", () => {
-    const reload = vi.fn();
-    vi.stubGlobal("sessionStorage", fakeSessionStorage());
-    vi.stubGlobal("window", { location: { reload } });
-    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
-
-    reloadOnce();
-    now.mockReturnValue(1_000_000 + 10_000);
-    reloadOnce();
-
-    expect(reload).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe("installChunkReloadHandler", () => {
-  function setup() {
-    const listeners: Record<string, EventListener[]> = {};
-    const reload = vi.fn();
-    const target = {
-      addEventListener: (type: string, cb: EventListener) => {
-        (listeners[type] ??= []).push(cb);
-      },
-      location: { reload },
-    };
-    vi.stubGlobal("sessionStorage", fakeSessionStorage());
-    vi.stubGlobal("window", target);
-    installChunkReloadHandler(target as unknown as Window);
-    const dispatch = (type: string, event: unknown) =>
-      listeners[type]?.forEach((cb) => cb(event as Event));
-    return { dispatch, reload };
-  }
-
-  test("reloads on an unhandled ChunkLoadError rejection", () => {
-    const { dispatch, reload } = setup();
-    const error = new Error("Loading chunk 5 failed.");
-    error.name = "ChunkLoadError";
-
-    dispatch("unhandledrejection", { reason: error });
-
-    expect(reload).toHaveBeenCalledTimes(1);
-  });
-
-  test("ignores unhandled rejections that are not chunk errors", () => {
-    const { dispatch, reload } = setup();
-
-    dispatch("unhandledrejection", { reason: new Error("validation failed") });
-
+  test("does not reload when the app booted normally", () => {
+    const { reload, fireDocument } = setup({ docusaurusBooted: true });
+    fireDocument("DOMContentLoaded", {});
     expect(reload).not.toHaveBeenCalled();
   });
 
-  test("reloads on a chunk error surfaced via the error event", () => {
-    const { dispatch, reload } = setup();
-    const error = new Error("Loading CSS chunk 9 failed.");
-    error.name = "ChunkLoadError";
-
-    dispatch("error", { error, target: null });
-
+  test("checks immediately when the DOM is already parsed", () => {
+    const { reload } = setup({
+      docusaurusBooted: false,
+      readyState: "complete",
+    });
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("installChunkReload asset error capture", () => {
+  test("reloads on a failed hashed <script> load", () => {
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    fireWindow("error", {
+      target: { tagName: "SCRIPT", src: "/assets/js/main.abc123.js" },
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("reloads on a failed hashed <link> stylesheet load", () => {
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    fireWindow("error", {
+      target: { tagName: "LINK", href: "/assets/css/styles.abc123.css" },
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores non-asset resource errors", () => {
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    fireWindow("error", {
+      target: {
+        tagName: "SCRIPT",
+        src: "https://cdn.example.com/analytics.js",
+      },
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("installChunkReload dynamic import rejection", () => {
+  test("reloads on a ChunkLoadError rejection", () => {
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    const error = new Error("Loading chunk 5 failed.");
+    error.name = "ChunkLoadError";
+    fireWindow("unhandledrejection", { reason: error });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores unrelated rejections", () => {
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    fireWindow("unhandledrejection", {
+      reason: new Error("validation failed"),
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("installChunkReload cooldown", () => {
+  test("suppresses a second reload within the cooldown window", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    const error = new Error("boom");
+    error.name = "ChunkLoadError";
+    fireWindow("unhandledrejection", { reason: error });
+    fireWindow("unhandledrejection", { reason: error });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("reloads again once the cooldown elapses", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const { reload, fireWindow } = setup({ docusaurusBooted: true });
+    const error = new Error("boom");
+    error.name = "ChunkLoadError";
+    fireWindow("unhandledrejection", { reason: error });
+    now.mockReturnValue(1_000_000 + 10_000);
+    fireWindow("unhandledrejection", { reason: error });
+    expect(reload).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/chunk-reload.test.ts
+++ b/tests/chunk-reload.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  installChunkReloadHandler,
+  isChunkLoadError,
+  reloadOnce,
+} from "../src/client/chunk-reload";
+
+function fakeSessionStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => void store.set(key, String(value)),
+    removeItem: (key) => void store.delete(key),
+    clear: () => store.clear(),
+    key: (index) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("isChunkLoadError", () => {
+  test.each([
+    ["webpack ChunkLoadError by name", "boom", "ChunkLoadError"],
+    ["webpack JS chunk message", "Loading chunk 42 failed.", "Error"],
+    ["webpack CSS chunk message", "Loading CSS chunk 7 failed.", "Error"],
+    [
+      "native dynamic import (Chrome)",
+      "Failed to fetch dynamically imported module: https://x/y.js",
+      "TypeError",
+    ],
+    [
+      "native dynamic import (Firefox)",
+      "error loading dynamically imported module",
+      "Error",
+    ],
+    [
+      "native dynamic import (Safari)",
+      "Importing a module script failed.",
+      "TypeError",
+    ],
+  ])("matches %s", (_label, message, name) => {
+    const error = new Error(message);
+    error.name = name;
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  test("ignores unrelated errors", () => {
+    expect(isChunkLoadError(new TypeError("x is not a function"))).toBe(false);
+    expect(isChunkLoadError(new Error("Network request failed"))).toBe(false);
+  });
+
+  test("ignores non-Error values", () => {
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError("ChunkLoadError")).toBe(false);
+    expect(isChunkLoadError({ name: "ChunkLoadError" })).toBe(false);
+  });
+});
+
+describe("reloadOnce", () => {
+  test("reloads when no prior reload is recorded", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("sessionStorage", fakeSessionStorage());
+    vi.stubGlobal("window", { location: { reload } });
+
+    reloadOnce();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("suppresses a second reload inside the cooldown window", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("sessionStorage", fakeSessionStorage());
+    vi.stubGlobal("window", { location: { reload } });
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+
+    reloadOnce();
+    reloadOnce();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("reloads again once the cooldown has elapsed", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("sessionStorage", fakeSessionStorage());
+    vi.stubGlobal("window", { location: { reload } });
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+
+    reloadOnce();
+    now.mockReturnValue(1_000_000 + 10_000);
+    reloadOnce();
+
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("installChunkReloadHandler", () => {
+  function setup() {
+    const listeners: Record<string, EventListener[]> = {};
+    const reload = vi.fn();
+    const target = {
+      addEventListener: (type: string, cb: EventListener) => {
+        (listeners[type] ??= []).push(cb);
+      },
+      location: { reload },
+    };
+    vi.stubGlobal("sessionStorage", fakeSessionStorage());
+    vi.stubGlobal("window", target);
+    installChunkReloadHandler(target as unknown as Window);
+    const dispatch = (type: string, event: unknown) =>
+      listeners[type]?.forEach((cb) => cb(event as Event));
+    return { dispatch, reload };
+  }
+
+  test("reloads on an unhandled ChunkLoadError rejection", () => {
+    const { dispatch, reload } = setup();
+    const error = new Error("Loading chunk 5 failed.");
+    error.name = "ChunkLoadError";
+
+    dispatch("unhandledrejection", { reason: error });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores unhandled rejections that are not chunk errors", () => {
+    const { dispatch, reload } = setup();
+
+    dispatch("unhandledrejection", { reason: new Error("validation failed") });
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test("reloads on a chunk error surfaced via the error event", () => {
+    const { dispatch, reload } = setup();
+    const error = new Error("Loading CSS chunk 9 failed.");
+    error.name = "ChunkLoadError";
+
+    dispatch("error", { error, target: null });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

A DevHub tab left open across a redeploy 404s on its content-hashed JS/CSS assets: the filenames change on each build and the old files no longer exist at the production domain. On the homepage this triggers Docusaurus's generic "Your Docusaurus site did not load properly / wrong baseUrl" banner, rendered unstyled because the CSS 404s too. The `baseUrl` message is a red herring (`baseUrl = /` is correct) — the real cause is the stale tab's main bundle failing to boot.

This injects a tiny, self-contained recovery script that transparently reloads the stale tab onto the current deployment.

### Why an inline `<head>` script (not a clientModule)

The symptom is a **boot-time** failure: the hashed `main.<hash>.js` bundle 404s, so `window.docusaurus` is never set and Docusaurus shows the banner. A `clientModule` would be bundled *into that same 404'd file*, so it could never run. The recovery logic therefore has to live in an **inline `<head>` script** that is independent of the app bundle.

### How it works

- `installChunkReload()` (`src/client/chunk-reload.ts`) is a self-contained function injected as an inline `<head>` script by a new plugin (`plugins/chunk-reload.ts`) via `injectHtmlTags`.
- Primary signal mirrors Docusaurus's own `BaseUrlIssueBanner` check: on `DOMContentLoaded`, if `window.docusaurus` is still undefined, an asset failed to boot → reload.
- Also handles capture-phase `error` on failed `/assets/` `<script>`/`<link>` loads, and `unhandledrejection` for post-boot route-chunk failures.
- All reloads are guarded by a 10s `sessionStorage` cooldown so a genuinely broken deploy can't cause a reload loop.

A header comment documents why Vercel Skew Protection was deliberately not adopted: Docusaurus is not a zero-config Skew Protection framework, so the only viable signal (the `__vdpl` cookie) would pin document navigations and trap users on stale deployments; this inline reload removes the user-visible symptom without that complexity.

> Note: the inline script is serialized via `.toString()`, so its body is kept to conservative vanilla JS (no optional chaining / nullish / spread) to avoid transpiler helpers leaking into the inlined source.

## Test plan

- [x] `npm run fmt`, `npm run typecheck`
- [x] Unit tests in `tests/chunk-reload.test.ts` (10 tests): boot check (booted vs not), asset `error` capture for `<script>`/`<link>`, dynamic-import rejection, and reload cooldown
- [x] `npm run build` (ran via pre-commit hook); verified the inline script is injected into the head and parses as valid JS
- [x] Local stale-then-fresh repro: reproduced the unstyled banner, then confirmed the fix auto-reloads the stale tab onto the fresh build (`window.docusaurus` defined, banner gone, now serving the new bundle hash)
- [ ] Post-deploy: leave a tab open, trigger a subsequent deploy, confirm the stale tab auto-recovers instead of showing the unstyled banner