### PR TITLE
docs: 2026-07 accuracy audit — sync agent-skills page with manifest

### DIFF
--- a/src/content/docs/tools/ai-tools/agent-skills.md
+++ b/src/content/docs/tools/ai-tools/agent-skills.md
@@ -57,44 +57,44 @@ You can also install Databricks skills with the [Skills CLI](https://github.com/
 
 Run `databricks aitools list` to see available skills and their install status.
 
-| Skill                                    | Description                                                                                                     |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `databricks-agent-bricks`                | Create Agent Bricks: Knowledge Assistants for document Q&A and Supervisor Agents for multi-agent orchestration. |
-| `databricks-ai-functions`                | Use Databricks built-in AI Functions (`ai_classify`, `ai_extract`, `ai_summarize`, `ai_query`, and more).       |
-| `databricks-aibi-dashboards`             | Create Databricks AI/BI dashboards. Use when creating, updating, or deploying Lakeview dashboards.              |
-| `databricks-app-design`                  | Design the UX of custom-code Databricks Apps (AppKit/React) data screens mapped to concrete AppKit components.  |
-| `databricks-apps`                        | Build apps on the Databricks Apps platform.                                                                     |
-| `databricks-apps-python`                 | Python backend for Databricks Apps — FastAPI (default), Flask, Dash, Streamlit, Gradio, Reflex.                 |
-| `databricks-core`                        | CLI operations and the parent/entry-point skill: authentication, profile selection, and bundles.                |
-| `databricks-dabs`                        | Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs).                     |
-| `databricks-data-discovery`              | Discover, explore, and query Databricks data via Genie — the CLI equivalent of the Genie One MCP.               |
-| `databricks-dbsql`                       | Databricks SQL (DBSQL) advanced features and SQL warehouse capabilities.                                        |
-| `databricks-docs`                        | Databricks documentation reference via `llms.txt` index.                                                        |
-| `databricks-execution-compute`           | Execute code and manage compute: run Python/Scala/SQL/R via serverless, classic, or interactive clusters.       |
-| `databricks-iceberg`                     | Apache Iceberg tables on Databricks — Managed Iceberg, External Iceberg Reads, IRC, Iceberg v3, and more.       |
-| `databricks-jobs`                        | Develop and deploy Lakeflow Jobs via DABs, Python SDK, or the CLI.                                              |
-| `databricks-lakebase`                    | Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API.                     |
-| `databricks-lakeflow-connect`            | Build managed ingestion pipelines into Databricks using Lakeflow Connect.                                       |
-| `databricks-metric-views`                | Unity Catalog metric views: define, create, query, and manage governed business metrics in YAML.                |
-| `databricks-ml-training`                 | Train ML or custom-agent models with MLflow tracking and Unity Catalog registration.                            |
-| `databricks-mlflow-evaluation`           | MLflow 3 GenAI agent evaluation.                                                                                |
-| `databricks-model-serving`               | Databricks Model Serving endpoint lifecycle and ops.                                                            |
-| `databricks-pipelines`                   | Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables).                                      |
-| `databricks-python-sdk`                  | Databricks development guidance including Python SDK, Databricks Connect, CLI, and REST API.                    |
-| `databricks-serverless-migration`        | Migrate Databricks workloads from classic compute to serverless compute.                                        |
-| `databricks-spark-structured-streaming`  | Comprehensive guide to Spark Structured Streaming for production workloads.                                     |
-| `databricks-synthetic-data-gen`          | Generate realistic synthetic data using Spark + Faker, with serverless execution and multiple output formats.   |
-| `databricks-unity-catalog`               | Unity Catalog governance, access control, and observability — grants, privilege model, RLS, and column masks.   |
-| `databricks-unstructured-pdf-generation` | Build RAG / unstructured-document evaluation datasets and demo documents on Databricks.                         |
-| `databricks-vector-search`               | Databricks Vector Search endpoints and indexes for RAG and semantic search.                                     |
-| `databricks-zerobus-ingest`              | Build Zerobus Ingest clients for near real-time data ingestion into Databricks Delta tables via gRPC.           |
+| Skill                                    | Description                                                                                                      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `databricks-agent-bricks`                | Create Agent Bricks: Knowledge Assistants for document Q&A and Supervisor Agents for multi-agent orchestration.  |
+| `databricks-ai-functions`                | Use Databricks built-in AI Functions (`ai_classify`, `ai_extract`, `ai_summarize`, `ai_query`, and more).        |
+| `databricks-aibi-dashboards`             | Create Databricks AI/BI dashboards. Use when creating, updating, or deploying Lakeview dashboards.               |
+| `databricks-app-design`                  | Design the UX of custom-code Databricks Apps (AppKit/React) data screens mapped to concrete AppKit components.   |
+| `databricks-apps`                        | Build apps on the Databricks Apps platform.                                                                      |
+| `databricks-apps-python`                 | Python backend for Databricks Apps — FastAPI (default), Flask, Dash, Streamlit, Gradio, Reflex.                  |
+| `databricks-core`                        | CLI operations and the parent/entry-point skill: authentication, profile selection, and bundles.                 |
+| `databricks-dabs`                        | Create, configure, validate, deploy, run, and manage Declarative Automation Bundles (DABs).                      |
+| `databricks-data-discovery`              | Discover, explore, and query Databricks data via Genie — the CLI equivalent of the Genie One MCP.                |
+| `databricks-dbsql`                       | Databricks SQL (DBSQL) advanced features and SQL warehouse capabilities.                                         |
+| `databricks-docs`                        | Databricks documentation reference via `llms.txt` index.                                                         |
+| `databricks-execution-compute`           | Execute code and manage compute: run Python/Scala/SQL/R via serverless, classic, or interactive clusters.        |
+| `databricks-genie-agents`                | Create, manage, and query Databricks Genie Agents (formerly Genie Spaces) for natural-language data exploration. |
+| `databricks-iceberg`                     | Apache Iceberg tables on Databricks — Managed Iceberg, External Iceberg Reads, IRC, Iceberg v3, and more.        |
+| `databricks-jobs`                        | Develop and deploy Lakeflow Jobs via DABs, Python SDK, or the CLI.                                               |
+| `databricks-lakebase`                    | Databricks Lakebase Postgres: projects, scaling, connectivity, synced tables, and Data API.                      |
+| `databricks-lakeflow-connect`            | Build managed ingestion pipelines into Databricks using Lakeflow Connect.                                        |
+| `databricks-metric-views`                | Unity Catalog metric views: define, create, query, and manage governed business metrics in YAML.                 |
+| `databricks-ml-training`                 | Train ML or custom-agent models with MLflow tracking and Unity Catalog registration.                             |
+| `databricks-mlflow-evaluation`           | MLflow 3 GenAI agent evaluation.                                                                                 |
+| `databricks-model-serving`               | Databricks Model Serving endpoint lifecycle and ops.                                                             |
+| `databricks-pipelines`                   | Develop Lakeflow Spark Declarative Pipelines (formerly Delta Live Tables).                                       |
+| `databricks-python-sdk`                  | Databricks development guidance including Python SDK, Databricks Connect, CLI, and REST API.                     |
+| `databricks-serverless-migration`        | Migrate Databricks workloads from classic compute to serverless compute.                                         |
+| `databricks-spark-structured-streaming`  | Comprehensive guide to Spark Structured Streaming for production workloads.                                      |
+| `databricks-synthetic-data-gen`          | Generate realistic synthetic data using Spark + Faker, with serverless execution and multiple output formats.    |
+| `databricks-unity-catalog`               | Unity Catalog governance, access control, and observability — grants, privilege model, RLS, and column masks.    |
+| `databricks-unstructured-pdf-generation` | Build RAG / unstructured-document evaluation datasets and demo documents on Databricks.                          |
+| `databricks-vector-search`               | Databricks Vector Search endpoints and indexes for RAG and semantic search.                                      |
+| `databricks-zerobus-ingest`              | Build Zerobus Ingest clients for near real-time data ingestion into Databricks Delta tables via gRPC.            |
 
 The following skills are experimental. They install only when you pass `--experimental`, and `databricks aitools list` shows them under "Experimental skills":
 
 | Skill                      | Description                                                                                                 |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `databricks-ai-runtime`    | Databricks AI Runtime (`air`) CLI for submitting and managing GPU training workloads on serverless compute. |
-| `databricks-genie`         | Create and query Databricks Genie Agents for natural language SQL exploration.                              |
 | `spark-python-data-source` | Build custom Python data sources for Apache Spark using the PySpark DataSource API.                         |
 
 ## Where to next


### PR DESCRIPTION
## Docs accuracy audit — 2026-07-31

Periodic accuracy pass over `/docs` and `/templates` content on developers.databricks.com, verified against the official Databricks documentation (docs.databricks.com) and the live Databricks CLI (**v1.10.0**). Nine parallel research agents audited every content cluster claim-by-claim; findings were re-verified against canonical pages and the real CLI before any edit.

**The content is in very good shape.** Across all nine clusters, this pass found **exactly one** fixable inaccuracy in editable content (below). Everything else was either verified correct or falls into acceptable/upstream/out-of-scope categories.

### Fixed in this PR

| Fix | File | What was wrong | Source of truth |
|---|---|---|---|
| Rename the renamed skill | `src/content/docs/tools/ai-tools/agent-skills.md` | The page listed `databricks-genie`, which was renamed upstream to `databricks-genie-agents` and graduated from experimental to stable. | The live manifest at [databricks/databricks-agent-skills](https://github.com/databricks/databricks-agent-skills/blob/main/manifest.json) and `databricks aitools list` (CLI v1.10.0). |

Specifically: renamed `databricks-genie` → `databricks-genie-agents`, moving it into the main "Available skills" table (its `repo_dir` changed from `experimental` to `skills`) and dropping its old row from the experimental section. The experimental section is **retained** with `databricks-ai-runtime` and `spark-python-data-source`, which are still experimental (`repo_dir: "experimental"` in the manifest; both listed under "Experimental skills" by `databricks aitools list`). The `--experimental` install-flag row is unchanged.

This makes the repo's own `docs-verify-agent-skills.test.ts` pass (was 2/4 failing → now 4/4). **Note for maintainers:** that test can't actually catch experimental-status drift — its check reads `manifest[name].experimental === true`, but the manifest has no `experimental` field (experimental status is encoded via `repo_dir: "experimental"`). Consider updating the test to key off `repo_dir` so a future experimental/stable move is caught automatically.

### Not in this PR

**Fix upstream in `databricks/appkit`** (pages under `src/content/docs/appkit/v0/**` are synced by `scripts/sync-appkit-docs.mjs`; local edits are overwritten):

- **STALE** — `plugins/genie.md:7` and `faq.md:17` use "AI/BI Genie" / "Genie Spaces". Canonical [genie docs](https://docs.databricks.com/aws/en/genie/) now use the "Genie Agents" family (Genie One / Genie Agents / Genie Code). Terminology only — the `spaces` config, space-id-in-API mechanics remain valid.
- **UNVERIFIABLE / worth confirming upstream** — `plugins/jobs.md:135` exact `user_api_scopes` token `jobs.jobs` for Jobs OBO; `plugins/agents.md:228` AI Gateway Responses path `/ai-gateway/mlflow/v1/responses`; and an internal inconsistency across `manifest.md` / `lakebase.md` / `faq.md` on `CAN_CONNECT_AND_CREATE` vs `CONNECT_AND_CREATE` (the apps docs and the DABs resource schema both use **`CAN_CONNECT_AND_CREATE`**, so that's the string to standardize on).
- **Missing internal link** — `/docs/api/appkit-ui`, referenced from `appkit/v0/development/type-generation.md` and `appkit/v0/api/appkit-ui/styling.md` (both synced pages).

**UNVERIFIABLE, left in place** (not contradicted by canonical docs — docs are silent — so not edited; listed for transparency):

- `docs/apps/development.md:125,144` — app-name **"26 characters or fewer"** cap. Canonical apps docs state the lowercase/hyphen/unique rule but **no maximum length**; `databricks apps init --help` says nothing about a length limit. The lowercase/hyphen rule itself is correct. (One research agent reported the 26 figure as confirmed; two hedged — no crisp canonical source found either way.)
- `docs/lakebase/quickstart.md:9` — CLI minimum **`v1.0.0+`**. The `databricks postgres` group is Beta/recent so the true floor may be higher, but no canonical page or CLI output pins the minimum. Not contradicted.

**Optional polish, not applied** (accurate as written, minor wording):

- `docs/lakehouse/jobs.md:135` — `CAN_VIEW` described as "Read the job definition and run history"; canonical [jobs privileges](https://docs.databricks.com/aws/en/jobs/privileges) describe `CAN VIEW` as run-results-only and reserve definition editing for `CAN MANAGE` (silent on definition *read*).
- Four Lakebase recipe prerequisites (`lakebase-data-persistence`, `lakebase-off-platform-env-management`, `lakebase-token-management`, `lakebase-pgvector`) say "A **provisioned** Lakebase project" where lowercase "provisioned" can collide with the product name "Lakebase **Provisioned**" — they mean an Autoscaling **project**. Internally consistent; a reword ("A created Lakebase project") would remove the ambiguity.
- `docs/agents/custom-agents.md:24` — Supervisor Agent "Setup" links the Supervisor API, which canonical docs position as a distinct programmatic path; optional reword to "or programmatically via the Supervisor API".

### Verification

- **Link check** (`check-links.sh`): no broken external links; internal links clean except `/docs/api/appkit-ui` (upstream AppKit page, listed above). 6 legacy `docs.databricks.com/en/...` links still redirect (polish, not blocking).
- **CLI flag tests** (`cli-options-*.test.ts`): **48/48 pass** (CLI v1.10.0).
- **Agent-skills sync test** (`docs-verify-agent-skills.test.ts`): **4/4 pass** after the fix (was 2 failing).
- `pnpm typecheck`: clean. `pnpm build`: succeeds. `pnpm fmt`: clean (table reflowed by prettier).
- **Live docs-verify suite** (Lakebase/Apps/deploy end-to-end against a real workspace, profile `tony-devhub-docs-check`): **74/74 pass across all 6 suites** (~4 min; creates and cleans up temporary apps and Lakebase projects). Every documented Lakebase, Apps, and deploy flow verified working against a live workspace.

---

This pull request and its description were written by Isaac.
