### PR TITLE
fix: resolve "Suggest edits" links to their source files

### DIFF
--- a/src/app/(website)/docs/[[...slug]]/page.tsx
+++ b/src/app/(website)/docs/[[...slug]]/page.tsx
@@ -40,7 +40,6 @@ export default async function DocsPage({
     level: item.depth,
     value: item.value,
   }));
-  const suggestEditsUrl = `https://github.com/databricks/devhub/edit/main/${post.editPath}`;
 
   return (
     <article className="grid grid-cols-1 gap-x-8 xl:grid-cols-[minmax(0,44rem)_12rem]">
@@ -75,7 +74,7 @@ export default async function DocsPage({
 
       <DocsAside
         className="inset-x-0 bottom-0 -mx-1 hidden overflow-auto px-1 py-8 leading-none xl:flex"
-        suggestEditsUrl={suggestEditsUrl}
+        suggestEditsUrl={post.suggestEditsUrl}
         sticky
         toc={toc}
       />

--- a/src/lib/docs-content.ts
+++ b/src/lib/docs-content.ts
@@ -11,9 +11,10 @@ import { expandLocalMdxImports } from "@/lib/expand-mdx";
 import { getUniqueMarkdownHeadingId } from "@/lib/markdown-heading-ids";
 import { buildSeoDescription } from "@/lib/seo-description";
 import { resolveSiteUrl } from "@/lib/site-url";
+import { getSuggestEditsUrl } from "@/lib/suggest-edits-url";
 
 type DocMeta = {
-  editPath: string;
+  suggestEditsUrl: string;
   slug: string;
   sidebarLabel: string;
   title: string;
@@ -233,7 +234,7 @@ function readDocMetaFromFile(absolutePath: string, slug: string): DocMeta {
   });
 
   return {
-    editPath: `docs/${relativeDocsPath}`,
+    suggestEditsUrl: getSuggestEditsUrl(relativeDocsPath),
     slug,
     sidebarLabel,
     title,

--- a/src/lib/suggest-edits-url.ts
+++ b/src/lib/suggest-edits-url.ts
@@ -1,0 +1,28 @@
+// Builds the GitHub "Suggest edits" link for a doc page. Most DevHub docs point
+// back at their file on databricks/devhub main.
+//
+// AppKit is the exception: scripts/sync-appkit-docs.mjs vendors databricks/appkit
+// docs/docs/** into the gitignored src/content/docs/appkit/<channel>/** (channel
+// = v0, v1, ... = the installed @databricks/appkit-ui major), so an edit here
+// would be lost on the next sync. We reverse that mapping to the upstream file,
+// dropping the DevHub-only channel dir.
+//
+// This assumes every appkit/<channel>/ file comes from upstream docs/docs/. The
+// sync script has a TODO to also vendor docs/versioned_docs/version-<n>/, which
+// would break that assumption; tests/suggest-edits-url.test.ts guards it.
+//
+// The returned URL is derived purely from the path; existence upstream is not
+// verified, so a repo restructure could yield a link that 404s.
+
+const DEVHUB_EDIT_BASE = "https://github.com/databricks/devhub/edit/main";
+const APPKIT_EDIT_BASE = "https://github.com/databricks/appkit/edit/main";
+
+// `relativeDocsPath` is a doc's posix path relative to src/content/docs, e.g.
+// "start-here.md" or "appkit/v0/plugins/ai-search.md".
+export function getSuggestEditsUrl(relativeDocsPath: string): string {
+  const appkitMatch = relativeDocsPath.match(/^appkit\/[^/]+\/(.+)$/);
+  if (appkitMatch) {
+    return `${APPKIT_EDIT_BASE}/docs/docs/${appkitMatch[1]}`;
+  }
+  return `${DEVHUB_EDIT_BASE}/src/content/docs/${relativeDocsPath}`;
+}

--- a/tests/suggest-edits-url.test.ts
+++ b/tests/suggest-edits-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import { getSuggestEditsUrl } from "../src/lib/suggest-edits-url";
+
+describe("getSuggestEditsUrl", () => {
+  test("points DevHub docs at their real src/content/docs path on main", () => {
+    expect(getSuggestEditsUrl("start-here.md")).toBe(
+      "https://github.com/databricks/devhub/edit/main/src/content/docs/start-here.md",
+    );
+  });
+
+  test("preserves nested paths and .mdx extensions for DevHub docs", () => {
+    expect(getSuggestEditsUrl("apps/overview.mdx")).toBe(
+      "https://github.com/databricks/devhub/edit/main/src/content/docs/apps/overview.mdx",
+    );
+  });
+
+  test("maps AppKit docs back to the upstream appkit repo, dropping the channel dir", () => {
+    expect(getSuggestEditsUrl("appkit/v0/plugins/ai-search.md")).toBe(
+      "https://github.com/databricks/appkit/edit/main/docs/docs/plugins/ai-search.md",
+    );
+  });
+
+  test("maps the AppKit channel index page", () => {
+    expect(getSuggestEditsUrl("appkit/v0/index.md")).toBe(
+      "https://github.com/databricks/appkit/edit/main/docs/docs/index.md",
+    );
+  });
+
+  test("is channel-agnostic so future AppKit majors keep resolving", () => {
+    expect(getSuggestEditsUrl("appkit/v1/api/appkit/Interface.Foo.md")).toBe(
+      "https://github.com/databricks/appkit/edit/main/docs/docs/api/appkit/Interface.Foo.md",
+    );
+  });
+
+  // Guards the coupling documented in src/lib/suggest-edits-url.ts: today every
+  // appkit/<channel>/ file is vendored from upstream docs/docs/. If the sync
+  // script's versioned-docs TODO lands, version-channel files will instead come
+  // from docs/versioned_docs/version-<n>/ and this expectation must change in
+  // lockstep with the mapping.
+  test("assumes AppKit channels are vendored from upstream docs/docs", () => {
+    expect(getSuggestEditsUrl("appkit/v0/configuration.mdx")).toBe(
+      "https://github.com/databricks/appkit/edit/main/docs/docs/configuration.mdx",
+    );
+  });
+});


### PR DESCRIPTION
## Overview

"Suggest edits" links 404'd: they were built from a `docs/<path>` prefix,
but docs live under `src/content/docs/`. AppKit docs are also synced from
databricks/appkit, so their link now points at the upstream file instead
of the local copy the sync overwrites.

The mapping is one pure helper; it derives the URL from the path and does
not check that the file exists.

## Testing

Verified locally that links resolve for a DevHub page, an AppKit plugin
page, and the AppKit index (each 200s on GitHub). Added
tests/suggest-edits-url.test.ts.

This pull request and its description were written by Isaac.
