### PR TITLE
build: exclude generated content from Vercel CLI uploads

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -8,6 +8,30 @@ test-results
 playwright-report
 screenshots
 
+# Generated content — regenerated on every Vercel build by the pre/postbuild
+# scripts (build-home-hero-player.mjs, sync-appkit-docs.mjs,
+# generate-next-static-artifacts.mjs, next-sitemap). These are gitignored, but
+# the Vercel CLI uploads the working tree using .vercelignore (NOT .gitignore),
+# so without these entries a `vercel` deploy ships whatever stale copies happen
+# to be on disk. When source is renamed upstream (e.g. appkit vector-search ->
+# ai-search), the build regenerates the tree and drops the old file, and the
+# "Deploying outputs" step fails with ENOENT on the now-missing stale path.
+# Keep this list in sync with the generated-files block in .gitignore
+# (same order, so the two blocks diff line-for-line).
+public/llms.txt
+public/robots.txt
+public/sitemap*.xml
+public/raw-docs
+public/docs
+public/templates
+public/solutions
+public/templates.md
+public/solutions.md
+src/content/docs/appkit/
+src/components/doc-examples/
+public/appkit-preview/
+public/js/home-hero-player.js
+
 # Keep Vercel on npm — bun.lock would make it try bun, which
 # hits registry-proxy issues and hangs/fails the deploy
 bun.lock

--- a/tests/vercel-config.test.ts
+++ b/tests/vercel-config.test.ts
@@ -104,3 +104,34 @@ describe("vercel headers", () => {
     ).toBe(false);
   });
 });
+
+const generatedFilesHeading = "# Generated files";
+
+function readGitignoreGeneratedPaths(): string[] {
+  const block = readFileSync(resolve(__dirname, "..", ".gitignore"), "utf-8")
+    .split(/\n\s*\n/)
+    .find((section) => section.startsWith(generatedFilesHeading));
+
+  if (!block) {
+    throw new Error(`Missing "${generatedFilesHeading}" block in .gitignore`);
+  }
+
+  return block.trim().split("\n").slice(1);
+}
+
+describe("vercel upload ignores", () => {
+  // The Vercel CLI builds its upload ignore set from .vercelignore and never
+  // reads .gitignore, so a generated path listed only in .gitignore gets
+  // uploaded stale. The build then regenerates the tree without that file and
+  // "Deploying outputs" fails with ENOENT on the now-missing path.
+  test("excludes every generated path that .gitignore excludes", () => {
+    const vercelignore = readFileSync(
+      resolve(__dirname, "..", ".vercelignore"),
+      "utf-8",
+    ).split("\n");
+
+    for (const generatedPath of readGitignoreGeneratedPaths()) {
+      expect(vercelignore).toContain(generatedPath);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

A manual production deploy of `main` via `vercel --prod` failed three times in a row at Vercel's **"Deploying outputs"** step:

```
ENOENT: no such file or directory, lstat '/vercel/path0/public/docs/appkit/v0/plugins/vector-search.md'
```

The build itself compiled, typechecked, and prerendered all 612 pages successfully every time — the failure was purely in packaging the output. Skipping the build cache (`--force`) did not help, because the problem was in the uploaded working tree, not the cache.

## Root cause

The `vercel` CLI uploads the working tree using **`.vercelignore`**, not `.gitignore`. Our generated content under `public/` (and the synced appkit sources under `src/`) is gitignored but was **absent from `.vercelignore`**, so a CLI deploy shipped whatever copies happened to be on disk locally.

Those copies had gone stale: appkit renamed a doc upstream (`vector-search` → `ai-search`) and the local `src/content/docs/appkit` source was re-synced to the new name, but the local generated `public/docs/` tree was days older and still contained `vector-search.md`. On the build machine, `next build` traced the uploaded stale file, then the `postbuild` script (`generate-next-static-artifacts.mjs`) wiped and regenerated `public/docs` from source — dropping `vector-search.md` — and the output packager then failed to `lstat` the now-missing path.

Git-integration builds were never affected, because they never have these generated files locally and always regenerate them fresh. This only bites manual CLI deploys.

## Fix

**1. Exclude the generated files from CLI uploads** (`.vercelignore`)

Mirror the generated-files block of `.gitignore` into `.vercelignore`, so the CLI relies on the Vercel build to regenerate these files fresh — matching how git-integration builds already behave.

Every excluded path:

- has **zero** git-tracked files, and
- is regenerated during the Vercel build by the pre/postbuild scripts (`build-home-hero-player.mjs`, `sync-appkit-docs.mjs`, `generate-next-static-artifacts.mjs`, `next-sitemap`).

**2. Guard the invariant** (`tests/vercel-config.test.ts`)

The fix above leaves the same trap set for the next person: `.gitignore` is mandatory (or the file gets committed), while `.vercelignore` is easy to forget and stays silent until someone runs `vercel --prod`. Drift between the two lists is exactly what caused this outage.

The new test derives its expectations from the `# Generated files` block in `.gitignore` rather than hardcoding a second list, so adding a generated path there and forgetting `.vercelignore` fails the suite instead of the next production deploy. It throws if the block is ever renamed, so it cannot silently become vacuous.

Note that GitHub Actions is currently disabled on this repo (no CI run since March), and the pre-commit hook does not run vitest, so today this guard fires only when someone runs `pnpm test` / `pnpm test:smoke`. It documents and enforces the invariant, but wiring it into an automated gate is follow-up work.

## Verification

- Pre-commit hook (prettier, typecheck, validate:content, verify:images, **build**) passed on both commits.
- Isolated **preview** deploy (`vercel deploy`) with the `.vercelignore` change → **● Ready**. This confirms the build regenerates the full tree when these files are excluded from the upload, so nothing the app serves is lost.
- The guard test passes as-is, and fails as intended when a generated path is removed from `.vercelignore` to simulate the drift that caused the outage: `expected [ …(38) ] to include 'public/raw-docs'`.
- The production deploy that motivated this was unblocked separately by regenerating the local artifacts (`pnpm build`); production is live and healthy. This PR prevents the class of failure from recurring.

This pull request and its description were written by Isaac.