### PR TITLE
Add Neon to product nav dropdown after Databricks Apps

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -29,6 +29,7 @@ const FOOTER_SECTIONS: FooterSection[] = [
       { label: "Databricks Apps", to: "/product/databricks-apps" },
       { label: "Lakebase", to: "/product/lakebase" },
       { label: "Agent Bricks", to: "/product/agent-bricks" },
+      { label: "Neon", href: "https://neon.com", externalArrow: true },
     ],
   },
   {

--- a/src/components/header/mobile-nav.tsx
+++ b/src/components/header/mobile-nav.tsx
@@ -3,9 +3,11 @@
 import { useEffect, useId, type ComponentProps } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
 
 import {
   getActiveProductHref,
+  isExternalHref,
   isHeaderNavItemActive,
   PRODUCT_LINKS,
   type HeaderNavItem,
@@ -101,6 +103,8 @@ function MobileTreeText({
   className?: string;
   href: string;
 } & Omit<ComponentProps<typeof Link>, "children" | "className" | "href">) {
+  const isExternal = isExternalHref(href);
+
   return (
     <Link
       href={href}
@@ -111,17 +115,27 @@ function MobileTreeText({
           : "text-grey-80 hover:text-grey-80",
         className,
       )}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       {...props}
     >
       <span
         className={cn(
-          "inline-block px-0.5 py-1",
+          "inline-flex items-center px-0.5 py-1",
           active && "bg-grey-80",
-          activeFill === "full" && "block w-full",
+          activeFill === "full" && "flex w-full",
         )}
         data-mobile-menu-item-label="true"
       >
         {children}
+        {isExternal && (
+          <ArrowUpRight
+            className={cn(
+              "ml-1 size-4 shrink-0",
+              active ? "text-grey-12" : "text-grey-80",
+            )}
+            aria-label="(opens in a new tab)"
+          />
+        )}
       </span>
     </Link>
   );

--- a/src/components/header/mobile-nav.tsx
+++ b/src/components/header/mobile-nav.tsx
@@ -259,15 +259,16 @@ export function MobileNav({
             className="relative flex h-full w-full justify-between font-mono text-xl leading-none font-normal tracking-[-0.025rem]"
             aria-label="Main navigation"
           >
-            <MobileTreeLine className="top-[38px] left-[23px] h-[226px] w-px" />
+            <MobileTreeLine className="top-[38px] left-[23px] h-[260px] w-px" />
             <MobileTreeLine className="top-[58px] left-6 h-px w-[37px]" />
             <MobileTreeLine className="top-[90px] left-[63px] h-px w-[37px]" />
             <MobileTreeLine className="top-[124px] left-[63px] h-px w-[37px]" />
             <MobileTreeLine className="top-[158px] left-[63px] h-px w-[37px]" />
-            <MobileTreeLine className="top-[194px] left-6 h-px w-[37px] md:w-[39px]" />
+            <MobileTreeLine className="top-[192px] left-[63px] h-px w-[37px]" />
             <MobileTreeLine className="top-[228px] left-6 h-px w-[37px] md:w-[39px]" />
-            <MobileTreeLine className="top-[264px] left-6 h-px w-[37px] md:w-[39px]" />
-            <MobileTreeLine className="top-[72px] left-[63px] h-[86px] w-px md:top-[73px] md:h-[85px]" />
+            <MobileTreeLine className="top-[262px] left-6 h-px w-[37px] md:w-[39px]" />
+            <MobileTreeLine className="top-[298px] left-6 h-px w-[37px] md:w-[39px]" />
+            <MobileTreeLine className="top-[72px] left-[63px] h-[120px] w-px md:top-[73px] md:h-[119px]" />
 
             <MobileTreeText
               active={isHomeActive}
@@ -300,6 +301,7 @@ export function MobileNav({
                     index === 0 && "top-[76px]",
                     index === 1 && "top-[110px]",
                     index === 2 && "top-36",
+                    index === 3 && "top-[178px]",
                   )}
                   data-mobile-menu-product-link="true"
                   href={product.href}
@@ -320,9 +322,9 @@ export function MobileNav({
                   aria-current={isActive ? "page" : undefined}
                   className={cn(
                     "right-5 left-[61px] md:right-[22px] md:left-[63px]",
-                    index === 0 && "top-[180px]",
-                    index === 1 && "top-[214px]",
-                    index === 2 && "top-[248px]",
+                    index === 0 && "top-[214px]",
+                    index === 1 && "top-[248px]",
+                    index === 2 && "top-[282px]",
                   )}
                   data-mobile-menu-section-link="true"
                   href={item.href}

--- a/src/components/header/nav.tsx
+++ b/src/components/header/nav.tsx
@@ -26,10 +26,10 @@ type HeaderNavProps = {
 };
 
 const PRODUCT_DROPDOWN_ROW_STEP = 24;
-const PRODUCT_SCROLLBAR_STEP = 12;
-const PRODUCT_SCROLL_DOT_TRACK_HEIGHT = 42;
+const PRODUCT_SCROLLBAR_STEP = 16;
+const PRODUCT_SCROLL_DOT_TRACK_HEIGHT = 66;
 const PRODUCT_SCROLL_DOT_Y_POSITIONS = Array.from(
-  { length: 21 },
+  { length: 33 },
   (_, index) => index * 2 + 1.5,
 );
 
@@ -72,21 +72,21 @@ function ProductDropdownFrame() {
   return (
     <svg
       data-product-dropdown-frame="true"
-      className="pointer-events-none absolute top-2.5 left-1 z-30 h-[90px] w-[178px] overflow-visible text-white"
-      viewBox="0 0 178 90"
+      className="pointer-events-none absolute top-2.5 left-1 z-30 h-[114px] w-[178px] overflow-visible text-white"
+      viewBox="0 0 178 114"
       fill="none"
       preserveAspectRatio="none"
       aria-hidden="true"
     >
       <path
-        d="M177.5 80.0319V89.5H0.5V0.5H177.5V1.44681V9.96809"
+        d="M177.5 104.0319V113.5H0.5V0.5H177.5V1.44681V9.96809"
         stroke="currentColor"
       />
       <path
-        d="M176.5 0.504639V1.45145V9.97272M176.5 89.5046V80.0365"
+        d="M176.5 0.504639V1.45145V9.97272M176.5 113.5046V104.0365"
         stroke="currentColor"
       />
-      <path d="M1.5 0.5V89.5" stroke="currentColor" />
+      <path d="M1.5 0.5V113.5" stroke="currentColor" />
     </svg>
   );
 }
@@ -133,7 +133,7 @@ function ProductScrollDotColumn({ left, top }: { left: number; top: number }) {
   return (
     <svg
       data-product-dropdown-dot-column="true"
-      className="absolute z-0 h-[42px] w-[3px] overflow-visible"
+      className="absolute z-0 h-[66px] w-[3px] overflow-visible"
       style={{ left, top }}
       viewBox={`0 0 3 ${PRODUCT_SCROLL_DOT_TRACK_HEIGHT}`}
       fill="none"
@@ -177,7 +177,7 @@ function ProductScrollbar({
           }px)`,
         }}
       />
-      <ProductScrollArrow direction="down" top={76} />
+      <ProductScrollArrow direction="down" top={100} />
     </span>
   );
 }
@@ -200,7 +200,7 @@ function ProductDropdown({
 
   return (
     <div
-      className="bg-grey-12 relative h-[111px] w-[185px] font-mono text-sm leading-none text-white"
+      className="bg-grey-12 relative h-[135px] w-[185px] font-mono text-sm leading-none text-white"
       onMouseLeave={onHighlightReset}
       onBlur={(event) => {
         const nextFocusedElement = event.relatedTarget;
@@ -289,7 +289,7 @@ export function HeaderNav({ className, items }: HeaderNavProps) {
                 <NavigationMenuTrigger className="group/product-trigger focus-visible:outline-db-cyan h-auto rounded-none bg-transparent! p-0 font-mono text-white shadow-none !transition-none hover:bg-transparent! hover:text-white! focus:bg-transparent! focus:text-white! focus-visible:outline-offset-2 data-[active=true]:!bg-transparent data-[state=open]:bg-transparent! data-[state=open]:text-white! [&>svg]:hidden">
                   <NavItemChrome active={isActive}>{label}</NavItemChrome>
                 </NavigationMenuTrigger>
-                <NavigationMenuContent className="bg-grey-12! z-60 mt-0! h-[111px]! w-[185px]! overflow-visible! rounded-none! border-0! p-0! shadow-none! !transition-none !duration-0 group-data-[viewport=false]/navigation-menu:!duration-0 data-[motion^=from-]:!animate-none data-[motion^=to-]:!animate-none data-[state=closed]:!animate-none group-data-[viewport=false]/navigation-menu:data-[state=closed]:!animate-none data-[state=open]:!animate-none group-data-[viewport=false]/navigation-menu:data-[state=open]:!animate-none">
+                <NavigationMenuContent className="bg-grey-12! z-60 mt-0! h-[135px]! w-[185px]! overflow-visible! rounded-none! border-0! p-0! shadow-none! !transition-none !duration-0 group-data-[viewport=false]/navigation-menu:!duration-0 data-[motion^=from-]:!animate-none data-[motion^=to-]:!animate-none data-[state=closed]:!animate-none group-data-[viewport=false]/navigation-menu:data-[state=closed]:!animate-none data-[state=open]:!animate-none group-data-[viewport=false]/navigation-menu:data-[state=open]:!animate-none">
                   <ProductDropdown
                     activeProductHref={activeProductHref}
                     highlightedProductHref={productHighlightHref}

--- a/src/components/header/nav.tsx
+++ b/src/components/header/nav.tsx
@@ -3,9 +3,11 @@
 import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
 
 import {
   getActiveProductHref,
+  isExternalHref,
   isHeaderNavItemActive,
   PRODUCT_LINKS,
   type HeaderNavItem,
@@ -228,6 +230,7 @@ function ProductDropdown({
         {PRODUCT_LINKS.map((product) => {
           const isProductActive = product.href === activeProductHref;
           const isProductHighlighted = product.href === highlightedProductHref;
+          const isExternal = isExternalHref(product.href);
 
           return (
             <NavigationMenuLink
@@ -246,8 +249,20 @@ function ProductDropdown({
                 href={product.href}
                 onFocus={() => onHighlightChange(product.href)}
                 onPointerEnter={() => onHighlightChange(product.href)}
+                {...(isExternal
+                  ? { target: "_blank", rel: "noopener noreferrer" }
+                  : {})}
               >
                 {product.label}
+                {isExternal && (
+                  <ArrowUpRight
+                    className={cn(
+                      "ml-1 size-3.5 shrink-0",
+                      isProductHighlighted ? "text-grey-12" : "text-white",
+                    )}
+                    aria-label="(opens in a new tab)"
+                  />
+                )}
               </Link>
             </NavigationMenuLink>
           );

--- a/src/lib/header-navigation.ts
+++ b/src/lib/header-navigation.ts
@@ -11,6 +11,7 @@ export const PRODUCT_LINKS = [
   { label: "Lakebase", href: "/product/lakebase" },
   { label: "Agent Bricks", href: "/product/agent-bricks" },
   { label: "Databricks Apps", href: "/product/databricks-apps" },
+  { label: "Neon", href: "https://neon.com" },
 ] as const;
 
 function normalizePath(path: string) {

--- a/src/lib/header-navigation.ts
+++ b/src/lib/header-navigation.ts
@@ -20,7 +20,7 @@ function normalizePath(path: string) {
   return path.replace(/\/$/, "");
 }
 
-function isExternalHref(href: string) {
+export function isExternalHref(href: string) {
   return /^https?:\/\//.test(href);
 }
 

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -90,7 +90,7 @@ test.describe("navbar navigation", () => {
     await expect(activeLink).toHaveCSS("color", "rgb(28, 29, 34)");
     await expect(
       productMenu.locator("[data-product-dropdown-frame]"),
-    ).toHaveAttribute("viewBox", "0 0 178 90");
+    ).toHaveAttribute("viewBox", "0 0 178 114");
 
     const highlight = productMenu.locator("[data-product-dropdown-highlight]");
     const thumb = productMenu.locator("[data-product-dropdown-thumb]");
@@ -155,7 +155,7 @@ test.describe("navbar navigation", () => {
 
         return Math.round((box?.y ?? 0) - initialThumbBox.y);
       })
-      .toBe(12);
+      .toBe(16);
   });
 });
 
@@ -247,13 +247,13 @@ test.describe("mobile navigation", () => {
       expect(Math.round(lakebaseBox.y)).toBe(offsetY + 132);
       expect(Math.round(lakebaseBox.width)).toBe(viewport.highlightWidth);
       expect(Math.round(solutionsBox.x)).toBe(viewport.sectionX);
-      expect(Math.round(solutionsBox.y)).toBe(offsetY + 236);
+      expect(Math.round(solutionsBox.y)).toBe(offsetY + 270);
       expect(Math.round(solutionsBox.width)).toBe(viewport.sectionClickWidth);
       expect(Math.round(templatesBox.x)).toBe(viewport.sectionX);
-      expect(Math.round(templatesBox.y)).toBe(offsetY + 270);
+      expect(Math.round(templatesBox.y)).toBe(offsetY + 304);
       expect(Math.round(templatesBox.width)).toBe(viewport.sectionClickWidth);
       expect(Math.round(docsBox.x)).toBe(viewport.sectionX);
-      expect(Math.round(docsBox.y)).toBe(offsetY + 304);
+      expect(Math.round(docsBox.y)).toBe(offsetY + 338);
       expect(Math.round(docsBox.width)).toBe(viewport.sectionClickWidth);
     });
   }
@@ -293,7 +293,7 @@ test.describe("mobile navigation", () => {
     );
     await expect(lakebase).toHaveCSS("color", "rgb(199, 201, 209)");
 
-    await expect(productLinks).toHaveCount(3);
+    await expect(productLinks).toHaveCount(4);
     for (const productLink of await productLinks.all()) {
       await expect(productLink).not.toHaveAttribute("aria-current", "page");
     }

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -501,6 +501,7 @@ test.describe("footer navigation", () => {
     "/product/databricks-apps",
     "/product/lakebase",
     "/product/agent-bricks",
+    "https://neon.com",
     "/docs/start-here",
     "/templates",
     "/solutions",


### PR DESCRIPTION
## What

Adds a **Neon** entry (external link to https://neon.com) to two places:

- the header **Product** dropdown, positioned after Databricks Apps (desktop + mobile menu), and
- the footer **Products** section, after Agent Bricks.

Both open in a new tab and show an external-link arrow icon.

## Why one line became a few files

The single content change is one line in `src/lib/header-navigation.ts`:

```ts
{ label: "Neon", href: "https://neon.com" },
```

But two things fan out from it:

**1. External-link affordance.** Neon is the first external entry in the product nav, so both nav components now detect external hrefs and render accordingly — `target="_blank" rel="noopener noreferrer"` plus an `ArrowUpRight` icon with an `aria-label="(opens in a new tab)"`. To share the check, `isExternalHref` is now exported from `header-navigation.ts`.

**2. Fixed-count chrome geometry.** The dropdown frame and the mobile tree are hand-tuned for a fixed item count (decorative SVG frame + scrollbar on desktop, absolutely-positioned tree connectors on mobile), so a 4th row needs the surrounding geometry extended.

## Files

- **`src/lib/header-navigation.ts`** — add the Neon product link; export `isExternalHref`.
- **`src/components/header/nav.tsx`** (desktop dropdown) — external-link icon + new-tab behavior; frame `viewBox` 90 → 114, container height 111 → 135, scrollbar dot track 42 → 66, scrollbar step 12 → 16, down-arrow position moved to match.
- **`src/components/header/mobile-nav.tsx`** (mobile menu) — external-link icon + new-tab behavior; added the 4th product-row position (`top-[178px]`), shifted the section links down 34px, and extended the tree connector lines / trunk to match.
- **`src/components/footer.tsx`** — add Neon to the Products section with the external-arrow icon (opens in a new tab, matching the other external footer links).
- **`tests/e2e/navigation.spec.ts`** — updated the frame `viewBox` assertion, the scrollbar step delta, the shifted mobile section-link positions, the product-link count (3 → 4), and the footer expected-hrefs order.

## Verification

Run locally on this branch:

- `pnpm typecheck` — passes
- `pnpm build` — passes
- `pnpm exec prettier -c .` — clean
- `pnpm exec fallow dead-code` — no issues; `pnpm exec fallow dupes` — no new duplication in changed files
- `pnpm exec playwright test tests/e2e/navigation.spec.ts` — **69/69 passed**, including the desktop dropdown geometry, mobile tree layout, and footer link-order assertions

## Notes for reviewer

- The Neon entry opens in a new tab (`target="_blank"`), unlike the internal product links which navigate in the same tab. This is intentional since it leaves the site.
- External hrefs are handled by the shared `isExternalHref` helper — external links never render as the active product, so no active-state logic changed.

This pull request and its description were written by Isaac.
