### PR TITLE
feat: add reusable env-gated site announcement banner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,13 +38,35 @@ Next.js loads `.env.local` automatically. Restart the dev server after editing t
 
 A flag is **enabled only when its value is exactly `"true"`** — any other value (empty, `"1"`, `"yes"`) is treated as disabled.
 
+### Site Announcement Banner
+
+The reusable site-wide announcement bar is driven by env vars, resolved by [`src/lib/site-banner-server.ts`](./src/lib/site-banner-server.ts), and rendered by [`SiteBanner`](./src/components/site-banner/site-banner.tsx) in the website layout (above the hackathon banner; not on Perspectives). It is **non-dismissible**.
+
+| Env var                 | Purpose                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `SITE_BANNER_ENABLED`   | Exact `"true"` shows the banner. Any other value (including unset) hides it.  |
+| `SITE_BANNER_TEXT`      | Lead-in copy, injected as raw HTML (keep it trusted). **Required** to render. |
+| `SITE_BANNER_LINK`      | CTA href (`/` path or `http(s):` URL). **Required**.                          |
+| `SITE_BANNER_LINK_TEXT` | CTA label (e.g. `Learn more`). **Required**. No default.                      |
+
+The banner is resolved at build time and ships in the initial HTML, so it never shifts layout after hydration. There is no date window: starting and ending a campaign is a redeploy, which is the tradeoff for avoiding that shift.
+
+Example (Data + AI World Tour):
+
+```bash
+SITE_BANNER_ENABLED=true
+SITE_BANNER_TEXT="Vibe code (safely) at work! Enable anyone to build and deploy AI apps that are fully-connected to enterprise data at"
+SITE_BANNER_LINK="https://www.databricks.com/dataaisummit/worldtour"
+SITE_BANNER_LINK_TEXT="Data + AI World Tour"
+```
+
 ### Hackathon Banner & Events
 
 Each hackathon event is its own page at `/hackathon/<slug>`, served by a Next App Router wrapper under `src/app/(website)/hackathon/<slug>/page.tsx`. Reusable legacy event bodies live under [`src/legacy-pages/hackathon/`](./src/legacy-pages/hackathon/) (for example [`apps-agents-for-good-2026.tsx`](./src/legacy-pages/hackathon/apps-agents-for-good-2026.tsx)). Events are fully independent — editing one never touches another. An event can reuse the shared [`HackathonEventPage`](./src/components/hackathon/hackathon-event-page.tsx) template by passing a typed `HackathonEvent` object, or render a completely bespoke layout instead. Event pages are `noindex` and kept out of `sitemap.xml`; entry is via the banner.
 
 `/hackathon` ([`src/app/(website)/hackathon/page.tsx`](<./src/app/(website)/hackathon/page.tsx>)) redirects to the active event.
 
-The site-wide announcement bar is driven by env vars at build time, resolved by [`src/lib/hackathon-banner-server.ts`](./src/lib/hackathon-banner-server.ts), and rendered by [`HackathonBanner`](./src/components/hackathon/hackathon-banner.tsx) in the website layout. It shows above the navbar across website routes and is intentionally **non-dismissible** so it stays the only on-site entry point to the event for the full window.
+The hackathon announcement bar is driven by env vars at build time, resolved by [`src/lib/hackathon-banner-server.ts`](./src/lib/hackathon-banner-server.ts), and rendered by [`HackathonBanner`](./src/components/hackathon/hackathon-banner.tsx) in the website layout. It shows above the navbar across website routes and is intentionally **non-dismissible** so it stays the only on-site entry point to the event for the full window. When both the site banner and hackathon banner are active, they stack (site banner on top).
 
 | Env var                    | Purpose                                                                                                                                                                                                                                                 |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { getDocsSearchItems } from "@/lib/docs-content";
 import { HackathonBanner } from "@/components/hackathon/hackathon-banner";
 import { Header } from "@/components/header/header";
+import { SiteBanner } from "@/components/site-banner/site-banner";
 
 export default function WebsiteLayout({ children }: { children: ReactNode }) {
   const searchItems = getDocsSearchItems();
@@ -14,6 +15,7 @@ export default function WebsiteLayout({ children }: { children: ReactNode }) {
           Skip to main content
         </a>
       </div>
+      <SiteBanner />
       <HackathonBanner />
       <Header searchItems={searchItems} />
       <div id="devhub-main-content" tabIndex={-1}>

--- a/src/components/site-banner/site-banner.tsx
+++ b/src/components/site-banner/site-banner.tsx
@@ -1,0 +1,23 @@
+import { getSiteBannerConfig } from "@/lib/site-banner-server";
+
+export function SiteBanner() {
+  const banner = getSiteBannerConfig();
+
+  if (!banner) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-label="Site announcement"
+      className="devhub-site-banner"
+      data-banner-id={banner.id}
+      style={{
+        backgroundColor: banner.backgroundColor,
+        color: banner.textColor,
+      }}
+    >
+      <div dangerouslySetInnerHTML={{ __html: banner.content }} />
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -312,117 +312,44 @@
     color: var(--foreground);
   }
 
-  .devhub-hackathon-banner {
+  .devhub-hackathon-banner,
+  .devhub-site-banner {
     position: relative;
     z-index: 60;
     box-sizing: border-box;
     width: 100%;
     min-height: 44px;
-    overflow: hidden;
-    padding: 14px 0;
+    padding: 14px 1rem;
     font-family: "Geist Mono", monospace;
     font-size: 1rem;
     font-weight: 500;
-    line-height: 1;
+    line-height: 1.4;
     text-align: center;
     text-transform: uppercase;
   }
 
-  .devhub-hackathon-banner > div {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    font-size: inherit;
-  }
-
-  .devhub-hackathon-banner .banner-marquee-track {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .devhub-hackathon-banner .banner-marquee-item {
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .devhub-hackathon-banner .banner-marquee-copy {
-    display: none;
-  }
-
-  .devhub-hackathon-banner a {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin-left: 0.5rem;
+  .devhub-hackathon-banner a,
+  .devhub-site-banner a {
+    /* Geist Mono is monospace, so 1ch is exactly one space: the CTA sits a
+       word-width from the copy and tracks the font-size breakpoint. */
+    margin-left: 1ch;
     color: inherit;
     font-weight: 500;
     text-decoration: none !important;
+    white-space: nowrap;
   }
 
-  .devhub-hackathon-banner .banner-link-text {
+  .devhub-hackathon-banner .banner-link-text,
+  .devhub-site-banner .banner-link-text {
     text-decoration: underline;
     text-underline-offset: 2px;
   }
 
-  .devhub-hackathon-banner .banner-arrow {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-    vertical-align: middle;
-  }
-
-  @keyframes devhub-banner-marquee {
-    0% {
-      transform: translateX(0);
-    }
-
-    100% {
-      transform: translateX(-50%);
-    }
-  }
-
   @media (max-width: 768px) {
-    .devhub-hackathon-banner {
+    .devhub-hackathon-banner,
+    .devhub-site-banner {
       min-height: 38px;
-      padding: 12px 0;
       font-size: 14px;
-    }
-
-    .devhub-hackathon-banner > div {
-      justify-content: flex-start;
-    }
-
-    .devhub-hackathon-banner .banner-marquee-track {
-      display: flex;
-      min-width: max-content;
-      align-items: center;
-      white-space: nowrap;
-      animation: devhub-banner-marquee 12s linear infinite;
-      will-change: transform;
-    }
-
-    .devhub-hackathon-banner .banner-marquee-item {
-      flex: 0 0 auto;
-      padding-right: 2rem;
-      white-space: nowrap;
-    }
-
-    .devhub-hackathon-banner .banner-marquee-copy {
-      display: inline-flex;
-    }
-
-    .devhub-hackathon-banner a {
-      margin-left: 6px;
-      white-space: nowrap;
-    }
-
-    .devhub-hackathon-banner .banner-arrow {
-      width: 14px;
-      height: 14px;
     }
   }
 }

--- a/src/lib/hackathon-banner-server.ts
+++ b/src/lib/hackathon-banner-server.ts
@@ -38,24 +38,9 @@ export function resolveHackathonBannerActive(env: HackathonBannerEnv): boolean {
 
 const DEFAULT_BANNER_LEAD_TEXT = "Databricks Developer Hackathon is live.";
 
-const ARROW_SVG = `<svg class="banner-arrow" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0.5 8.01562H14.5" stroke="#040406" stroke-width="2" stroke-miterlimit="10"/><path d="M10 3.51562L14.5 8.01562L10 12.5156" stroke="#040406" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square"/></svg>`;
-
-function bannerLinkHtml(slug: string, hidden = false): string {
+function bannerLinkHtml(slug: string): string {
   const target = slug ? `/hackathon/${slug}` : "/hackathon";
-  const hiddenAttributes = hidden ? ' tabindex="-1" aria-hidden="true"' : "";
-  return `<a href="${target}"${hiddenAttributes}><span class="banner-link-text">See resources</span>${ARROW_SVG}</a>`;
-}
-
-function bannerMarqueeItemHtml(
-  leadText: string,
-  slug: string,
-  duplicate = false,
-): string {
-  const itemClasses = duplicate
-    ? "banner-marquee-item banner-marquee-copy"
-    : "banner-marquee-item";
-  const hiddenAttributes = duplicate ? ' aria-hidden="true"' : "";
-  return `<span class="${itemClasses}"${hiddenAttributes}><span class="banner-lead-text">${leadText}</span>${bannerLinkHtml(slug, duplicate)}</span>`;
+  return `<a href="${target}"><span class="banner-link-text">See resources</span></a>`;
 }
 
 export function getHackathonBannerConfig(
@@ -75,7 +60,7 @@ export function getHackathonBannerConfig(
     // HACKATHON_BANNER_TEXT overrides only the lead-in copy; the "See
     // resources" link is always appended so visitors can never end up on a
     // banner with no way to reach the event.
-    content: `<span class="banner-marquee-track">${bannerMarqueeItemHtml(leadText, slug)}${bannerMarqueeItemHtml(leadText, slug, true)}</span>`,
+    content: `<span class="banner-lead-text">${leadText}</span>${bannerLinkHtml(slug)}`,
     backgroundColor: "#FF5F46",
     textColor: "#040406",
     isCloseable: false,

--- a/src/lib/site-banner-server.ts
+++ b/src/lib/site-banner-server.ts
@@ -1,0 +1,105 @@
+/**
+ * Server-side resolution of the reusable site announcement banner.
+ *
+ * Campaign content and timing are env-driven (strict string matching, like the
+ * hackathon banner — no date windows, so the banner server-renders and never
+ * shifts layout after hydration):
+ *
+ *   - `SITE_BANNER_ENABLED="true"` → banner on. Any other value (including
+ *     unset) → off.
+ *   - `SITE_BANNER_TEXT` / `SITE_BANNER_LINK` / `SITE_BANNER_LINK_TEXT` —
+ *     required. No defaults; incomplete content keeps the banner off.
+ *
+ * Turning the banner on or off is a redeploy, which is the tradeoff for
+ * shipping it in the initial HTML.
+ *
+ * The resolvers are pure functions so they can be unit-tested with synthetic
+ * envs. The config builder is the thin imperative shell.
+ */
+
+type SiteBannerEnv = {
+  SITE_BANNER_ENABLED?: string;
+  SITE_BANNER_TEXT?: string;
+  SITE_BANNER_LINK?: string;
+  SITE_BANNER_LINK_TEXT?: string;
+};
+
+type SiteBannerConfig = {
+  id: string;
+  content: string;
+  backgroundColor: string;
+  textColor: string;
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function isSafeHref(href: string): boolean {
+  // `//host` is protocol-relative and browsers read `/\host` the same way, so
+  // neither is an internal path and neither may pass the leading-slash check.
+  return (
+    (href.startsWith("/") && !/^\/[/\\]/.test(href)) ||
+    href.startsWith("https://") ||
+    href.startsWith("http://")
+  );
+}
+
+function isExternalHref(href: string): boolean {
+  return href.startsWith("https://") || href.startsWith("http://");
+}
+
+export function resolveSiteBannerActive(env: SiteBannerEnv): boolean {
+  return env.SITE_BANNER_ENABLED === "true";
+}
+
+export function resolveSiteBannerContent(env: SiteBannerEnv):
+  | {
+      text: string;
+      link: string;
+      linkText: string;
+    }
+  | undefined {
+  const text = (env.SITE_BANNER_TEXT ?? "").trim();
+  const link = (env.SITE_BANNER_LINK ?? "").trim();
+  const linkText = (env.SITE_BANNER_LINK_TEXT ?? "").trim();
+  if (!text || !link || !linkText) return undefined;
+  if (!isSafeHref(link)) return undefined;
+  return { text, link, linkText };
+}
+
+function bannerCtaHtml(
+  href: string,
+  linkText: string,
+  isExternal: boolean,
+): string {
+  const externalAttributes = isExternal
+    ? ' target="_blank" rel="noopener noreferrer"'
+    : "";
+  return `<a href="${escapeHtml(href)}"${externalAttributes}><span class="banner-link-text">${escapeHtml(linkText)}</span></a>`;
+}
+
+/** Returns banner config when the banner is enabled and its content is complete. */
+export function getSiteBannerConfig(
+  env: SiteBannerEnv = process.env as SiteBannerEnv,
+): SiteBannerConfig | undefined {
+  if (!resolveSiteBannerActive(env)) return undefined;
+
+  const content = resolveSiteBannerContent(env);
+  if (!content) return undefined;
+
+  return {
+    // Non-dismissible by design, matching the hackathon banner: the campaign
+    // window is controlled by deploys, not by the visitor.
+    id: "site-banner",
+    // Only the CTA is clickable; the surrounding bar is not a link target.
+    content: `<span class="banner-lead-text">${content.text}</span>${bannerCtaHtml(content.link, content.linkText, isExternalHref(content.link))}`,
+    backgroundColor: "#FF5F46",
+    textColor: "#040406",
+  };
+}

--- a/tests/e2e/pages.spec.ts
+++ b/tests/e2e/pages.spec.ts
@@ -757,9 +757,11 @@ test.describe("docs MDX compatibility", () => {
       inlineCodes: document.querySelectorAll(
         ".prose.prose-docs > code, article :not(pre) > code",
       ).length,
-      linksWithoutHackathonBanner:
+      linksWithoutBanners:
         document.querySelectorAll("a").length -
-        document.querySelectorAll(".devhub-hackathon-banner a").length,
+        document.querySelectorAll(
+          ".devhub-hackathon-banner a, .devhub-site-banner a",
+        ).length,
     }));
 
     expect(layout.articleHeight).toBeGreaterThanOrEqual(3130);
@@ -767,8 +769,10 @@ test.describe("docs MDX compatibility", () => {
     expect(layout.codeBlocks).toBe(3);
     expect(layout.inlineCodes).toBe(2);
     // 67 = page links + footer links including "Your Privacy Choices", which
-    // the footer renders twice (desktop and mobile legal blocks).
-    expect(layout.linksWithoutHackathonBanner).toBe(67);
+    // the footer renders twice (desktop and mobile legal blocks). Announcement
+    // banners are env-gated, so their links are excluded to keep the count
+    // stable whether or not a banner is live.
+    expect(layout.linksWithoutBanners).toBe(67);
   });
 
   test("renders relative docs image assets and links", async ({ page }) => {

--- a/tests/hackathon-banner.test.ts
+++ b/tests/hackathon-banner.test.ts
@@ -54,9 +54,7 @@ describe("getHackathonBannerConfig", () => {
     );
     expect(config?.id).toBe("hackathon-apps-agents-for-good-2026");
     expect(config?.content).not.toContain("<img");
-    expect(config?.content).toContain(
-      '<svg class="banner-arrow" aria-hidden="true"',
-    );
+    expect(config?.content).not.toContain("<svg");
   });
 
   test("falls back to /hackathon and a generic id when no slug is set", () => {
@@ -102,12 +100,11 @@ describe("getHackathonBannerConfig", () => {
     expect(config?.content).toContain(
       '<span class="banner-lead-text">Custom message</span><a href="/hackathon/apps-agents-for-good-2026">',
     );
-    expect(config?.content).toContain(
-      '<span class="banner-marquee-item banner-marquee-copy" aria-hidden="true">',
-    );
-    expect(config?.content).toContain(
-      '<a href="/hackathon/apps-agents-for-good-2026" tabindex="-1" aria-hidden="true">',
-    );
+    // Copy is rendered once: no duplicated marquee track to scroll.
+    expect(config?.content).not.toContain("aria-hidden");
+    expect(
+      config?.content.match(/class="banner-lead-text"/g) ?? [],
+    ).toHaveLength(1);
     expect(config?.content).not.toContain("Custom message   ");
   });
 

--- a/tests/site-banner.test.ts
+++ b/tests/site-banner.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getSiteBannerConfig,
+  resolveSiteBannerActive,
+  resolveSiteBannerContent,
+} from "../src/lib/site-banner-server";
+
+const worldTourContent = {
+  SITE_BANNER_TEXT:
+    "Vibe code (safely) at work! Enable anyone to build and deploy AI apps that are fully-connected to enterprise data at Data + AI World Tour",
+  SITE_BANNER_LINK: "https://www.databricks.com/dataaisummit/worldtour",
+  SITE_BANNER_LINK_TEXT: "Learn more",
+} as const;
+
+describe("resolveSiteBannerActive", () => {
+  test("returns false when no env vars are set", () => {
+    expect(resolveSiteBannerActive({})).toBe(false);
+  });
+
+  test('returns true only when SITE_BANNER_ENABLED is exactly "true"', () => {
+    expect(resolveSiteBannerActive({ SITE_BANNER_ENABLED: "true" })).toBe(true);
+  });
+
+  test("returns false for any other enable value", () => {
+    for (const value of ["1", "yes", "True", "TRUE", "", "false"]) {
+      expect(resolveSiteBannerActive({ SITE_BANNER_ENABLED: value })).toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("resolveSiteBannerContent", () => {
+  test("requires text, link, and link text", () => {
+    expect(resolveSiteBannerContent({})).toBeUndefined();
+    expect(
+      resolveSiteBannerContent({
+        SITE_BANNER_TEXT: "Hello",
+        SITE_BANNER_LINK: "/x",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveSiteBannerContent({
+        SITE_BANNER_TEXT: "Hello",
+        SITE_BANNER_LINK: "/x",
+        SITE_BANNER_LINK_TEXT: "Go",
+      }),
+    ).toEqual({ text: "Hello", link: "/x", linkText: "Go" });
+  });
+
+  test("rejects unsafe hrefs", () => {
+    for (const link of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "//evil.example.com",
+      "/\\evil.example.com",
+    ]) {
+      expect(
+        resolveSiteBannerContent({
+          SITE_BANNER_TEXT: "Hello",
+          SITE_BANNER_LINK: link,
+          SITE_BANNER_LINK_TEXT: "Go",
+        }),
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("getSiteBannerConfig", () => {
+  test("returns undefined when inactive even with complete content", () => {
+    expect(getSiteBannerConfig({ ...worldTourContent })).toBeUndefined();
+    expect(
+      getSiteBannerConfig({
+        ...worldTourContent,
+        SITE_BANNER_ENABLED: "false",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when content is incomplete", () => {
+    expect(
+      getSiteBannerConfig({ SITE_BANNER_ENABLED: "true" }),
+    ).toBeUndefined();
+    expect(
+      getSiteBannerConfig({
+        SITE_BANNER_ENABLED: "true",
+        SITE_BANNER_TEXT: "Hello",
+        SITE_BANNER_LINK: "https://example.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("builds banner content; only the CTA is a link", () => {
+    const config = getSiteBannerConfig({
+      ...worldTourContent,
+      SITE_BANNER_ENABLED: "true",
+    });
+    expect(config?.backgroundColor).toBe("#FF5F46");
+    expect(config?.content).toContain(worldTourContent.SITE_BANNER_TEXT);
+    expect(config?.content).toContain(
+      '<a href="https://www.databricks.com/dataaisummit/worldtour" target="_blank" rel="noopener noreferrer"><span class="banner-link-text">Learn more</span></a>',
+    );
+    expect(config?.content.match(/<a /g) ?? []).toHaveLength(1);
+    expect(config?.content).not.toContain("<svg");
+    expect(config?.content).not.toContain("aria-hidden");
+    expect(
+      config?.content.match(/class="banner-lead-text"/g) ?? [],
+    ).toHaveLength(1);
+  });
+
+  test("internal links stay same-tab", () => {
+    const config = getSiteBannerConfig({
+      SITE_BANNER_ENABLED: "true",
+      SITE_BANNER_TEXT: "Hello",
+      SITE_BANNER_LINK: "/docs",
+      SITE_BANNER_LINK_TEXT: "Docs",
+    });
+    expect(config?.content).toContain('<a href="/docs">');
+    expect(config?.content).not.toContain("target=");
+  });
+
+  test("trims content fields", () => {
+    const config = getSiteBannerConfig({
+      SITE_BANNER_ENABLED: "true",
+      SITE_BANNER_TEXT: "  Hello  ",
+      SITE_BANNER_LINK: "  /docs  ",
+      SITE_BANNER_LINK_TEXT: "  Docs  ",
+    });
+    expect(config?.content).toContain(
+      '<span class="banner-lead-text">Hello</span><a href="/docs">',
+    );
+    expect(config?.content).toContain(
+      '<span class="banner-link-text">Docs</span>',
+    );
+  });
+
+  test("escapes the CTA label", () => {
+    const config = getSiteBannerConfig({
+      SITE_BANNER_ENABLED: "true",
+      SITE_BANNER_TEXT: "Hello",
+      SITE_BANNER_LINK: "/docs",
+      SITE_BANNER_LINK_TEXT: '<img src=x onerror="alert(1)">',
+    });
+    expect(config?.content).not.toContain("<img");
+    expect(config?.content).toContain("&lt;img");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable, env-gated site-wide announcement banner for campaigns like Data + AI World Tour. Until now the hackathon banner was the only announcement surface, so campaign copy had nowhere to live without hijacking it.

- New `SiteBanner` renders above `HackathonBanner` in the website layout. When both are enabled they stack, site banner on top. Perspectives is a separate route group and is unaffected.
- Driven by `SITE_BANNER_ENABLED` / `SITE_BANNER_TEXT` / `SITE_BANNER_LINK` / `SITE_BANNER_LINK_TEXT`, resolved at build time so the bar ships in the initial HTML and never shifts layout after hydration.
- Fail-closed: the banner stays hidden unless it is explicitly enabled **and** has text, a safe href, and a CTA label. Unsafe hrefs (`javascript:`, `data:`, `//host`, `/\host`) are rejected.
- Only the CTA is clickable; the surrounding bar is not a link target. External links get `target="_blank" rel="noopener noreferrer"`, and the CTA label is HTML-escaped.
- Drops the hackathon banner's mobile marquee animation and inline arrow SVG so both bars share one simple wrapping layout. This removes noticeably more CSS than it adds.

Follows the existing hackathon banner pattern: pure resolvers in `src/lib/site-banner-server.ts` with a thin config builder, component under `src/components/site-banner/`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` succeeds
- [x] 22/22 unit tests pass across `tests/site-banner.test.ts` and `tests/hackathon-banner.test.ts`
- [x] `prettier -c .` clean; `fallow dead-code` reports no issues; `fallow dupes` flags nothing in the banner files
- [x] Verified in a production build: banner root is a `div` with exactly one anchor, correct href/target/rel, `cursor: auto` on the bar and `pointer` on the link
- [x] Accessibility tree exposes only the CTA as a link, not the lead-in copy
- [x] Full e2e suite: 181/183 pass

### Known pre-existing failures (not from this branch)

Four failures reproduce identically on clean `main` (verified in a separate worktree with the same env), caused by AppKit docs drift — `src/content/docs/appkit/` is gitignored and synced from AppKit `main` at build time:

- `tests/broken-links.test.ts`: 2 broken internal AppKit links, 9 broken anchor links
- `tests/e2e/pages.spec.ts` "expands local AppKit MDX partial imports": link count 68 vs expected 67
- `tests/e2e/pages.spec.ts` "keeps nested HTML details collapsed in Lakebase docs": height 7036 vs expected <= 7030

The e2e link-count assertion was updated here to exclude both banners' links, so the count stays stable whether or not a banner is live. Notably `main` also reports 68 without any site banner, which confirms the new exclusion works rather than masking a new link.