### PR TITLE
Redirect /appkit to the current AppKit docs major

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import createMDX from "@next/mdx";
@@ -7,6 +9,36 @@ const resolveLocal = (relativePath) =>
 const resolveMdxPlugin = (file) =>
   resolveLocal(`./src/lib/mdx-plugins/${file}`);
 const projectRoot = resolveLocal("./");
+
+function appkitDocsChannel() {
+  const pkgJsonPath = join(
+    projectRoot,
+    "node_modules",
+    "@databricks",
+    "appkit-ui",
+    "package.json",
+  );
+  if (!existsSync(pkgJsonPath)) {
+    throw new Error(
+      "@databricks/appkit-ui is not installed. Run `pnpm install` and retry.",
+    );
+  }
+
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+  const version = pkg.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new Error(
+      `Invalid @databricks/appkit-ui version: ${JSON.stringify(version)}`,
+    );
+  }
+
+  const major = version.split(".")[0];
+  if (!/^\d+$/.test(major)) {
+    throw new Error(`Invalid @databricks/appkit-ui version: ${version}`);
+  }
+
+  return `v${major}`;
+}
 const textArtifactCacheHeader = {
   key: "Cache-Control",
   value: "public, max-age=0, s-maxage=600",
@@ -43,6 +75,8 @@ const nextConfig = {
     ],
   },
   async redirects() {
+    const latestAppkitDocs = `/docs/appkit/${appkitDocsChannel()}`;
+
     return [
       {
         source: "/docs",
@@ -58,6 +92,18 @@ const nextConfig = {
         source: "/product/data-lakehouse",
         destination: "/product/lakebase",
         permanent: true,
+      },
+      // /appkit is a moving alias for the current major. A 308 would pin
+      // crawlers to whatever destination this build happened to emit.
+      {
+        source: "/appkit",
+        destination: latestAppkitDocs,
+        permanent: false,
+      },
+      {
+        source: "/appkit/",
+        destination: latestAppkitDocs,
+        permanent: false,
       },
     ];
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -100,11 +100,6 @@ const nextConfig = {
         destination: latestAppkitDocs,
         permanent: false,
       },
-      {
-        source: "/appkit/",
-        destination: latestAppkitDocs,
-        permanent: false,
-      },
     ];
   },
   async rewrites() {

--- a/tests/appkit-latest-redirect.test.ts
+++ b/tests/appkit-latest-redirect.test.ts
@@ -52,14 +52,15 @@ describe("/appkit latest-docs redirect", () => {
     const destination = `/docs/appkit/${installedAppkitDocsChannel()}`;
     const redirects = readRedirects();
 
-    for (const source of ["/appkit", "/appkit/"]) {
-      expect(redirects).toContainEqual(
-        expect.objectContaining({
-          source,
-          destination,
-          statusCode: 307,
-        }),
-      );
-    }
+    expect(redirects).toContainEqual(
+      expect.objectContaining({
+        source: "/appkit",
+        destination,
+        statusCode: 307,
+      }),
+    );
+    expect(redirects).not.toContainEqual(
+      expect.objectContaining({ source: "/appkit/" }),
+    );
   });
 });

--- a/tests/appkit-latest-redirect.test.ts
+++ b/tests/appkit-latest-redirect.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..");
+
+type RouteManifestRedirect = {
+  destination: string;
+  source: string;
+  statusCode: number;
+};
+
+function installedAppkitDocsChannel(): string {
+  const pkg = JSON.parse(
+    readFileSync(
+      resolve(
+        REPO_ROOT,
+        "node_modules",
+        "@databricks",
+        "appkit-ui",
+        "package.json",
+      ),
+      "utf-8",
+    ),
+  ) as { version: unknown };
+
+  if (typeof pkg.version !== "string" || pkg.version.length === 0) {
+    throw new Error(
+      `Invalid @databricks/appkit-ui version: ${JSON.stringify(pkg.version)}`,
+    );
+  }
+
+  const major = pkg.version.split(".")[0];
+  if (!/^\d+$/.test(major)) {
+    throw new Error(`Invalid @databricks/appkit-ui version: ${pkg.version}`);
+  }
+
+  return `v${major}`;
+}
+
+function readRedirects(): RouteManifestRedirect[] {
+  const manifest = JSON.parse(
+    readFileSync(resolve(REPO_ROOT, ".next", "routes-manifest.json"), "utf-8"),
+  ) as { redirects: RouteManifestRedirect[] };
+
+  return manifest.redirects;
+}
+
+describe("/appkit latest-docs redirect", () => {
+  test("build emits a temporary redirect to the installed AppKit docs major", () => {
+    const destination = `/docs/appkit/${installedAppkitDocsChannel()}`;
+    const redirects = readRedirects();
+
+    for (const source of ["/appkit", "/appkit/"]) {
+      expect(redirects).toContainEqual(
+        expect.objectContaining({
+          source,
+          destination,
+          statusCode: 307,
+        }),
+      );
+    }
+  });
+});

--- a/tests/broken-links.test.ts
+++ b/tests/broken-links.test.ts
@@ -13,6 +13,7 @@ const NON_PAGE_ROUTES = new Set([
   "/docs/llms.txt",
   "/docs",
   "/product/data-lakehouse",
+  "/appkit",
   "/solutions/rss.xml",
   "/templates.md",
   "/solutions.md",

--- a/tests/e2e/pages.spec.ts
+++ b/tests/e2e/pages.spec.ts
@@ -297,6 +297,29 @@ test.describe("product pages", () => {
     await expect(page).toHaveTitle("Lakebase | Databricks Developer");
   });
 
+  test("/appkit redirects to the latest AppKit docs", async ({
+    page,
+    request,
+  }) => {
+    const destinationPath = /^\/docs\/appkit\/v\d+$/;
+    const response = await request.get("/appkit", { maxRedirects: 0 });
+    expect(response.status()).toBe(307);
+    const location = response.headers()["location"];
+    if (!location) {
+      throw new Error("Missing Location header for /appkit");
+    }
+    expect(new URL(location, "http://localhost").pathname).toMatch(
+      destinationPath,
+    );
+
+    await page.goto("/appkit");
+    await expect(page).toHaveURL(/\/docs\/appkit\/v\d+$/);
+    await expect(page).toHaveTitle("Getting started | Databricks Developer");
+
+    await page.goto("/appkit/");
+    await expect(page).toHaveURL(/\/docs\/appkit\/v\d+$/);
+  });
+
   test("uses static testimonial cards on desktop when three testimonials fit", async ({
     page,
   }) => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -222,6 +222,8 @@ describe("production build smoke tests", () => {
     expect(paths).toContain("/product/databricks-apps");
     expect(paths).not.toContain("/product/data-lakehouse");
     expect(paths).not.toContain("/product/data-lakehouse/");
+    expect(paths).not.toContain("/appkit");
+    expect(paths).not.toContain("/appkit/");
 
     for (const path of paths) {
       if (path !== "/") {


### PR DESCRIPTION
## Problem

AppKit docs are served at `/docs/appkit/v0`. That path names a major. There is no unversioned URL for the docs home.

`/appkit` is that URL. It aliases the landing page only. A reader can write `/appkit` for the docs home. Subtree URLs are unchanged: `/docs/appkit/v0/plugins/genie` still names a major.

## Diagnosis

The docs tree is published under `/docs/appkit/v{major}` from the installed `@databricks/appkit-ui` package. There is no page at `/docs/appkit`. The current major is already on disk: the first segment of that package's `version`. This checkout has `0.22.0`, so the home is `/docs/appkit/v0`.

`redirects()` reads that version at build time and emits a 307. A 308 would tell crawlers the destination is permanent. The destination changes when the installed major changes.

A Next build of this branch writes:

```
/appkit  →  /docs/appkit/v0  307
```

`/appkit/` is not a second rule. Next strips the trailing slash (308 to `/appkit`), then the 307 runs.

`/docs/appkit` still 404s. `/appkit/*` is not rewritten.

## HTTP interface

```
GET /appkit
307
Location: /docs/appkit/v0
```

```
GET /appkit/
308
Location: /appkit
```

The 308 is Next's trailing-slash strip. `redirects()` has no `/appkit/` entry. The Location major is the major of the installed `@databricks/appkit-ui` at build time.

Unchanged for existing callers:

- `/docs/appkit/v0` and every path under it
- `/docs/appkit` (404)
- `/appkit/plugins/genie` (not rewritten)

## Also in here

- Broken-link checker: `/appkit` is a known redirect source, not a prerendered page.
- Sitemap: `/appkit` and `/appkit/` must not appear. The indexed home stays `/docs/appkit/v0`.

## Verification

The added tests assert:

- The build's route manifest contains `{ source: "/appkit", destination: "/docs/appkit/v{installed major}", statusCode: 307 }`.
- That manifest has no `/appkit/` source.
- `GET /appkit` (no follow) is 307 and `Location` matches `/docs/appkit/v{n}`.
- Following `/appkit` and `/appkit/` lands on `/docs/appkit/v{n}` with title `Getting started | Databricks Developer`.
- Sitemap omits `/appkit` and `/appkit/`.

A local `.next/routes-manifest.json` on this branch matches the first two: `/appkit` → `/docs/appkit/v0` at 307, and Next's internal `/:path+/` 308. Installed `@databricks/appkit-ui` is `0.22.0`.

Not verified:

- Production `developers.databricks.com`.
- A build whose installed AppKit major is not `0`.
- The 308 status on `/appkit/` by itself. The e2e follows the slash through to the docs home and does not read that status.
- `/docs/appkit` and `/appkit/<path>`. No new tests; there is no page and no rewrite.

## For your attention

- **Home only.** Deep links under `/docs/appkit/v0/...` still hardcode a major. This PR does not add `/appkit/...` aliases.
- **Build-time major.** `/appkit` tracks the `@databricks/appkit-ui` this deploy was built with. Bumping the package and redeploying is what moves the Location.
- **307.** Caches and crawlers must not treat `/docs/appkit/v0` as the permanent home.
- **`/docs/appkit` stays 404.** The unversioned path is `/appkit`.